### PR TITLE
Add link to OpenCraft.Hosting to navigation [Demo]

### DIFF
--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -138,7 +138,9 @@ site_status_msg = get_site_status_msg(course_id)
             <a class="cta cta-register" href="/register${login_query()}">${_("Register")}</a>
           </li>
           % endif
-
+          <li class="nav-global-04">
+            <a class="cta" href="http://opencraft.hosting/">${_("Host your own instance")}</a>
+          </li>
       % endif
     </ol>
 


### PR DESCRIPTION
Adds a link to OpenCraft.Hosting to the main navigation bar.

This PR is to demo deploying an update to a production instance, using OpenCraft.Hosting.