### PR TITLE
Content libraries analytics enhancements (SOL-121)

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -229,8 +229,8 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             result = []
             for key in keys:
                 key = self.location.course_key.make_usage_key(*key)
-                orig_key = lib_tools.get_block_original_usage(key)
-                result.append((unicode(key), unicode(orig_key)))
+                orig_key, orig_version = lib_tools.get_block_original_usage(key)
+                result.append((unicode(key), unicode(orig_key), unicode(orig_version)))
             return result
 
         selected = set(tuple(k) for k in self.selected)  # set of (block_type, block_id) tuples

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -233,8 +233,9 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             # Publish an event for analytics purposes:
             self.runtime.publish(self, "edx.librarycontentblock.content.removed", {
                 "location": unicode(self.location),
-                "blocks": format_block_keys(invalid_block_keys),
+                "removed": format_block_keys(invalid_block_keys),
                 "reason": "invalid",  # Deleted from library or library being used has changed
+                "result": format_block_keys(selected),
             })
         # If max_count has been decreased, we may have to drop some previously selected blocks:
         overlimit_block_keys = set()
@@ -244,8 +245,9 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             # Publish an event for analytics purposes:
             self.runtime.publish(self, "edx.librarycontentblock.content.removed", {
                 "location": unicode(self.location),
-                "blocks": format_block_keys(overlimit_block_keys),
+                "removed": format_block_keys(overlimit_block_keys),
                 "reason": "overlimit",
+                "result": format_block_keys(selected),
             })
         # Do we have enough blocks now?
         num_to_add = self.max_count - len(selected)

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -219,20 +219,11 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
         if hasattr(self, "_selected_set"):
             # Already done:
             return self._selected_set  # pylint: disable=access-member-before-definition
-        # Determine which of our children we will show:
+
         lib_tools = self.runtime.service(self, 'library_tools')
+        format_block_keys = lambda block_keys: lib_tools.create_block_analytics_summary(self.location.course_key, block_keys)
 
-        def format_block_keys(keys):
-            """
-            Format (block_type, block_id) pairs for logging
-            """
-            result = []
-            for key in keys:
-                key = self.location.course_key.make_usage_key(*key)
-                orig_key, orig_version = lib_tools.get_block_original_usage(key)
-                result.append((unicode(key), unicode(orig_key), unicode(orig_version)))
-            return result
-
+        # Determine which of our children we will show:
         selected = set(tuple(k) for k in self.selected)  # set of (block_type, block_id) tuples
         valid_block_keys = set([(c.block_type, c.block_id) for c in self.children])  # pylint: disable=no-member
         # Remove any selected blocks that are no longer valid:

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -220,24 +220,50 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             # Already done:
             return self._selected_set  # pylint: disable=access-member-before-definition
         # Determine which of our children we will show:
+        jsonify_block_keys = lambda keys: [unicode(self.location.course_key.make_usage_key(*key)) for key in keys]
         selected = set(tuple(k) for k in self.selected)  # set of (block_type, block_id) tuples
         valid_block_keys = set([(c.block_type, c.block_id) for c in self.children])  # pylint: disable=no-member
         # Remove any selected blocks that are no longer valid:
-        selected -= (selected - valid_block_keys)
+        invalid_block_keys = (selected - valid_block_keys)
+        if invalid_block_keys:
+            selected -= invalid_block_keys
+            # Publish an event for analytics purposes:
+            self.runtime.publish(self, "edx.librarycontentblock.content.removed", {
+                "location": unicode(self.location),
+                "blocks": jsonify_block_keys(invalid_block_keys),
+                "reason": "invalid",  # Deleted from library or library being used has changed
+            })
         # If max_count has been decreased, we may have to drop some previously selected blocks:
+        overlimit_block_keys = set()
         while len(selected) > self.max_count:
