### PR TITLE
Renames discussion_module to discussion_xblock

### DIFF
--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -866,7 +866,7 @@ class InlineDiscussionTest(UniqueCourseTest, DiscussionResponsePaginationTestMix
         self.assertFalse(self.thread_page.is_comment_deletable("comment1"))
         self.assertFalse(self.thread_page.is_comment_deletable("comment2"))
 
-    def test_dual_discussion_module(self):
+    def test_dual_discussion_xblock(self):
         """
         Scenario: Two discussion module in one unit shouldn't override their actions
         Given that I'm on courseware page where there are two inline discussion

--- a/conf/locale/ar/LC_MESSAGES/django.po
+++ b/conf/locale/ar/LC_MESSAGES/django.po
@@ -357,7 +357,7 @@ msgstr "المساق "
 #: common/djangoapps/course_modes/models.py
 #: common/lib/xmodule/xmodule/annotatable_module.py
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1855,7 +1855,7 @@ msgid "XML data for the annotation"
 msgstr "بيانات ’XML‘ للملاحظات التوضيحية"
 
 #: common/lib/xmodule/xmodule/annotatable_module.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1988,7 +1988,7 @@ msgid "Per Student"
 msgstr "لكلّ طالب"
 
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "XML data for the problem"
 msgstr "بيانات XML للمسألة"
 
@@ -3119,21 +3119,21 @@ msgstr ""
 msgid "General"
 msgstr "عام"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Discussion Id"
 msgstr "رقم المناقشة"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "The id is a unique identifier for the discussion. It is non editable."
 msgstr ""
 "الرقم التعريفي هو عبارة عن معرّف فريد من نوعه لتمييز مناقشة معيّنة عن غيرها."
 " وهو غير قابل للتعديل. "
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Category"
 msgstr "الفئة"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A category name for the discussion. This name appears in the left pane of "
 "the discussion forum for the course."
@@ -3141,11 +3141,11 @@ msgstr ""
 "هو اسم فئة النقاشات. يظهر هذا الاسم على الجانب الأيسر من منتدى النقاشات "
 "الخاص بالمساق."
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Subcategory"
 msgstr "فئة فرعية"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A subcategory name for the discussion. This name appears in the left pane of"
 " the discussion forum for the course."
@@ -13856,21 +13856,21 @@ msgid "There are no posts here yet. Be the first one to post!"
 msgstr "لا توجد منشورات هنا بعد. كن أوّل من ينشر!"
 
 #: lms/templates/discussion/_discussion_course_navigation.html
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "New Post"
 msgstr "منشور جديد "
 
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "Show Discussion"
 msgstr "إظهار المناقشة"
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "To view live discussions, click Preview or View Live in Unit Settings."
 msgstr ""
 "لمشاهدة النقاشات المباشرة، يُرجى النقر على \"المعاينة\" أو \"العرض المباشر\""
 " في إعدادات الوحدة. "
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "Discussion ID: {discussion_id}"
 msgstr "رقم المناقشة: {discussion_id}"
 

--- a/conf/locale/es_419/LC_MESSAGES/django.po
+++ b/conf/locale/es_419/LC_MESSAGES/django.po
@@ -393,7 +393,7 @@ msgstr "Curso"
 #: common/djangoapps/course_modes/models.py
 #: common/lib/xmodule/xmodule/annotatable_module.py
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1896,7 +1896,7 @@ msgid "XML data for the annotation"
 msgstr "Datos XML para la anotación"
 
 #: common/lib/xmodule/xmodule/annotatable_module.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -2034,7 +2034,7 @@ msgid "Per Student"
 msgstr "Por estudiante"
 
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "XML data for the problem"
 msgstr "Datos XML para el problema"
 
@@ -3189,19 +3189,19 @@ msgstr "Introduzca los detalles para Instructor del Curso"
 msgid "General"
 msgstr "General"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Discussion Id"
 msgstr "ID de Discusión"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "The id is a unique identifier for the discussion. It is non editable."
 msgstr "El ID es un identificador único para el debate. No es editable."
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Category"
 msgstr "Categoría"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A category name for the discussion. This name appears in the left pane of "
 "the discussion forum for the course."
@@ -3209,11 +3209,11 @@ msgstr ""
 "Un nombre de categoría para la discusión. Este nombre aparece en el panel "
 "izquierdo de la discusión para el curso."
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Subcategory"
 msgstr "Subcategoría"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A subcategory name for the discussion. This name appears in the left pane of"
 " the discussion forum for the course."
@@ -14112,21 +14112,21 @@ msgid "There are no posts here yet. Be the first one to post!"
 msgstr "Todavía no hay publicaciones. Sé el primero en publicar!"
 
 #: lms/templates/discussion/_discussion_course_navigation.html
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "New Post"
 msgstr " Nueva Entrada"
 
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "Show Discussion"
 msgstr "Mostrar Discusión"
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "To view live discussions, click Preview or View Live in Unit Settings."
 msgstr ""
 "Para ver las discusiones en vivo, haga clic en Vista previa o Ver en vivo en"
 " las opciones de la unidad."
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "Discussion ID: {discussion_id}"
 msgstr "ID de discusión: {discussion_id}"
 

--- a/conf/locale/fr/LC_MESSAGES/django.po
+++ b/conf/locale/fr/LC_MESSAGES/django.po
@@ -391,7 +391,7 @@ msgstr "Cours"
 #: common/djangoapps/course_modes/models.py
 #: common/lib/xmodule/xmodule/annotatable_module.py
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1769,7 +1769,7 @@ msgid "XML data for the annotation"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/annotatable_module.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1891,7 +1891,7 @@ msgid "Per Student"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "XML data for the problem"
 msgstr ""
 
@@ -2849,29 +2849,29 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Discussion Id"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "The id is a unique identifier for the discussion. It is non editable."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Category"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A category name for the discussion. This name appears in the left pane of "
 "the discussion forum for the course."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Subcategory"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A subcategory name for the discussion. This name appears in the left pane of"
 " the discussion forum for the course."
@@ -12824,21 +12824,21 @@ msgid "There are no posts here yet. Be the first one to post!"
 msgstr "Il n'y a aucun message ici. Soyez le premier à en écrire !"
 
 #: lms/templates/discussion/_discussion_course_navigation.html
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "New Post"
 msgstr "Nouveau message"
 
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "Show Discussion"
 msgstr "Afficher la discussion"
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "To view live discussions, click Preview or View Live in Unit Settings."
 msgstr ""
 "Pour voir les discussions en direct, cliquez sur Prévisualisation ou "
 "Visualisation en direct dans les paramètres de l'unité."
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "Discussion ID: {discussion_id}"
 msgstr "ID de discussion : {discussion_id}"
 

--- a/conf/locale/he/LC_MESSAGES/django.po
+++ b/conf/locale/he/LC_MESSAGES/django.po
@@ -269,7 +269,7 @@ msgstr ""
 #: common/djangoapps/course_modes/models.py
 #: common/lib/xmodule/xmodule/annotatable_module.py
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1647,7 +1647,7 @@ msgid "XML data for the annotation"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/annotatable_module.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1771,7 +1771,7 @@ msgid "Per Student"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "XML data for the problem"
 msgstr ""
 
@@ -2726,29 +2726,29 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Discussion Id"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "The id is a unique identifier for the discussion. It is non editable."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Category"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A category name for the discussion. This name appears in the left pane of "
 "the discussion forum for the course."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Subcategory"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A subcategory name for the discussion. This name appears in the left pane of"
 " the discussion forum for the course."
@@ -12544,19 +12544,19 @@ msgid "There are no posts here yet. Be the first one to post!"
 msgstr ""
 
 #: lms/templates/discussion/_discussion_course_navigation.html
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "New Post"
 msgstr ""
 
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "Show Discussion"
 msgstr ""
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "To view live discussions, click Preview or View Live in Unit Settings."
 msgstr ""
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "Discussion ID: {discussion_id}"
 msgstr ""
 

--- a/conf/locale/hi/LC_MESSAGES/django.po
+++ b/conf/locale/hi/LC_MESSAGES/django.po
@@ -269,7 +269,7 @@ msgstr ""
 #: common/djangoapps/course_modes/models.py
 #: common/lib/xmodule/xmodule/annotatable_module.py
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1643,7 +1643,7 @@ msgid "XML data for the annotation"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/annotatable_module.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1765,7 +1765,7 @@ msgid "Per Student"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "XML data for the problem"
 msgstr ""
 
@@ -2719,29 +2719,29 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Discussion Id"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "The id is a unique identifier for the discussion. It is non editable."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Category"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A category name for the discussion. This name appears in the left pane of "
 "the discussion forum for the course."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Subcategory"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A subcategory name for the discussion. This name appears in the left pane of"
 " the discussion forum for the course."
@@ -12578,19 +12578,19 @@ msgid "There are no posts here yet. Be the first one to post!"
 msgstr "इस वक्त तक कोई भी पोस्ट नहीं है। आपकी पोस्ट सबसे पहली हो सकती है!"
 
 #: lms/templates/discussion/_discussion_course_navigation.html
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "New Post"
 msgstr "नई पोस्ट"
 
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "Show Discussion"
 msgstr "चर्चा दिखाएं"
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "To view live discussions, click Preview or View Live in Unit Settings."
 msgstr ""
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "Discussion ID: {discussion_id}"
 msgstr ""
 

--- a/conf/locale/ko_KR/LC_MESSAGES/django.po
+++ b/conf/locale/ko_KR/LC_MESSAGES/django.po
@@ -1623,7 +1623,7 @@ msgid "XML data for the annotation"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/annotatable_module.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1745,7 +1745,7 @@ msgid "Per Student"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "XML data for the problem"
 msgstr ""
 
@@ -2696,29 +2696,29 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Discussion Id"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "The id is a unique identifier for the discussion. It is non editable."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Category"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A category name for the discussion. This name appears in the left pane of "
 "the discussion forum for the course."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Subcategory"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A subcategory name for the discussion. This name appears in the left pane of"
 " the discussion forum for the course."
@@ -12468,19 +12468,19 @@ msgid "There are no posts here yet. Be the first one to post!"
 msgstr "아직 게시글이 없습니다. 처음 게시자가 되어 보세요!"
 
 #: lms/templates/discussion/_discussion_course_navigation.html
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "New Post"
 msgstr "글쓰기"
 
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "Show Discussion"
 msgstr "게시물 보기"
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "To view live discussions, click Preview or View Live in Unit Settings."
 msgstr "게시판을 보려면, 학습활동 설정에서 미리 보기나 적용 결과 보기를 클릭하세요."
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "Discussion ID: {discussion_id}"
 msgstr "토의 ID: {discussion_id}"
 

--- a/conf/locale/pt_BR/LC_MESSAGES/django.po
+++ b/conf/locale/pt_BR/LC_MESSAGES/django.po
@@ -456,7 +456,7 @@ msgstr "Curso"
 #: common/djangoapps/course_modes/models.py
 #: common/lib/xmodule/xmodule/annotatable_module.py
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1938,7 +1938,7 @@ msgid "XML data for the annotation"
 msgstr "Dados XML para a anotação"
 
 #: common/lib/xmodule/xmodule/annotatable_module.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -2072,7 +2072,7 @@ msgid "Per Student"
 msgstr "Por aluno"
 
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "XML data for the problem"
 msgstr "Dados do XML para o problema"
 
@@ -3177,20 +3177,20 @@ msgstr ""
 msgid "General"
 msgstr "Geral"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Discussion Id"
 msgstr "Identificação da Discussão"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "The id is a unique identifier for the discussion. It is non editable."
 msgstr ""
 "Este ID é uma identificação única para a discussão. Ela não é editável. "
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Category"
 msgstr "Categoria"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A category name for the discussion. This name appears in the left pane of "
 "the discussion forum for the course."
@@ -3198,11 +3198,11 @@ msgstr ""
 "Um nome de categoria para a discussão. Este nome aparecerá no painel à "
 "esquerda do fórum de discussão do curso."
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Subcategory"
 msgstr "Subcategoria"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A subcategory name for the discussion. This name appears in the left pane of"
 " the discussion forum for the course."
@@ -14028,21 +14028,21 @@ msgid "There are no posts here yet. Be the first one to post!"
 msgstr "Não há publicações aqui ainda. Seja o primeiro a publicar algo!"
 
 #: lms/templates/discussion/_discussion_course_navigation.html
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "New Post"
 msgstr "Nova publicação"
 
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "Show Discussion"
 msgstr "Mostrar Discussão"
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "To view live discussions, click Preview or View Live in Unit Settings."
 msgstr ""
 "Para visualizar discussões ao vivo, clique em Pré-visualização ou Ver ao "
 "vivo nas Configurações da unidade."
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "Discussion ID: {discussion_id}"
 msgstr "Identificação da Discussão: {discussion_id}"
 

--- a/conf/locale/ru/LC_MESSAGES/django.po
+++ b/conf/locale/ru/LC_MESSAGES/django.po
@@ -402,7 +402,7 @@ msgstr "Курс"
 #: common/djangoapps/course_modes/models.py
 #: common/lib/xmodule/xmodule/annotatable_module.py
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1899,7 +1899,7 @@ msgid "XML data for the annotation"
 msgstr "Содержание пояснения в формате XML"
 
 #: common/lib/xmodule/xmodule/annotatable_module.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -2037,7 +2037,7 @@ msgid "Per Student"
 msgstr "Для каждого слушателя"
 
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "XML data for the problem"
 msgstr "Данные, связанные с заданием, в формате XML"
 
@@ -3181,20 +3181,20 @@ msgstr ""
 msgid "General"
 msgstr "Общее"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Discussion Id"
 msgstr "Идентификатор обсуждения"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "The id is a unique identifier for the discussion. It is non editable."
 msgstr ""
 "Это уникальный идентификатор обсуждения.  Он не подлежит редактированию."
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Category"
 msgstr "Тема"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A category name for the discussion. This name appears in the left pane of "
 "the discussion forum for the course."
@@ -3202,11 +3202,11 @@ msgstr ""
 "Название темы обсуждения.  Это название отображается в левой навигационной "
 "панели форума курса."
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Subcategory"
 msgstr "Подтема"
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A subcategory name for the discussion. This name appears in the left pane of"
 " the discussion forum for the course."
@@ -14089,21 +14089,21 @@ msgid "There are no posts here yet. Be the first one to post!"
 msgstr "Здесь еще нет сообщений. Станьте первым, кто оставит сообщение!"
 
 #: lms/templates/discussion/_discussion_course_navigation.html
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "New Post"
 msgstr "Новая тема"
 
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "Show Discussion"
 msgstr "Показать обсуждение"
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "To view live discussions, click Preview or View Live in Unit Settings."
 msgstr ""
 "Чтобы просмотреть активные темы обсуждения, нажмите «Предварительный "
 "просмотр» или «Просмотр курса» в настройках блока."
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "Discussion ID: {discussion_id}"
 msgstr "Идентификатор обсуждения: {discussion_id}"
 

--- a/conf/locale/zh_CN/LC_MESSAGES/django.po
+++ b/conf/locale/zh_CN/LC_MESSAGES/django.po
@@ -1876,7 +1876,7 @@ msgid "XML data for the annotation"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/annotatable_module.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 #: common/lib/xmodule/xmodule/html_module.py
 #: common/lib/xmodule/xmodule/imageannotation_module.py
 #: common/lib/xmodule/xmodule/library_content_module.py
@@ -1998,7 +1998,7 @@ msgid "Per Student"
 msgstr ""
 
 #: common/lib/xmodule/xmodule/capa_base.py
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "XML data for the problem"
 msgstr ""
 
@@ -2950,29 +2950,29 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Discussion Id"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "The id is a unique identifier for the discussion. It is non editable."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Category"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A category name for the discussion. This name appears in the left pane of "
 "the discussion forum for the course."
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid "Subcategory"
 msgstr ""
 
-#: common/lib/xmodule/xmodule/discussion_module.py
+#: common/lib/xblock/xblock_discussion/xblock_discussion.py
 msgid ""
 "A subcategory name for the discussion. This name appears in the left pane of"
 " the discussion forum for the course."
@@ -12715,19 +12715,19 @@ msgid "There are no posts here yet. Be the first one to post!"
 msgstr "现在还没有讨论帖。成为第一个发帖的人吧！"
 
 #: lms/templates/discussion/_discussion_course_navigation.html
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "New Post"
 msgstr "新讨论帖"
 
-#: lms/templates/discussion/_discussion_module.html
+#: lms/templates/discussion/_discussion_inline.html
 msgid "Show Discussion"
 msgstr "显示讨论"
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "To view live discussions, click Preview or View Live in Unit Settings."
 msgstr "要查看现场讨论，请在单元设置中点击“预览”或“现场查看”"
 
-#: lms/templates/discussion/_discussion_module_studio.html
+#: lms/templates/discussion/_discussion_inline_studio.html
 msgid "Discussion ID: {discussion_id}"
 msgstr ""
 

--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -9,7 +9,7 @@ from mock import patch
 from courseware.tests.factories import BetaTesterFactory
 from courseware.access import has_access
 from lms.djangoapps.ccx.tests.test_overrides import inject_field_overrides
-from lms.djangoapps.django_comment_client.utils import get_accessible_discussion_modules
+from lms.djangoapps.django_comment_client.utils import get_accessible_discussion_xblocks
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData, OverrideModulestoreFieldData
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -51,7 +51,7 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         inject_field_overrides((course, section), course, self.user)
         return (course, section)
 
-    def create_discussion_modules(self, parent):
+    def create_discussion_xblocks(self, parent):
         # Create a released discussion module
         ItemFactory.create(
             parent=parent,
@@ -110,31 +110,31 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
         self.assertTrue(has_access(beta_tester, 'load', self_paced_section, self_paced_course.id))
 
     @patch.dict('courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
-    def test_instructor_paced_discussion_module_visibility(self):
+    def test_instructor_paced_discussion_xblock_visibility(self):
         """
         Verify that discussion modules scheduled for release in the future are
         not visible to students in an instructor-paced course.
         """
         course, section = self.setup_course(start=self.now, self_paced=False)
-        self.create_discussion_modules(section)
+        self.create_discussion_xblocks(section)
 
         # Only the released module should be visible when the course is instructor-paced.
-        modules = get_accessible_discussion_modules(course, self.non_staff_user)
+        modules = get_accessible_discussion_xblocks(course, self.non_staff_user)
         self.assertTrue(
             all(module.display_name == 'released' for module in modules)
         )
 
     @patch.dict('courseware.access.settings.FEATURES', {'DISABLE_START_DATES': False})
-    def test_self_paced_discussion_module_visibility(self):
+    def test_self_paced_discussion_xblock_visibility(self):
         """
         Regression test. Verify that discussion modules scheduled for release
         in the future are visible to students in a self-paced course.
         """
         course, section = self.setup_course(start=self.now, self_paced=True)
-        self.create_discussion_modules(section)
+        self.create_discussion_xblocks(section)
 
         # The scheduled module should be visible when the course is self-paced.
-        modules = get_accessible_discussion_modules(course, self.non_staff_user)
+        modules = get_accessible_discussion_xblocks(course, self.non_staff_user)
         self.assertEqual(len(modules), 2)
         self.assertTrue(
             any(module.display_name == 'scheduled' for module in modules)

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -188,8 +188,8 @@ class GetCourseTopicsTest(UrlResetMixin, ModuleStoreTestCase):
         self.request.user = self.user
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
-    def make_discussion_module(self, topic_id, category, subcategory, **kwargs):
-        """Build a discussion module in self.course"""
+    def make_discussion_xblock(self, topic_id, category, subcategory, **kwargs):
+        """Build a discussion xblock in self.course"""
         ItemFactory.create(
             parent_location=self.course.location,
             category="discussion",
@@ -256,7 +256,7 @@ class GetCourseTopicsTest(UrlResetMixin, ModuleStoreTestCase):
         self.assertEqual(actual, expected)
 
     def test_with_courseware(self):
-        self.make_discussion_module("courseware-topic-id", "Foo", "Bar")
+        self.make_discussion_xblock("courseware-topic-id", "Foo", "Bar")
         actual = self.get_course_topics()
         expected = {
             "courseware_topics": [
@@ -279,11 +279,11 @@ class GetCourseTopicsTest(UrlResetMixin, ModuleStoreTestCase):
                 "B": {"id": "non-courseware-2"},
             }
             self.store.update_item(self.course, self.user.id)
-            self.make_discussion_module("courseware-1", "A", "1")
-            self.make_discussion_module("courseware-2", "A", "2")
-            self.make_discussion_module("courseware-3", "B", "1")
-            self.make_discussion_module("courseware-4", "B", "2")
-            self.make_discussion_module("courseware-5", "C", "1")
+            self.make_discussion_xblock("courseware-1", "A", "1")
+            self.make_discussion_xblock("courseware-2", "A", "2")
+            self.make_discussion_xblock("courseware-3", "B", "1")
+            self.make_discussion_xblock("courseware-4", "B", "2")
+            self.make_discussion_xblock("courseware-5", "C", "1")
         actual = self.get_course_topics()
         expected = {
             "courseware_topics": [
@@ -325,13 +325,13 @@ class GetCourseTopicsTest(UrlResetMixin, ModuleStoreTestCase):
                 "Z": {"id": "non-courseware-4", "sort_key": "W"},
             }
             self.store.update_item(self.course, self.user.id)
-            self.make_discussion_module("courseware-1", "First", "A", sort_key="D")
-            self.make_discussion_module("courseware-2", "First", "B", sort_key="B")
-            self.make_discussion_module("courseware-3", "First", "C", sort_key="E")
-            self.make_discussion_module("courseware-4", "Second", "A", sort_key="F")
-            self.make_discussion_module("courseware-5", "Second", "B", sort_key="G")
-            self.make_discussion_module("courseware-6", "Second", "C")
-            self.make_discussion_module("courseware-7", "Second", "D", sort_key="A")
+            self.make_discussion_xblock("courseware-1", "First", "A", sort_key="D")
+            self.make_discussion_xblock("courseware-2", "First", "B", sort_key="B")
+            self.make_discussion_xblock("courseware-3", "First", "C", sort_key="E")
+            self.make_discussion_xblock("courseware-4", "Second", "A", sort_key="F")
+            self.make_discussion_xblock("courseware-5", "Second", "B", sort_key="G")
+            self.make_discussion_xblock("courseware-6", "Second", "C")
+            self.make_discussion_xblock("courseware-7", "Second", "D", sort_key="A")
 
         actual = self.get_course_topics()
         expected = {
@@ -393,21 +393,21 @@ class GetCourseTopicsTest(UrlResetMixin, ModuleStoreTestCase):
             )
 
         with self.store.bulk_operations(self.course.id, emit_signals=False):
-            self.make_discussion_module("courseware-1", "First", "Everybody")
-            self.make_discussion_module(
+            self.make_discussion_xblock("courseware-1", "First", "Everybody")
+            self.make_discussion_xblock(
                 "courseware-2",
                 "First",
                 "Cohort A",
                 group_access={self.partition.id: [self.partition.groups[0].id]}
             )
-            self.make_discussion_module(
+            self.make_discussion_xblock(
                 "courseware-3",
                 "First",
                 "Cohort B",
                 group_access={self.partition.id: [self.partition.groups[1].id]}
             )
-            self.make_discussion_module("courseware-4", "Second", "Staff Only", visible_to_staff_only=True)
-            self.make_discussion_module(
+            self.make_discussion_xblock("courseware-4", "Second", "Staff Only", visible_to_staff_only=True)
+            self.make_discussion_xblock(
                 "courseware-5",
                 "Second",
                 "Future Start Date",

--- a/lms/djangoapps/django_comment_client/forum/tests.py
+++ b/lms/djangoapps/django_comment_client/forum/tests.py
@@ -631,8 +631,8 @@ class SingleThreadContentGroupTestCase(ContentGroupTestCase):
         thread_id = "test_thread_id"
         mock_request.side_effect = make_mock_request_impl(course=self.course, text="dummy content", thread_id=thread_id)
 
-        for discussion_module in [self.alpha_module, self.beta_module, self.global_module]:
-            self.assert_can_access(self.staff_user, discussion_module.discussion_id, thread_id, True)
+        for discussion_xblock in [self.alpha_module, self.beta_module, self.global_module]:
+            self.assert_can_access(self.staff_user, discussion_xblock.discussion_id, thread_id, True)
 
     def test_alpha_user(self, mock_request):
         """
@@ -642,8 +642,8 @@ class SingleThreadContentGroupTestCase(ContentGroupTestCase):
         thread_id = "test_thread_id"
         mock_request.side_effect = make_mock_request_impl(course=self.course, text="dummy content", thread_id=thread_id)
 
-        for discussion_module in [self.alpha_module, self.global_module]:
-            self.assert_can_access(self.alpha_user, discussion_module.discussion_id, thread_id, True)
+        for discussion_xblock in [self.alpha_module, self.global_module]:
+            self.assert_can_access(self.alpha_user, discussion_xblock.discussion_id, thread_id, True)
 
         self.assert_can_access(self.alpha_user, self.beta_module.discussion_id, thread_id, False)
 
@@ -655,8 +655,8 @@ class SingleThreadContentGroupTestCase(ContentGroupTestCase):
         thread_id = "test_thread_id"
         mock_request.side_effect = make_mock_request_impl(course=self.course, text="dummy content", thread_id=thread_id)
 
-        for discussion_module in [self.beta_module, self.global_module]:
-            self.assert_can_access(self.beta_user, discussion_module.discussion_id, thread_id, True)
+        for discussion_xblock in [self.beta_module, self.global_module]:
+            self.assert_can_access(self.beta_user, discussion_xblock.discussion_id, thread_id, True)
 
         self.assert_can_access(self.beta_user, self.alpha_module.discussion_id, thread_id, False)
 

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -177,7 +177,7 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
 
     @ddt.data((ModuleStoreEnum.Type.mongo, 2), (ModuleStoreEnum.Type.split, 1))
     @ddt.unpack
-    def test_get_accessible_discussion_modules(self, modulestore_type, expected_discussion_modules):
+    def test_get_accessible_discussion_xblocks(self, modulestore_type, expected_discussion_xblocks):
         """
         Tests that the accessible discussion modules having no parents do not get fetched for split modulestore.
         """
@@ -190,7 +190,7 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
         self.assertNotIn(test_discussion.location, self.store.get_orphans(course.id))
 
         # Assert that there is only one discussion module in the course at the moment.
-        self.assertEqual(len(utils.get_accessible_discussion_modules(course, self.user)), 1)
+        self.assertEqual(len(utils.get_accessible_discussion_xblocks(course, self.user)), 1)
 
         # Add an orphan discussion module to that course
         orphan = course.id.make_usage_key('discussion', 'orphan_discussion')
@@ -199,7 +199,7 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
         # Assert that the discussion module is an orphan.
         self.assertIn(orphan, self.store.get_orphans(course.id))
 
-        self.assertEqual(len(utils.get_accessible_discussion_modules(course, self.user)), expected_discussion_modules)
+        self.assertEqual(len(utils.get_accessible_discussion_xblocks(course, self.user)), expected_discussion_xblocks)
 
 
 @attr('shard_3')
@@ -505,7 +505,7 @@ class CategoryMapTestCase(CategoryMapTestMixin, ModuleStoreTestCase):
             cohorted_if_in_list=True
         )
 
