### PR TITLE
Implemented revision list on dashboard

### DIFF
--- a/common/djangoapps/adaptive_domoscio/views.py
+++ b/common/djangoapps/adaptive_domoscio/views.py
@@ -1,0 +1,66 @@
+"""
+Adaptive Domoscio
+"""
+import calendar
+import datetime
+import json
+
+from django.contrib.auth.decorators import login_required
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse
+from django.views.decorators.csrf import ensure_csrf_cookie
+from xmodule.modulestore.django import modulestore
+from opaque_keys.edx.locator import BlockUsageLocator
+from xmodule.modulestore.search import path_to_location, navigation_index
+
+
+@login_required
+@ensure_csrf_cookie
+def revisions(request):
+    """
+    Return a JSON list of all revisions for a user. Each revision includes a name, due date, and URL.
+    """
+    user = request.user
+
+    revisions = _get_pending_revisions(user)
+    json_revisions = json.dumps(revisions)
+
+    return HttpResponse(json_revisions)
+
+
+def _get_pending_revisions(user):
+    """
+    Returns information about each problem that needs revision for a given user, including a display name, the due date
+    of the revision, and a courseware URL.
+    """
+    # TODO: Grab all of the AdaptiveLibraryContentModules for the user.
+    #       to the Domoscio API.
+    serialized_locators = [
+        'block-v1:asdf+asdf+asdf+type@problem+block@9adc878ed55943caa7d4b4cd48e52752',
+        'block-v1:asdf+asdf+asdf+type@problem+block@0c4c0798cf3847ae9c706cdcb9442c62',
+    ]
+
+    locators = map(BlockUsageLocator.from_string, serialized_locators)
+
+    revision_data = []
+    for locator in locators:
+        # Resolve the courseware URL for the revision xblock.
+        (
+            course_key, chapter, section, vertical_unused,
+            position, final_target_id_unused
+        ) = path_to_location(modulestore(), locator)
+
+        url = reverse(
+            'courseware_position',
+            args=(unicode(course_key), chapter, section, navigation_index(position))
+        )
+
+        xblock = modulestore().get_item(locator)
+        # TODO: Make a call to the Domoscio API to get the display information for the xblock.
+        revision_data.append({
+            'name': 'testname',  # xblock.name,
+            'due_date': calendar.timegm(datetime.date(2017, 1, 1).timetuple()),  # xblock.due,
+            'url': url,
+        })
+
+    return revision_data

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1941,6 +1941,8 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.self_paced',
 
     'sorl.thumbnail',
+
+    'adaptive_domoscio',
 )
 
 # Migrations which are not in the standard module "migrations"

--- a/lms/static/js/revisions/collections/revision_collection.js
+++ b/lms/static/js/revisions/collections/revision_collection.js
@@ -1,0 +1,48 @@
+;(function (define) {
+
+define([
+    'backbone',
+    'js/revisions/models/revision'
+], function (Backbone, Revision) {
+    'use strict';
+
+    return Backbone.Collection.extend({
+
+        model: Revision,
+        url: '/api/revisions/',
+        fetchXhr: null,
+
+        initialize: function (models, options) {
+            Backbone.Collection.prototype.initialize.apply(this, arguments);
+        },
+
+        fetchRevisions: function () {
+            this.fetchXhr && this.fetchXhr.abort();
+            this.resetState();
+            this.fetchXhr = this.fetch({
+                data: {},
+                type: 'GET',
+                success: function (self, xhr) {
+                    self.trigger('revisions_loaded');
+                },
+                error: function (self, xhr) {
+                    self.trigger('error');
+                }
+            });
+        },
+
+        parse: function(response) {
+            return response;
+        },
+
+        resetState: function () {
+            // empty the entire collection
+            this.reset();
+        },
+
+    });
+
+});
+
+
+})(define || RequireJS.define);

--- a/lms/static/js/revisions/dashboard_revision_factory.js
+++ b/lms/static/js/revisions/dashboard_revision_factory.js
@@ -1,0 +1,30 @@
+;(function (define) {
+    'use strict';
+
+    define(['backbone', 'js/revisions/collections/revision_collection', 'js/revisions/views/revision_list_view'],
+        function(Backbone, RevisionCollection, RevisionListView) {
+
+            return function () {
+
+                var collection = new RevisionCollection([]);
+                var view = new RevisionListView({ collection: collection });
+                var dispatcher = _.clone(Backbone.Events);
+
+                dispatcher.listenTo(collection, 'revisions_loaded', function() {
+                    // The revisions were fetched successfully.
+                    view.render();
+                });
+
+                dispatcher.listenTo(collection, 'error', function() {
+                    // The revisions couldn't be fetched.
+                    view.showErrorMessage();
+                });
+
+                // Kick off the revision fetch.
+                collection.fetchRevisions();
+
+            };
+
+        });
+
+})(define || RequireJS.define);

