### PR TITLE
Don't require terms of service if checkbox is hidden

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1553,7 +1553,7 @@ def create_account_with_params(request, params):
         not do_external_auth
     )
     # Can't have terms of service for certain SHIB users, like at Stanford
-    tos_required = (
+    tos_required = settings.REGISTRATION_EXTRA_FIELDS.get('terms_of_service') != 'hidden' and (
         not settings.FEATURES.get("AUTH_USE_SHIB") or
         not settings.FEATURES.get("SHIB_DISABLE_TOS") or
         not do_external_auth or

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1580,6 +1580,16 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             }
         )
 
+    @override_settings(REGISTRATION_EXTRA_FIELDS={"honor_code": "hidden", "terms_of_service": "hidden"})
+    def test_register_hidden_honor_code_and_terms_of_service(self):
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+        })
+        self.assertHttpOK(response)
+
     def test_missing_fields(self):
         response = self.client.post(
             self.url,


### PR DESCRIPTION
JIRA task: [OC-1381](https://tasks.opencraft.com/browse/OC-1381)

Removing the honor code checkbox causes the registration form to fail, as the registration form assumes that agreeing to the honor code means agreeing to the terms of service as well. This pull request changes the registration view to make agreeing to the terms of service required only if the checkbox is displayed.

Upstream PR: https://github.com/edx/edx-platform/pull/11644