### PR TITLE
Support for inline explanatory popups in problem XML

### DIFF
--- a/common/lib/capa/capa/templates/clarification.html
+++ b/common/lib/capa/capa/templates/clarification.html
@@ -1,0 +1,4 @@
+<span class="clarification">
+    <span data-tooltip="${clarification | h}" data-tooltip-show-on-click="true" aria-hidden="true">?</span>
+    <span class="sr">(${clarification})</span>
+</span>

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -162,6 +162,17 @@ div.problem {
         white-space: nowrap;
         overflow: hidden;
       }
+      span.clarification span {
+        background-color: $shadow-l2;
+        border-radius: ($baseline/4);
+        color: $gray-l1;
+        cursor: default;
+        padding: 0 ($baseline/4);
+        &:hover {
+          background-color: $blue;
+          color: $white;
+        }
+      }
     }
 
     &.unanswered {

--- a/common/static/js/spec/tooltip_manager_spec.js
+++ b/common/static/js/spec/tooltip_manager_spec.js
@@ -70,6 +70,12 @@ describe('TooltipManager', function () {
         expect($('.tooltip')).toBeHidden();
     });
 
+    it('can be configured to show when user clicks on the element', function () {
+        this.element.attr('data-tooltip-show-on-click', true);
+        this.element.trigger($.Event("click"));
+        expect($('.tooltip')).toBeVisible();
+    });
+
     it('should moves correctly', function () {
         showTooltip(this.element);
         expect($('.tooltip')).toBeVisible();

--- a/common/static/js/src/tooltip_manager.js
+++ b/common/static/js/src/tooltip_manager.js
@@ -26,7 +26,7 @@
                 'mouseover.TooltipManager': this.showTooltip,
                 'mousemove.TooltipManager': this.moveTooltip,
                 'mouseout.TooltipManager': this.hideTooltip,
-                'click.TooltipManager': this.hideTooltip
+                'click.TooltipManager': this.click
             }, this.SELECTOR);
         },
 
@@ -66,6 +66,18 @@
             // Wait for a 50ms before hiding the tooltip to avoid blinking when
             // the item contains nested elements.
             this.tooltipTimer = setTimeout(this.hide, 50);