-    def test_get_unstarted_discussion_modules(self):
+    def test_get_unstarted_discussion_xblocks(self):
         later = datetime.datetime(datetime.MAXYEAR, 1, 1, tzinfo=django_utc())
 
         self.create_discussion("Chapter 1", "Discussion 1", start=later)

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -124,9 +124,9 @@ def has_required_keys(module):
     return True
 
 
-def get_accessible_discussion_modules(course, user, include_all=False):  # pylint: disable=invalid-name
+def get_accessible_discussion_xblocks(course, user, include_all=False):  # pylint: disable=invalid-name
     """
-    Return a list of all valid discussion modules in this course that
+    Return a list of all valid discussion xblocks in this course that
     are accessible to the given user.
     """
     all_modules = modulestore().get_items(course.id, qualifiers={'category': 'discussion'}, include_orphans=False)
@@ -195,7 +195,7 @@ def get_discussion_id_map(course, user):
     Transform the list of this course's discussion modules (visible to a given user) into a dictionary of metadata keyed
     by discussion_id.
     """
-    return dict(map(get_discussion_id_map_entry, get_accessible_discussion_modules(course, user)))
+    return dict(map(get_discussion_id_map_entry, get_accessible_discussion_xblocks(course, user)))
 
 
 def _filter_unstarted_categories(category_map, course):
@@ -301,7 +301,7 @@ def get_discussion_category_map(course, user, cohorted_if_in_list=False, exclude
     """
     unexpanded_category_map = defaultdict(list)
 