-            selected.pop()
+            overlimit_block_keys.add(selected.pop())
+        if overlimit_block_keys:
+            # Publish an event for analytics purposes:
+            self.runtime.publish(self, "edx.librarycontentblock.content.removed", {
+                "location": unicode(self.location),
+                "blocks": jsonify_block_keys(overlimit_block_keys),
+                "reason": "overlimit",
+            })
         # Do we have enough blocks now?
         num_to_add = self.max_count - len(selected)
         if num_to_add > 0:
+            added_block_keys = None
             # We need to select [more] blocks to display to this user:
+            pool = valid_block_keys - selected
             if self.mode == "random":
-                pool = valid_block_keys - selected
                 num_to_add = min(len(pool), num_to_add)
-                selected |= set(random.sample(pool, num_to_add))
+                added_block_keys = set(random.sample(pool, num_to_add))
                 # We now have the correct n random children to show for this user.
             else:
                 raise NotImplementedError("Unsupported mode.")
+            selected |= added_block_keys
+            if added_block_keys:
+                # Publish an event for analytics purposes:
+                self.runtime.publish(self, "edx.librarycontentblock.content.assigned", {
+                    "location": unicode(self.location),
+                    "added": jsonify_block_keys(added_block_keys),
+                    "result": jsonify_block_keys(selected),
+                })
         # Save our selections to the user state, to ensure consistency:
         self.selected = list(selected)  # TODO: this doesn't save from the LMS "Progress" page.
         # Cache the results

--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -44,12 +44,40 @@ class LibraryToolsService(object):
             return library.location.library_key.version_guid
         return None
 
-    def get_block_original_usage(self, usage_key):
+    def create_block_analytics_summary(self, course_key, block_keys):
         """
-        Get the LibraryUsageLocator and version from which the given BlockUsageLocator was copied.
-        i.e. Identify the library block from the block ID used in a course.
+        Given a CourseKey and a list of (block_type, block_id) pairs,
+        prepare the JSON-ready metadata needed for analytics logging.
+
+        This is [
+            {"usage_key": x, "original_usage_key": y, "original_usage_version": z, "descendants": [...]}
+        ]
+        where the main list contains all top-level blocks, and descendants contains a *flat* list of all
+        descendants of the top level blocks, if any.
         """
-        return self.store.get_block_original_usage(usage_key)
+        def summarize_block(usage_key):
+            """ Basic information about the given block """
+            orig_key, orig_version = self.store.get_block_original_usage(usage_key)
+            return {
+                "usage_key": unicode(usage_key),
+                "original_usage_key": unicode(orig_key),
+                "original_usage_version": unicode(orig_version),
+            }
+
+        result_json = []
+        for block_key in block_keys:
+            key = course_key.make_usage_key(*block_key)
+            info = summarize_block(key)
+            info['descendants'] = []
+            block = self.store.get_item(key, depth=None)  # Load the item and all descendants
+            children = list(getattr(block, "children", []))
+            while children:
+                child_key = children.pop()
+                child = self.store.get_item(child_key)
+                info['descendants'].append(summarize_block(child_key))
+                children.extend(getattr(child, "children", []))
+            result_json.append(info)
+        return result_json
 
     def _filter_child(self, usage_key, capa_type):
         """

--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -46,7 +46,7 @@ class LibraryToolsService(object):
 
     def get_block_original_usage(self, usage_key):
         """
-        Get the LibraryUsageLocator from which the given BlockUsageLocator was copied.
+        Get the LibraryUsageLocator and version from which the given BlockUsageLocator was copied.
         i.e. Identify the library block from the block ID used in a course.
         """
         return self.store.get_block_original_usage(usage_key)

--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -44,6 +44,13 @@ class LibraryToolsService(object):
             return library.location.library_key.version_guid
         return None
 
+    def get_block_original_usage(self, usage_key):
+        """
+        Get the LibraryUsageLocator from which the given BlockUsageLocator was copied.
+        i.e. Identify the library block from the block ID used in a course.
+        """
+        return self.store.get_block_original_usage(usage_key)
+
     def _filter_child(self, usage_key, capa_type):
         """
         Filters children by CAPA problem type, if configured

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -509,6 +509,17 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         store = self._get_modulestore_for_courseid(location.course_key)
         return store.get_parent_location(location, **kwargs)
 