--- a/lms/static/js/revisions/models/revision.js
+++ b/lms/static/js/revisions/models/revision.js
@@ -1,0 +1,16 @@
+;(function (define) {
+
+define(['backbone'], function (Backbone) {
+    'use strict';
+
+    return Backbone.Model.extend({
+        defaults: {
+            name: '',
+            due_date: '',
+            url: ''
+        }
+    });
+
+});
+
+})(define || RequireJS.define);

--- a/lms/static/js/revisions/views/revision_list_view.js
+++ b/lms/static/js/revisions/views/revision_list_view.js
@@ -1,0 +1,58 @@
+;(function (define) {
+
+define([
+    'jquery',
+    'underscore',
+    'backbone',
+    'gettext',
+], function ($, _, Backbone, gettext) {
+
+   'use strict';
+
+    return Backbone.View.extend({
+
+        el: '#dashboard-revisions',
+        revisionListTemplateId: '#dashboard_revision_list-tpl',
+        revisionListItemTemplateId: '#dashboard_revision_item-tpl',
+        loadingTemplateId: '#dashboard_revision_loading-tpl',
+        errorTemplateId: '#dashboard_revision_error-tpl',
+        events: {},
+
+        initialize: function () {
+            this.revisionListTemplate = _.template($(this.revisionListTemplateId).html());
+            this.revisionListItemTemplate = _.template($(this.revisionListItemTemplateId).html());
+            this.loadingTemplate = _.template($(this.loadingTemplateId).html());
+            this.errorTemplate = _.template($(this.errorTemplateId).html());
+            this.showLoadingMessage();
+        },
+
+        render: function () {
+            this.$el.html(this.revisionListTemplate({
+                totalCount: this.collection.length,
+            }));
+            this.renderItems();
+            return this;
+        },
+
+        renderItems: function () {
+            var items = this.collection.map(function (revision) {
+                var data = _.clone(revision.attributes);
+                return this.revisionListItemTemplate(data);
+            }, this);
+            this.$el.find('ul').html(items.join(''));
+        },
+
+        showLoadingMessage: function () {
+            this.$el.html(this.loadingTemplate());
+        },
+
+        showErrorMessage: function () {
+            this.$el.html(this.errorTemplate());
+        },
+
+    });
+
+});
+
+
+})(define || RequireJS.define);

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -32,6 +32,18 @@
     }
   }
 