+        },
+
+        click: function(event) {
+            var showOnClick = !!$(event.currentTarget).data('tooltip-show-on-click'); // Default is false
+            if (showOnClick) {
+                this.show();
+                if (this.tooltipTimer) {
+                    clearTimeout(this.tooltipTimer);
+                }
+            } else {
+                this.hideTooltip(event);
+            }
         },
 
         destroy: function () {

--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -46,3 +46,17 @@ class ProblemPage(PageObject):
         Is there a "correct" status showing?
         """
         return self.q(css="div.problem div.capa_inputtype.textline div.correct p.status").is_present()
+
+    def click_clarification(self, index=0):
+        """
+        Click on a [?] icon that can be included inline in problem text using <clarification>
+        """
+        self.q(css='div.problem .clarification:nth-child({index}) span[data-tooltip]'.format(index=index + 1)).click()
+
+    @property
+    def visible_tooltip_text(self):
+        """
+        Get the text seen in any tooltip currently visible on the page.
+        """
+        self.wait_for_element_visibility('body > .tooltip', 'A tooltip is visible.')
+        return self.q(css='body > .tooltip').text[0]

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""
+Bok choy acceptance tests for problems in the LMS
+
+See also old lettuce tests in lms/djangoapps/courseware/features/problems.feature
+"""
+from ..helpers import UniqueCourseTest
+from ...pages.studio.auto_auth import AutoAuthPage
+from ...pages.lms.courseware import CoursewarePage
+from ...pages.lms.problem import ProblemPage
+from ...fixtures.course import CourseFixture, XBlockFixtureDesc
+from textwrap import dedent
+
+
+class ProblemsTest(UniqueCourseTest):
+    """
+    Base class for tests of problems in the LMS.
+    """
+    USERNAME = "joe_student"
+    EMAIL = "joe@example.com"
+
+    def setUp(self):
+        super(ProblemsTest, self).setUp()
+
+        self.xqueue_grade_response = None
+
+        self.courseware_page = CoursewarePage(self.browser, self.course_id)
+
+        # Install a course with a hierarchy and problems
+        course_fixture = CourseFixture(
+            self.course_info['org'], self.course_info['number'],
+            self.course_info['run'], self.course_info['display_name']
+        )
+
+        problem = self.get_problem()
+        course_fixture.add_children(
+            XBlockFixtureDesc('chapter', 'Test Section').add_children(
+                XBlockFixtureDesc('sequential', 'Test Subsection').add_children(problem)
+            )
+        ).install()
+
+        # Auto-auth register for the course.
+        AutoAuthPage(self.browser, username=self.USERNAME, email=self.EMAIL,
+                     course_id=self.course_id, staff=False).visit()
+
+    def get_problem(self):
+        """ Subclasses should override this to comlete the fixture """
+        raise NotImplementedError()
+
+
+class ProblemClarificationTest(ProblemsTest):
+    """
+    Tests the <clarification> element that can be used in problem XML.
+    """
+    def get_problem(self):
+        """
+        Create a problem with a <clarification>
+        """
+        xml = dedent("""
+            <problem markdown="null">
+                <text>
+                    <p>
+                        Given the data in Table 7 <clarification>Table 7: "Example PV Installation Costs",
+                        Page 171 of Roberts textbook</clarification>, compute the ROI
+                        <clarification>Return on Investment <strong>(per year)</strong></clarification> over 20 years.
+                    </p>
+                    <numericalresponse answer="6.5">
+                        <textline label="Enter the annual ROI" trailing_text="%" />
+                    </numericalresponse>
+                </text>
+            </problem>
+        """)
+        return XBlockFixtureDesc('problem', 'TOOLTIP TEST PROBLEM', data=xml)
+
+    def test_clarification(self):
+        """
+        Test that we can see the <clarification> tooltips.
+        """
+        self.courseware_page.visit()
+        problem_page = ProblemPage(self.browser)
+        self.assertEqual(problem_page.problem_name, 'TOOLTIP TEST PROBLEM')
+        problem_page.click_clarification(0)
+        self.assertIn('"Example PV Installation Costs"', problem_page.visible_tooltip_text)
+        problem_page.click_clarification(1)
+        tooltip_text = problem_page.visible_tooltip_text
+        self.assertIn('Return on Investment', tooltip_text)
+        self.assertIn('per year', tooltip_text)
+        self.assertNotIn('strong', tooltip_text)


### PR DESCRIPTION
This PR implements the ability to add an inline marker in the text of problems, which can reveal more information to the user when he hovers over it.

## Screenshots ##
Below you can see a two clarification markers - the one on the left is active because the user is hovering over it. There is an un-hovered state seen on the right.
![screen shot 2015-01-14 at 9 29 17 pm](https://cloud.githubusercontent.com/assets/945577/5752932/a4ac9ed6-9c34-11e4-9eea-c4397f558a1b.png)

The tooltips can also contain HTML:
![screen shot 2015-01-14 at 9 29 36 pm](https://cloud.githubusercontent.com/assets/945577/5752950/d8e85ba4-9c34-11e4-82a1-1327340ac5e9.png)

## XML Example ##
The following XML is taken from the bok choy test:
```xml
<problem markdown="null">
    <p>
        Given the data in Table 7 <clarification>Table 7: "Example PV Installation Costs",
        Page 171 of Roberts textbook</clarification>, compute the ROI
        <clarification>Return on Investment <strong>(per year)</strong></clarification> over 20 years.
    </p>
    <numericalresponse answer="6.5">
        <textline label="Enter the annual ROI" trailing_text="%" />
    </numericalresponse>
</problem>
```

## Notes ##
* I attempted to make the tooltip content accessible to screen reader users, but I'm not sure if there's a better way to do that than what I've done so far
* The changes to `test_lms_matlab_problem.py` are just a refactoring to reduce code overlap. That change can be omitted to make maintenance easier if merging to the St. Gallen fork only.