+    def get_block_original_usage(self, usage_key):
+        """
+        If a block was inherited into another structure using inherit_copy,
+        this will return the original block usage locator from which the
+        copy was inherited.
+        """
+        store = self._verify_modulestore_support(usage_key.course_key, 'get_block_original_usage')
+        if store:
+            return store.get_block_original_usage(usage_key)
+        return None
+
     def get_modulestore_type(self, course_id):
         """
         Returns a type which identifies which modulestore is servicing the given course_id.

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -515,10 +515,11 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         this will return the original block usage locator from which the
         copy was inherited.
         """
-        store = self._verify_modulestore_support(usage_key.course_key, 'get_block_original_usage')
-        if store:
+        try:
+            store = self._verify_modulestore_support(usage_key.course_key, 'get_block_original_usage')
             return store.get_block_original_usage(usage_key)
-        return None
+        except NotImplementedError:
+            return None, None
 
     def get_modulestore_type(self, course_id):
         """

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -454,8 +454,8 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
         if block_info['edit_info'].get('update_version') == update_version:
             return
 
-        original_usage = block_info['edit_info'].get('original_usage', None)
-        original_usage_version = block_info['edit_info'].get('original_usage_version', None)
+        original_usage = block_info['edit_info'].get('original_usage')
+        original_usage_version = block_info['edit_info'].get('original_usage_version')
         block_info['edit_info'] = {
             'edited_on': datetime.datetime.now(UTC),
             'edited_by': user_id,
@@ -1267,10 +1267,10 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         Returns usage_key, version if the data is available, otherwise returns (None, None)
         """
         blocks = self._lookup_course(usage_key.course_key).structure['blocks']
-        block = blocks.get(BlockKey.from_usage_key(usage_key), None)
+        block = blocks.get(BlockKey.from_usage_key(usage_key))
         if block and 'original_usage' in block['edit_info']:
             usage_key = BlockUsageLocator.from_string(block['edit_info']['original_usage'])
-            return usage_key, block['edit_info'].get('original_usage_version', None)
+            return usage_key, block['edit_info'].get('original_usage_version')
         return None, None
 
     def create_definition_from_data(self, course_key, new_def_data, category, user_id):
@@ -2224,7 +2224,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             new_block_info['edit_info']['edited_by'] = user_id
             new_block_info['edit_info']['edited_on'] = datetime.datetime.now(UTC)
             new_block_info['edit_info']['original_usage'] = unicode(usage_key.replace(branch=None, version_guid=None))
-            new_block_info['edit_info']['original_usage_version'] = source_block_info['edit_info'].get('update_version', None)
+            new_block_info['edit_info']['original_usage_version'] = source_block_info['edit_info'].get('update_version')
             dest_structure['blocks'][new_block_key] = new_block_info
 
             children = source_block_info['fields'].get('children')

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -454,12 +454,15 @@ class SplitBulkWriteMixin(BulkOperationsMixin):
         if block_info['edit_info'].get('update_version') == update_version:
             return
 
+        original_usage = block_info['edit_info'].get('original_usage', None)
         block_info['edit_info'] = {
             'edited_on': datetime.datetime.now(UTC),
             'edited_by': user_id,
             'previous_version': block_info['edit_info']['update_version'],
             'update_version': update_version,
         }