+  .dashboard-revisions {
+    margin: ($baseline*2) 0;
+    border-top: 3px solid #f72c30;
+    border-bottom: 3px solid #f72c30 !important;
+    padding: $baseline 0;
+    color: $link-color;
+    li {
+      list-style-type: disc;
+      color: $link-color;
+    }
+  }
+
   .profile-sidebar {
     background: transparent;
     @include float(right);

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -31,6 +31,12 @@ import json
     <%static:include path="search/${template_name}.underscore" />
 </script>
 % endfor
+
+% for template_name in ["dashboard_revision_item", "dashboard_revision_list", "dashboard_revision_loading", "dashboard_revision_error"]:
+<script type="text/template" id="${template_name}-tpl">
+    <%static:include path="revisions/${template_name}.underscore" />
+</script>
+% endfor
 </%block>
 
 <%block name="js_extra">
@@ -57,6 +63,10 @@ import json
         banner.showMessage(${json.dumps(redirect_message)})
     </%static:require_module>
   % endif
+
+  <%static:require_module module_name="js/revisions/dashboard_revision_factory" class_name="DashboardRevisionFactory">
+    DashboardRevisionFactory();
+  </%static:require_module>
 </%block>
 
 <div class="dashboard-notifications" tabindex="-1">
@@ -179,12 +189,13 @@ import json
         <a href="${reverse('payment:list-receipts')}" class="edit-name">
             ${_("Order History")}
         </a>
-
-      </ul>
+      </span>
       ## We remove the identity verification status display, because this process is entrusted to proctorU
       ## <%include file='dashboard/_dashboard_status_verification.html' />
 ## END FUN
-
+      </ul>
+    </section>
+    <section id="dashboard-revisions" class="dashboard-revisions">
     </section>
   </section>
 </section>

--- a/lms/templates/revisions/dashboard_revision_error.underscore
+++ b/lms/templates/revisions/dashboard_revision_error.underscore
@@ -1,0 +1,3 @@
+<span class="title edit-name">
+  <%= gettext("Error fetching revisions.") %>
+</span>

--- a/lms/templates/revisions/dashboard_revision_item.underscore
+++ b/lms/templates/revisions/dashboard_revision_item.underscore
@@ -1,0 +1,16 @@
+<li>
+    <a href="<%- url %>">
+        <%- name %>
+        <% if (due_date) { %>
+            (<%= gettext("before") %> <%
+                var d = new Date(due_date*1000),
+                    fragments = [
+                        d.getDate(),
+                        d.getMonth() + 1,
+                        d.getFullYear()
+                    ];
+                print(fragments.join('/'));
+                %>)
+        <% } %>
+    </a>
+</li>

--- a/lms/templates/revisions/dashboard_revision_list.underscore
+++ b/lms/templates/revisions/dashboard_revision_list.underscore
@@ -1,0 +1,16 @@
+<span class="title edit-name">
+    <% if (totalCount > 0 ) { %>
+        <%= interpolate(
+            ngettext(
+                "You have (%(num_items)s) pending revision:",
+                "You have (%(num_items)s) pending revisions:",
+                totalCount
+            ),
+            { num_items: totalCount },
+            true
+        ) %>
+    <% } else { %>
+        <%= gettext("You have no pending revisions.") %>
+    <% } %>
+</span>
+<ul class="revision-list"></ul>

--- a/lms/templates/revisions/dashboard_revision_loading.underscore
+++ b/lms/templates/revisions/dashboard_revision_loading.underscore
@@ -1,0 +1,3 @@
+<span class="title edit-name">
+  <%= gettext("Loading revisions...") %>
+</span>

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -29,6 +29,9 @@ urlpatterns = (
     url(r'^login_ajax$', 'student.views.login_user', name="login"),
     url(r'^login_ajax/(?P<error>[^/]*)$', 'student.views.login_user'),
 
+    # Revisions API
+    url(r'^api/revisions/', 'adaptive_domoscio.views.revisions', name='revisions'),
+
     url(r'^email_confirm/(?P<key>[^/]*)$', 'student.views.confirm_email_change'),
     url(r'^event$', 'track.views.user_track'),
     url(r'^performance$', 'performance.views.performance_log'),


### PR DESCRIPTION
This change implements an async display of pending revisions (see the [Adaptive Learning](https://tasks.opencraft.com/browse/OC-2127) epic). The display isn't hooked up to the Domoscio API yet, so the list of xblocks to display is currently [hard coded](#diff-55b798ee23a7fde8d1103408afcd0f16R736) in the view.

**JIRA tickets**: [OC-2153](https://tasks.opencraft.com/browse/OC-2153)

**Screenshots**:
![](http://i.imgur.com/WfGSCK4.png)

**Testing instructions**:

1. Setup a [fun-box](https://github.com/openfun/fun-boxes) against this branch (open-craft:bdero/revision-list).
1. Create a course in studio with two or three problem xblocks (multiple choice, drop down, etc).
1. Navigate to the course in the LMS using a staff user, and obtain the serialized XBlock locations using the `Staff Debug Info` modal: ![](http://i.imgur.com/uqnnTUH.png)
1. Place those locations into the hardcoded list in [_get_pending_revisions](#diff-55b798ee23a7fde8d1103408afcd0f16R731): ![](http://i.imgur.com/6lE4VhI.png)
1. Navigate to the [dashboard](http://localhost:8000/dashboard) and notice the list of revisions is showing up on the right: ![](http://i.imgur.com/WfGSCK4.png)
1. Click on the revisions and notice that the links lead to the correct courseware unit.

**Author notes and concerns**:

There are two TODO notes in [_get_pending_revisions](#diff-55b798ee23a7fde8d1103408afcd0f16R731) that are to be answered in a future ticket when this is fully hooked up to the Domoscio API.

**Reviewers**
- [x] @itsjeyd
