### PR TITLE
Move courses and libraries into tabs on CMS dashboard.

### DIFF
--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -152,6 +152,14 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
             CreateLibraryUtils.configureHandlers();
         };
 
+        var showTab = function(tab) {
+          return function(e) {
+            e.preventDefault();
+            $('.courses-tab').toggleClass('active', tab === 'courses');
+            $('.libraries-tab').toggleClass('active', tab === 'libraries');
+          }
+        };
+
         var onReady = function () {
             $('.new-course-button').bind('click', addNewCourse);
             $('.new-library-button').bind('click', addNewLibrary);
@@ -159,6 +167,8 @@ define(["domReady", "jquery", "underscore", "js/utils/cancel_on_escape", "js/vie
                 ViewUtils.reload();
             }));
             $('.action-reload').bind('click', ViewUtils.reload);
+            $('#course-index-tabs .courses-tab').bind('click', showTab('courses'));
+            $('#course-index-tabs .libraries-tab').bind('click', showTab('libraries'));
         };
 
         domReady(onReady);

--- a/cms/static/sass/elements/_forms.scss
+++ b/cms/static/sass/elements/_forms.scss
@@ -394,7 +394,6 @@ form {
 // ELEM: form wrapper
 .wrapper-create-element {
   height: 0;
-  margin-bottom: $baseline;
   opacity: 0.0;
   pointer-events: none;
   overflow: hidden;
@@ -405,6 +404,7 @@ form {
 
   &.is-shown {
     height: auto; // define a specific height for the animating version of this UI to work properly
+    margin-bottom: $baseline;
     opacity: 1.0;
     pointer-events: auto;
   }

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -289,10 +289,42 @@
 
   // ====================
 
-  // ELEM: course listings
-  .courses {
-    margin: $baseline 0;
+  // Course/Library tabs
+  #course-index-tabs {
+    margin: 0;
+    font-size: 1.4rem;
 
+    li {
+      display: inline-block;
+      line-height: $baseline*2;
+      margin: 0 10px;
+
+      &.active, &:hover {
+        border-bottom: 4px solid $blue;
+      }
+
+      a {
+        color: $blue;
+        cursor: pointer;
+        display: inline-block;
+      }
+
+      &.active a {
+        color: $gray-d2;
+      }
+    }
+  }
+
+  // ELEM: course listings
+  .courses-tab, .libraries-tab {
+    display: none;
+
+    &.active {
+      display: block;
+    }
+  }
+
+  .courses, .libraries {
     .title {
       @extend %t-title6;
       margin-bottom: $baseline;
@@ -311,7 +343,6 @@
 	}
 
   .list-courses {
-    margin-top: $baseline;
     border-radius: 3px;
     border: 1px solid $gray-l2;
     background: $white;

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -262,8 +262,15 @@
       </div>
       %endif
 
+      %if libraries_enabled:
+      <ul id="course-index-tabs">
+        <li class="courses-tab active"><a>${_("Courses")}</a></li>
+        <li class="libraries-tab"><a>${_("Libraries")}</a></li>
+      </ul>
+      %endif
+
       %if len(courses) > 0:
-      <div class="courses">
+      <div class="courses courses-tab active">
         <ul class="list-courses">
           %for course_info in sorted(courses, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
           <li class="course-item" data-course-key="${course_info['course_key'] | h}">
@@ -300,10 +307,7 @@
       </div>
 
       %else:
-      <div class="courses">
-      </div>
-
-      <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices">
+      <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices courses-tab active">
         <div class="notice-item">
           <div class="msg">
             <h3 class="title">${_("Are you staff on an existing Studio course?")}</h3>
@@ -410,14 +414,8 @@
       </div>
       % endif
 
-      %if libraries:
-      <div class="copy">
-        <h1>Content Libraries</h1>
-        <p>${_("Warning: Content Libraries are currently a beta feature, and may be subject to backwards-incompatible changes.")}</p>
-        <p>${_("Here are all of the libraries you currently have access to in Studio:")}</p>
-      </div>
-
-      <div class="courses">
+      %if len(libraries) > 0:
+      <div class="libraries libraries-tab">
         <ul class="list-courses">
           %for library_info in sorted(libraries, key=lambda s: s['display_name'].lower() if s['display_name'] is not None else ''):
           <li class="course-item">
@@ -437,6 +435,17 @@
           </li>
           %endfor
         </ul>
+      </div>
+
+      %else:
+      <div class="notice notice-incontext notice-instruction notice-instruction-nocourses list-notices libraries-tab">
+        <div class="notice-item">
+          <div class="msg">
+            <div class="copy">
+              <p>${_('You don\'t have any content libraries yet.')}</p>
+            </div>
+          </div>
+        </div>
       </div>
       %endif
 


### PR DESCRIPTION
The courses and libraries are grouped into tabs as seen on https://projects.invisionapp.com/share/TS1L3B28U#/screens/44282460.

The tabs are only visible if content libraries are enabled.