+        if original_usage:
+            block_info['edit_info']['original_usage'] = original_usage
 
     def find_matching_course_indexes(self, branch=None, search_targets=None):
         """
@@ -2203,6 +2206,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             # Setting it to the source_block_info structure version here breaks split_draft's has_changes() method.
             new_block_info['edit_info']['edited_by'] = user_id
             new_block_info['edit_info']['edited_on'] = datetime.datetime.now(UTC)
+            new_block_info['edit_info']['original_usage'] = unicode(usage_key.replace(branch=None, version_guid=None))
             dest_structure['blocks'][new_block_key] = new_block_info
 
             children = source_block_info['fields'].get('children')

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1256,6 +1256,18 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         # TODO implement
         pass
 
+    def get_block_original_usage(self, usage_key):
+        """
+        If a block was inherited into another structure using inherit_copy,
+        this will return the original block usage locator from which the
+        copy was inherited.
+        """
+        blocks = self._lookup_course(usage_key.course_key).structure['blocks']
+        block = blocks.get(BlockKey.from_usage_key(usage_key), None)
+        if block and 'original_usage' in block['edit_info']:
+            return BlockUsageLocator.from_string(block['edit_info']['original_usage'])
+        return None
+
     def create_definition_from_data(self, course_key, new_def_data, category, user_id):
         """
         Pull the definition fields out of descriptor and save to the db as a new definition

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split_draft.py
@@ -267,6 +267,15 @@ class DraftVersioningModuleStore(SplitMongoModuleStore, ModuleStoreDraftAndPubli
         location = self._map_revision_to_branch(location, revision=revision)
         return super(DraftVersioningModuleStore, self).get_parent_location(location, **kwargs)
 
+    def get_block_original_usage(self, usage_key):
+        """
+        If a block was inherited into another structure using inherit_copy,
+        this will return the original block usage locator from which the
+        copy was inherited.
+        """
+        usage_key = self._map_revision_to_branch(usage_key)
+        return super(DraftVersioningModuleStore, self).get_block_original_usage(usage_key)
+
     def get_orphans(self, course_key, **kwargs):
         course_key = self._map_revision_to_branch(course_key)
         return super(DraftVersioningModuleStore, self).get_orphans(course_key, **kwargs)

--- a/common/lib/xmodule/xmodule/modulestore/tests/utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/utils.py
@@ -119,6 +119,7 @@ class MixedSplitTestCase(TestCase):
         extra.update(kwargs)
         return ItemFactory.create(
             category=category,
+            parent=parent_block,
             parent_location=parent_block.location,
             modulestore=self.store,
             **extra

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -303,7 +303,8 @@ class TestLibraries(MixedSplitTestCase):
             _, event_name, event_data = publisher.call_args[0]
             self.assertEqual(event_name, "edx.librarycontentblock.content.removed")
             self.assertEqual(event_data["location"], unicode(self.lc_block.location))
-            self.assertEqual(len(event_data["blocks"]), num_removed)
+            self.assertEqual(len(event_data["removed"]), num_removed)
+            self.assertEqual(len(event_data["result"]), num_children_left)
             self.assertEqual(event_data["reason"], reason)
         check_remove_event(num_children_left=1, num_removed=1, reason="overlimit")
         publisher.reset_mock()

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -5,6 +5,7 @@ Test for lms courseware app, module render unit
 from functools import partial
 import json
 
+from bson import ObjectId
 import ddt
 from django.http import Http404, HttpResponse
 from django.core.urlresolvers import reverse
@@ -13,6 +14,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.contrib.auth.models import AnonymousUser
 from mock import MagicMock, patch, Mock
+from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xblock.field_data import FieldData
 from xblock.runtime import Runtime
@@ -971,12 +973,13 @@ class TestModuleTrackingContext(ModuleStoreTestCase):
 
     def test_context_contains_display_name(self, mock_tracker):
         problem_display_name = u'Option Response Problem'
-        actual_display_name = self.handle_callback_and_get_display_name_from_event(mock_tracker, problem_display_name)
-        self.assertEquals(problem_display_name, actual_display_name)
+        module_info = self.handle_callback_and_get_module_info_from_event(mock_tracker, problem_display_name)
+        self.assertEquals(problem_display_name, module_info['display_name'])
 
-    def handle_callback_and_get_display_name_from_event(self, mock_tracker, problem_display_name=None):
+    def handle_callback_and_get_module_info_from_event(self, mock_tracker, problem_display_name=None):
         """
-        Creates a fake module, invokes the callback and extracts the display name from the emitted problem_check event.
+        Creates a fake module, invokes the callback and extracts the 'module'
+        metadata from the emitted problem_check event.
         """
         descriptor_kwargs = {
             'category': 'problem',
@@ -1000,11 +1003,26 @@ class TestModuleTrackingContext(ModuleStoreTestCase):
         event = mock_call[1][0]
 
         self.assertEquals(event['event_type'], 'problem_check')
-        return event['context']['module']['display_name']
+        return event['context']['module']
 
     def test_missing_display_name(self, mock_tracker):
-        actual_display_name = self.handle_callback_and_get_display_name_from_event(mock_tracker)
+        actual_display_name = self.handle_callback_and_get_module_info_from_event(mock_tracker)['display_name']
         self.assertTrue(actual_display_name.startswith('problem'))
+
+    def test_library_source_information(self, mock_tracker):
+        """
+        Check that XBlocks that are inherited from a library include the
+        information about their library block source in events.
+        We patch the modulestore to avoid having to create a library.
+        """
+        original_usage_key = UsageKey.from_string(u'block-v1:A+B+C+type@problem+block@abcd1234')
+        original_usage_version = ObjectId()
+        with patch('xmodule.modulestore.mixed.MixedModuleStore.get_block_original_usage', lambda _, key: (original_usage_key, original_usage_version)):
+            module_info = self.handle_callback_and_get_module_info_from_event(mock_tracker)
+            self.assertIn('original_usage_key', module_info)
+            self.assertEqual(module_info['original_usage_key'], unicode(original_usage_key))
+            self.assertIn('original_usage_version', module_info)
+            self.assertEqual(module_info['original_usage_version'], unicode(original_usage_version))
 
 
 class TestXmoduleRuntimeEvent(TestSubmittingProblems):

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from lms.djangoapps.lms_xblock.models import XBlockAsidesConfig
 from openedx.core.djangoapps.user_api.api import course_tag as user_course_tag_api
 from xmodule.modulestore.django import modulestore
+from xmodule.library_tools import LibraryToolsService
 from xmodule.x_module import ModuleSystem
 from xmodule.partitions.partitions_service import PartitionService
 
@@ -198,6 +199,7 @@ class LmsModuleSystem(LmsHandlerUrls, ModuleSystem):  # pylint: disable=abstract
             runtime=self,
             track_function=kwargs.get('track_function', None),
         )
+        services['library_tools'] = LibraryToolsService(modulestore())
         services['fs'] = xblock.reference.plugins.FSService()
         self.request_token = kwargs.pop('request_token', None)
         super(LmsModuleSystem, self).__init__(**kwargs)


### PR DESCRIPTION
This implements support for analytics of content libraries, built to implement the ideas of Brian Wilson and Don Mitchell described on [the Confluence wiki page](https://openedx.atlassian.net/wiki/display/SOL/Content+Libraries) in the section near the top entitled "Analytics Considerations".

## New tracking events:
Two new events will appear in the tracking logs (see example below):

* `edx.librarycontentblock.content.assigned` - indicates that a student has been assigned their subset of blocks. Data includes:
  - `location` The BlockUsageLocator of the LibraryContentModule emitting the event
  - `added`: the BlockUsageLocator **and LibraryUsageLocator** and version of any newly-assigned blocks
  - `result`: the complete set of blocks now assigned to this student. (will always equal `added` at first, but if `max_count` is increased, `added` may be different)
* `edx.librarycontentblock.content.removed` - indicates that a previously-assigned block is no longer being shown to this student. This should be very rare. Data includes:
  - `location` The BlockUsageLocator of the LibraryContentModule emitting the event
  - `blocks`: the BlockUsageLocator **and LibraryUsageLocator** and version of the blocks that were removed
  - `reason`: Either `overlimit` (`max_count` was decreased by the course author) or `invalid` (Block was deleted from library or library setting was changed and no longer includes this block)

## Testing Notes
This builds on #25 which stores data in the modulestore differently than previous work on content libraries. If testing this PR or PR 25, **create a new course** and keep it separate from other content courses that may already exist on your system. You can share libraries between this and other PRs, and once this is merged there will be no need to worry about keeping anything separate.

To test: As the vagrant user you can run `sudo tail -f /edx/var/log/tracking/tracking.log` to watch the tracking log. If you sign in to the LMS as a student and view a course containing a LibraryContent block, the first time that you view the courseware should result in an "edx.librarycontentblock.content.assigned" entry appearing in the logs. This entry should appear as below.

Also the Django admin interface at http://localhost:8000/admin/courseware/studentmodule/ is helpful for resetting the student state for your test student user.

## Example tracking log entry

```json
{
    "username": "honor",
    "host": "precise64",
    "event_source": "server",
    "event_type": "edx.librarycontentblock.content.assigned",
    "context": {
        "course_user_tags": {},
        "user_id": 1,
        "org_id": "BradenX",
        "course_id": "course-v1:BradenX+OVRD_TEST+1",
        "path": "/courses/course-v1:BradenX+OVRD_TEST+1/courseware/f61bfa6228e948f59ac1107f6077e00c/1aac970a9128469ea78c8ef1c1d0a965/"
    },
    "time": "2015-01-02T22:01:17.252372+00:00",
    "event": {
        "added": [
            ["block-v1:BradenX+OVRD_TEST+1+type@problem+block@c279e825df7fb020cb2c", "lib-block-v1:BradenX+OVRD+type@problem+block@4b0043c672b54878b4600f7b1655435c", "54a2234656c02c0fdaa54f57"]
        ],
        "location": "block-v1:BradenX+OVRD_TEST+1+type@library_content+block@f3ebf2bfd1d047c284deebbff984e4e3",
        "result": [
            ["block-v1:BradenX+OVRD_TEST+1+type@problem+block@c279e825df7fb020cb2c", "lib-block-v1:BradenX+OVRD+type@problem+block@4b0043c672b54878b4600f7b1655435c", "54a2234656c02c0fdaa54f57"]
        ]
    },
}
```

This PR also adds tracking context data to some normal events like `problem_check`:

```json
{
    "username": "honor",
    "event_source": "server",
    "event_type": "problem_check",
    "context": {
        "course_user_tags": {},
        "user_id": 1,
        "org_id": "BradenX",
        "module": {
            "usage_key": "block-v1:BradenX+OVRD_TEST+1+type@problem+block@c279e825df7fb020cb2c",
            "original_usage_version": "54a2234656c02c0fdaa54f57",
            "display_name": "A Friendly Test Problem",
            "original_usage_key": "lib-block-v1:BradenX+OVRD+type@problem+block@4b0043c672b54878b4600f7b1655435c"
        },
        "course_id": "course-v1:BradenX+OVRD_TEST+1",
        "path": "/courses/course-v1:BradenX+OVRD_TEST+1/xblock/block-v1:BradenX+OVRD_TEST+1+type@problem+block@c279e825df7fb020cb2c/handler/xmodule_handler/problem_check"
    },
    "time": "2015-01-02T22:08:54.091389+00:00",
    "event": {
        "submission": {},
        "success": "incorrect"
    }
}
```
## TODO:
* When viewing the course "Progress" page, spurious `assigned` events are emitted, because the XBlock assigns children but isn't able to save its state to the database - so in the future, children will be re-assigned.