-    modules = get_accessible_discussion_modules(course, user)
+    modules = get_accessible_discussion_xblocks(course, user)
 
     course_cohort_settings = get_course_cohort_settings(course.id)
 
@@ -416,7 +416,7 @@ def get_discussion_categories_ids(course, user, include_all=False):
 
     """
     accessible_discussion_ids = [
-        module.discussion_id for module in get_accessible_discussion_modules(course, user, include_all=include_all)
+        module.discussion_id for module in get_accessible_discussion_xblocks(course, user, include_all=include_all)
     ]
     return course.top_level_discussion_topic_ids + accessible_discussion_ids
 

--- a/openedx/core/djangoapps/content/course_structures/tests.py
+++ b/openedx/core/djangoapps/content/course_structures/tests.py
@@ -32,12 +32,12 @@ class CourseStructureTaskTests(ModuleStoreTestCase):
         super(CourseStructureTaskTests, self).setUp()
         self.course = CourseFactory.create(org='TestX', course='TS101', run='T1')
         self.section = ItemFactory.create(parent=self.course, category='chapter', display_name='Test Section')
-        self.discussion_module_1 = ItemFactory.create(
+        self.discussion_xblock_1 = ItemFactory.create(
             parent=self.course,
             category='discussion',
             discussion_id='test_discussion_id_1'
         )
-        self.discussion_module_2 = ItemFactory.create(
+        self.discussion_xblock_2 = ItemFactory.create(
             parent=self.course,
             category='discussion',
             discussion_id='test_discussion_id_2'


### PR DESCRIPTION
This change renames all code instances of `discussion_module` and to `discussion_xblock`, and updates the file paths used in the locale config to reflect new file locations.

The only remaining references to `discussion_module` or `discussion-module` are JS or CSS-related, and unnecessary coffee/JS changes are prohibited by [OC-1623](https://tasks.opencraft.com/browse/OC-1623).

**JIRA tickets**: Final part of [OC-1623](https://tasks.opencraft.com/browse/OC-1623).

**Reviewers**
- [x] @e-kolpakov 