### PR TITLE
Adaptive Content Block: Send "Unit viewed" event, selectively display review questions

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -170,6 +170,20 @@ class TextbookList(List):
 
 
 class CourseFields(object):
+    adaptive_learning_configuration = Dict(
+        display_name=_("Adaptive Learning Configuration"),
+        help=_(
+            "Enter configuration for accessing external service that provides adaptive learning features."
+        ),
+        default={
+            'url': '',
+            'api_version': '',
+            'instance_id': -1,
+            'access_token': '',
+        },
+        scope=Scope.settings
+    )
+
     lti_passports = List(
         display_name=_("LTI Passports"),
         help=_('Enter the passports for course LTI tools in the following format: "id:client_key:client_secret".'),

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -526,9 +526,12 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         }
         selections = []
         for pending_review in pending_reviews:
-            block_id = pending_review.get('knowledge_node_uid')
-            if block_id in valid_block_keys:
-                selections.append(valid_block_keys['block_id'])
+            unit_id = pending_review.get('knowledge_node_uid')
+            # TODO: Adjust if necessary (name of property that specifies block ID of review question
+            # might differ from the one we are currently using):
+            question_id = pending_review.get('review_question_uid')
+            if unit_id == self.parent_unit_id and question_id in valid_block_keys:
+                selections.append(valid_block_keys[question_id])
         return selections
 
     def student_view(self, context):

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -428,6 +428,13 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
             anonymous_user_id = None
         return anonymous_user_id
 
+    @lazy
+    def child_block_ids(self):
+        """
+        Return list of `block_id`s identifying children of this block.
+        """
+        return [child.block_id for child in self.children]
+
     @classmethod
     def make_selection(cls, selected, children, max_count, mode):
         """
@@ -530,6 +537,8 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         """
         # Notify external service that parent unit has been viewed by learner
         self.send_unit_viewed_event()
+        # Link current user to children of this block
+        self.link_current_user_to_children()
 
         return super(AdaptiveLibraryContentModule, self).student_view(context)
 
@@ -543,6 +552,18 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         user_id = self.anonymous_user_id
         # Send "Unit viewed" event
         self.create_read_event(block_id, user_id)
+
+    def link_current_user_to_children(self):
+        """
+        On external service, establish links between current user and children of this block
+        if they don't exist.
+        """
+        # Get IDs of children
+        block_ids = self.child_block_ids
+        # Get student ID for current user
+        user_id = self.anonymous_user_id
+        # Establish links
+        self.create_knowledge_node_students(block_ids, user_id)
 
 
 @XBlock.wants('user')

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -3,7 +3,6 @@
 LibraryContent: The XBlock used to include blocks from a library in a course.
 """
 import json, logging
-import requests
 from lxml import etree
 from copy import copy
 from capa.responsetypes import registry
@@ -415,13 +414,16 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
     @lazy
     def anonymous_user_id(self):
         """
-        Return anonymous ID of current user.
+        Return anonymous ID for current user.
+
+        Note that we can't use `user_service.get_anonymous_user_id` here
+        because it only produces meaningful results for staff users.
         """
         user_service = self.runtime.service(self, 'user')
         if user_service:
             current_user = user_service.get_current_user()
-            username = current_user.opt_attrs.get('edx-platform.username')
-            anonymous_user_id = user_service.get_anonymous_user_id(username, unicode(self.course_id))
+            user_id = current_user.opt_attrs.get('edx-platform.user_id')
+            anonymous_user_id = self._make_anonymous_user_id(user_id)
         else:
             anonymous_user_id = None
         return anonymous_user_id

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -463,7 +463,9 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         # Set of (block_type, block_id) tuples assigned to this student
         selected = set(tuple(k) for k in selected)
         # Set of (block_type, block_id) tuples previously assigned to this student
-        previously_selected = set(tuple(k) for k in kwargs.get('previously_selected'))
+        previously_selected = kwargs.get('previously_selected')
+        if previously_selected is not None:
+            previously_selected = set(tuple(k) for k in previously_selected)
 
         # Determine which of our children we will show:
         valid_block_keys = set([(c.block_type, c.block_id) for c in children])

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -423,7 +423,7 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         if user_service:
             current_user = user_service.get_current_user()
             user_id = current_user.opt_attrs.get('edx-platform.user_id')
-            anonymous_user_id = self._make_anonymous_user_id(user_id)
+            anonymous_user_id = self.make_anonymous_user_id(user_id)
         else:
             anonymous_user_id = None
         return anonymous_user_id

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -398,9 +398,11 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
 
     def __init__(self, descriptor, *args, **kwargs):
         """
-        Cache relevant data.
+        Initialize cache for relevant data.
         """
         self._adaptive_learning_configuration = None
+        self._current_user_id = None
+        self._parent_unit_id = None
 
         super(AdaptiveLibraryContentModule, self).__init__(descriptor, *args, **kwargs)
 
@@ -628,18 +630,21 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         """
         Return anonymous ID of current user.
         """
-        user_service = self.runtime.service(self, 'user')
-        current_user = user_service.get_current_user()
-        username = current_user.opt_attrs.get('edx-platform.username')
-        user_id = user_service.get_anonymous_user_id(username, unicode(self.course_id))
-        return user_id
+        if self._current_user_id is None:
+            user_service = self.runtime.service(self, 'user')
+            current_user = user_service.get_current_user()
+            username = current_user.opt_attrs.get('edx-platform.username')
+            self._current_user_id = user_service.get_anonymous_user_id(username, unicode(self.course_id))
+        return self._current_user_id
 
     def get_parent_unit_id(self):
         """
         Return block ID of parent unit.
         """
-        parent_unit = self.get_parent()
-        return parent_unit.scope_ids.usage_id.block_id
+        if self._parent_unit_id is None:
+            parent_unit = self.get_parent()
+            self._parent_unit_id = parent_unit.scope_ids.usage_id.block_id
+        return self._parent_unit_id
 
     def get_or_create_knowledge_node_student(self, block_id, user_id):
         """

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -337,19 +337,19 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
         """
         self._bind_course_module(self.lc_block)
         module = self.lc_block._xmodule
-        with patch.object(module, '_make_anonymous_user_id') as patched__make_anonymous_user_id, \
+        with patch.object(module, 'make_anonymous_user_id') as patched_make_anonymous_user_id, \
              patch.object(module.runtime, 'service') as patched_service:
             user_service_mock = Mock()
             current_user_mock = Mock()
             current_user_mock.opt_attrs.get.return_value = 42
             user_service_mock.get_current_user.return_value = current_user_mock
             patched_service.return_value = user_service_mock
-            patched__make_anonymous_user_id.return_value = 'dummy-id'
+            patched_make_anonymous_user_id.return_value = 'dummy-id'
             user_id = module.anonymous_user_id
             self.assertEqual(user_id, 'dummy-id')
             patched_service.assert_called_once_with(module, 'user')
             current_user_mock.opt_attrs.get.assert_called_once_with('edx-platform.user_id')
-            patched__make_anonymous_user_id.assert_called_once_with(42)
+            patched_make_anonymous_user_id.assert_called_once_with(42)
 
     def test_anonymous_user_id_no_user_service(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
@@ -1,0 +1,449 @@
+"""
+Tests for adaptive learning utilities.
+"""
+
+import json
+import unittest
+
+import httpretty
+from mock import DEFAULT, MagicMock, Mock, patch
+
+from ..util.adaptive_learning import AdaptiveLearningConfiguration, AdaptiveLearningAPIMixin
+
+
+ADAPTIVE_LEARNING_CONFIGURATION = {
+    'url': 'https://dummy.com',
+    'api_version': 'v42',
+    'instance_id': 23,
+    'access_token': 'this-is-not-a-test',
+}
+
+URLS = {
+    'adaptive_learning_url': 'https://dummy.com/v42',
+    'instance_url': 'https://dummy.com/v42/instances/23',
+    'students_url': 'https://dummy.com/v42/instances/23/students',
+    'events_url': 'https://dummy.com/v42/instances/23/events',
+    'knowledge_node_students_url': 'https://dummy.com/v42/instances/23/knowledge_node_students',
+    'pending_reviews_url': 'https://dummy.com/v42/instances/23/review_utils/fetch_reviews'
+}
+
+class TestAdaptiveLearningConfiguration(unittest.TestCase):
+    """
+    Tests for class that stores configuration for interacting with external services
+    that provide adaptive learning features.
+    """
+
+    def setUp(self):
+        self.attributes = {
+            'foo': None,
+            'bar': 42,
+            'baz': 'This is not a test.',
+        }
+        self.adaptive_learning_configuration = AdaptiveLearningConfiguration(**self.attributes)
+
+    def test_init(self):
+        """
+        Test that constructor correctly sets attributes.
+        """
+        self.assertEqual(self.adaptive_learning_configuration._configuration, self.attributes)
+        for attribute, value in self.attributes.items():
+            self.assertTrue(hasattr(self.adaptive_learning_configuration, attribute))
+            self.assertEqual(getattr(self.adaptive_learning_configuration, attribute), value)
+
+    def test_str(self):
+        """
+        Test string representation of AdaptiveLearningConfiguration object.
+        """
+        self.assertEqual(
+            str(self.adaptive_learning_configuration),
+            str(self.adaptive_learning_configuration._configuration)
+        )
+
+
+class DummyModule(AdaptiveLearningAPIMixin):
+    """
+    Helper class for testing functionality provided by AdaptiveLearningAPIMixin.
+    """
+
+    def __init__(self):
+        self.parent_course = MagicMock()
+        self.parent_course.adaptive_learning_configuration = ADAPTIVE_LEARNING_CONFIGURATION
+
+
+class AdaptiveLearningServiceMixin(object):
+    """
+    Mixin that provides utility methods for mocking an external adaptive learning service.
+    """
+    def _mock_request(self, method, url, status, body):
+        """
+        Register a mock response with HTTP status `status` and response body `body`
+        for a request to `url` that uses `method`.
+        """
+        httpretty.register_uri(method, url, status=status, body=json.dumps(body))
+
+    def _mock_get_request(self, url, body, status=200):
+        """
+        Register a mock response for a GET request.
+        """
+        self._mock_request(httpretty.GET, url, status, body)
+
+    def _mock_post_request(self, url, body, status=200):
+        """
+        Register a mock response for a POST request.
+        """
+        self._mock_request(httpretty.POST, url, status, body)
+
+    def register_students(self, students):
+        """
+        Register a mock response listing students that external service knows about.
+        """
+        self._mock_get_request(URLS['students_url'], students)
+
+    def register_knowledge_node_students(self, knowledge_node_students):
+        """
+        Register a mock response listing students that external service knows about.
+        """
+        self._mock_get_request(URLS['knowledge_node_students_url'], knowledge_node_students)
+
+    def register_pending_reviews(self, pending_reviews):
+        """
+        Register a mock response listing students that external service knows about.
+        """
+        self._mock_get_request(URLS['pending_reviews_url'], pending_reviews)
+
+
+@httpretty.activate
+class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMixin):
+    """
+    Tests for mixin that provides methods for interacting with external adaptive learning service.
+
+    Note that example data only lists properties of corresponding entities (students, events, etc.)
+    that are relevant in the context of individual tests. The external service that provides
+    adaptive learning features may return additional properties for different types of entities.
+    """
+
+    STUDENTS = [
+        {
+            'id': n,
+            'uid': 'student-{n}'.format(n=n)
+        } for n in range(5)
+    ]
+
+    KNOWLEDGE_NODE_STUDENTS = [
+        {
+            'id': n,
+            'knowledge_node_id': n,
+            'knowledge_node_uid': 'knowledge-node-{n}'.format(n=n),
+            'student_id': n,
+            'student_uid': 'student-{n}'.format(n=n)
+        } for n in range(5)
+    ]
+
+    PENDING_REVIEWS = [
+        {
+            'id': n,
+            'student_uid': 'student-{n}'.format(n=n)
+        } for n in range(5)
+    ]
+
+    def setUp(self):
+        self.dummy_module = DummyModule()
+
+    def test_adaptive_learning_configuration(self):
+        """
+        Test `adaptive_learning_configuration` property.
+        """
+        adaptive_learning_configuration = self.dummy_module.adaptive_learning_configuration
+        self.assertIsInstance(adaptive_learning_configuration, AdaptiveLearningConfiguration)
+        for attribute, value in ADAPTIVE_LEARNING_CONFIGURATION.items():
+            self.assertTrue(hasattr(adaptive_learning_configuration, attribute))
+            self.assertEqual(getattr(adaptive_learning_configuration, attribute), value)
+
+    def test_urls(self):
+        """
+        Test that `*_url` properties return appropriate values.
+        """
+        for url_property, expected_value in URLS.items():
+            self.assertTrue(hasattr(self.dummy_module, url_property))
+            self.assertEqual(getattr(self.dummy_module, url_property), expected_value)
+
+    def test_request_headers(self):
+        """
+        Test that `request_headers` property returns appropriate value.
+        """
+        expected_headers = {
+            'Authorization': 'Token token=this-is-not-a-test'
+        }
+        self.assertEqual(self.dummy_module.request_headers, expected_headers)
+
+    def test_get_students(self):
+        """
+        Test that `get_students` method returns list of all users that external service knows about.
+        """
+        self.register_students(self.STUDENTS)
+        students = self.dummy_module.get_students()
+        self.assertEqual(students, self.STUDENTS)
+
+    def test_get_knowledge_node_students(self):
+        """
+        Test that `get_students` method returns list of all users that external service knows about.
+        """
+        self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
+        knowledge_node_students = self.dummy_module.get_knowledge_node_students()
+        self.assertEqual(knowledge_node_students, self.KNOWLEDGE_NODE_STUDENTS)
+
+    def test_get_student(self):
+        """
+        Test that `get_student` method returns appropriate information
+        if external service knows about a given student,
+        and `None` otherwise.
+        """
+        self.register_students(self.STUDENTS)
+
+        # Unknown student
+        student = self.dummy_module.get_student('student-999')
+        self.assertIsNone(student)
+
+        # Known students
+        for expected_student in self.STUDENTS:
+            student = self.dummy_module.get_student(expected_student['uid'])
+            self.assertDictEqual(student, expected_student)
+
+    def test_get_knowledge_node_student(self):
+        """
+        Test that `get_knowledge_node_student` method returns appropriate information
+        if 'knowledge node student' object exists on external service,
+        and `None` otherwise.
+        """
+        self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
+
+        # Unknown 'knowledge node student' object
+        knowledge_node_student = self.dummy_module.get_knowledge_node_student('knowledge-node-999', 'student-999')
+        self.assertIsNone(knowledge_node_student)
+
+        # Known 'knowledge node student' object
+        for expected_knowledge_node_student in self.KNOWLEDGE_NODE_STUDENTS:
+            knowledge_node_student = self.dummy_module.get_knowledge_node_student(
+                expected_knowledge_node_student['knowledge_node_uid'],
+                expected_knowledge_node_student['student_uid']
+            )
+            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
+
+    def test_get_pending_reviews(self):
+        """
+        Test that `get_student` method returns appropriate information
+        if external service knows about a given student,
+        and `None` otherwise.
+        """
+        self.register_pending_reviews(self.PENDING_REVIEWS)
+
+        user_id = 'student-0'
+        expected_pending_reviews = self.PENDING_REVIEWS[:1]
+        response = Mock()
+        response.content = json.dumps(expected_pending_reviews)
+        with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
+            patched_requests.get.return_value = response
+            pending_reviews = self.dummy_module.get_pending_reviews(user_id)
+            self.assertEqual(pending_reviews, expected_pending_reviews)
+            patched_requests.get.assert_called_once_with(
+                self.dummy_module.pending_reviews_url,
+                headers=self.dummy_module.request_headers,
+                data={'student_uid': user_id}
+            )
+
+    def test_create_student(self):
+        """
+        Test that `create_student` method creates student on external service, and returns it.
+        """
+        user_id = 'student-42'
+        expected_student = {
+            'id': 42,
+            'uid': user_id,
+        }
+        response = Mock()
+        response.content = json.dumps(expected_student)
+        with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
+            patched_requests.post.return_value = response
+            student = self.dummy_module.create_student(user_id)
+            self.assertDictEqual(student, expected_student)
+            patched_requests.post.assert_called_once_with(
+                self.dummy_module.students_url,
+                headers=self.dummy_module.request_headers,
+                data={'uid': user_id}
+            )
+
+    def test_create_knowledge_node_student(self):
+        """
+        Test that `create_knowledge_node_student` method creates 'knowledge node student' object
+        on external service, and returns it.
+        """
+        block_id = 'knowledge-node-42'
+        user_id = 'student-42'
+        expected_knowledge_node_student = {
+            'id': 23,
+            'knowledge_node_id': 23,
+            'knowledge_node_uid': block_id,
+            'student_id': 23,
+            'student_uid': user_id,
+        }
+        response = Mock()
+        response.content = json.dumps(expected_knowledge_node_student)
+        with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
+            patched_requests.post.return_value = response
+            knowledge_node_student = self.dummy_module.create_knowledge_node_student(block_id, user_id)
+            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
+            patched_requests.post.assert_called_once_with(
+                self.dummy_module.knowledge_node_students_url,
+                headers=self.dummy_module.request_headers,
+                data={'knowledge_node_uid': block_id, 'student_uid': user_id}
+            )
+
+    def test_create_event(self):
+        """
+        Test that `create_event` method creates event of appropriate type on external service,
+        and returns it.
+        """
+        block_id = 'knowledge-node-42'
+        user_id = 'student-42'
+        event_type = 'DummyEventType'
+        expected_event = {
+            'id': 42,
+            'knowledge_node_student_id': 42,
+            'type': 'DummyEventType',
+            'payload': None,
+        }
+        response = Mock()
+        response.content = json.dumps(expected_event)
+        with patch.object(self.dummy_module, 'get_knowledge_node_student_id') as patched_get_knowledge_node_student_id, \
+             patch('xmodule.util.adaptive_learning.requests') as patched_requests:
+            patched_get_knowledge_node_student_id.return_value = 23
+            patched_requests.post.return_value = response
+            event = self.dummy_module.create_event(block_id, user_id, event_type)
+            self.assertDictEqual(event, expected_event)
+            patched_get_knowledge_node_student_id.assert_called_once_with(block_id, user_id)
+            patched_requests.post.assert_called_once_with(
+                self.dummy_module.events_url,
+                headers=self.dummy_module.request_headers,
+                data={'knowledge_node_student_id': 23, 'event_type': event_type}
+            )
+
+    def test_create_read_event(self):
+        """
+        Test that `create_read_event` method creates an event of type `EventRead` on external service,
+        and returns it.
+        """
+        block_id = 'knowledge-node-42'
+        user_id = 'student-42'
+        expected_event = {
+            'id': 42,
+            'knowledge_node_student_id': 42,
+            'type': 'EventRead',
+            'payload': None,
+        }
+        with patch.object(self.dummy_module, 'create_event') as patched_create_event:
+            patched_create_event.return_value = expected_event
+            event = self.dummy_module.create_read_event(block_id, user_id)
+            self.assertDictEqual(event, expected_event)
+            patched_create_event.assert_called_once_with(block_id, user_id, 'EventRead')
+
+    def test_get_or_create_student(self):
+        """
+        Test that `get_or_create_student` method creates student on external service if it doesn't exist,
+        and returns it.
+        """
+        self.register_students(self.STUDENTS)
+
+        user_id = 'student-42'
+        expected_student = {
+            'id': 42,
+            'uid': user_id,
+        }
+
+        # Student does not exist
+        with patch.object(self.dummy_module, 'get_student') as patched_get_student, \
+             patch.object(self.dummy_module, 'create_student') as patched_create_student:
+            patched_get_student.return_value = None
+            patched_create_student.return_value = expected_student
+            student = self.dummy_module.get_or_create_student(user_id)
+            self.assertDictEqual(student, expected_student)
+            patched_get_student.assert_called_once_with(user_id)
+            patched_create_student.assert_called_once_with(user_id)
+
+        # Student exists
+        with patch.object(self.dummy_module, 'get_student') as patched_get_student, \
+             patch.object(self.dummy_module, 'create_student') as patched_create_student:
+            patched_get_student.return_value = expected_student
+            patched_create_student.return_value = expected_student
+            student = self.dummy_module.get_or_create_student(user_id)
+            self.assertDictEqual(student, expected_student)
+            patched_get_student.assert_called_once_with(user_id)
+            patched_create_student.assert_not_called()
+
+    def test_get_or_create_knowledge_node_student(self):
+        """
+        Test that `get_or_create_knowledge_node_student` method creates 'knowledge node student' object
+        on external service if it doesn't exist, and returns it.
+        """
+        self.register_students(self.STUDENTS)
+        self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
+
+        student = self.STUDENTS[0]
+        block_id = 'knowledge-node-42'
+        user_id = student['uid']
+        expected_knowledge_node_student = {
+            'id': 23,
+            'knowledge_node_id': 23,
+            'knowledge_node_uid': block_id,
+            'student_id': 23,
+            'student_uid': user_id,
+        }
+        # Student does not exist
+        with patch.multiple(
+                self.dummy_module,
+                get_or_create_student=DEFAULT,
+                get_knowledge_node_student=DEFAULT,
+                create_knowledge_node_student=DEFAULT
+        ) as patched_methods:
+            patched_methods['get_or_create_student'].return_value = student
+            patched_methods['get_knowledge_node_student'].return_value = None
+            patched_methods['create_knowledge_node_student'].return_value = expected_knowledge_node_student
+            knowledge_node_student = self.dummy_module.get_or_create_knowledge_node_student(block_id, user_id)
+            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
+            patched_methods['get_or_create_student'].assert_called_once_with(user_id)
+            patched_methods['get_knowledge_node_student'].assert_called_once_with(block_id, user_id)
+            patched_methods['create_knowledge_node_student'].assert_called_once_with(block_id, user_id)
+
+        # Student exists
+        with patch.multiple(
+                self.dummy_module,
+                get_or_create_student=DEFAULT,
+                get_knowledge_node_student=DEFAULT,
+                create_knowledge_node_student=DEFAULT
+        ) as patched_methods:
+            patched_methods['get_or_create_student'].return_value = student
+            patched_methods['get_knowledge_node_student'].return_value = expected_knowledge_node_student
+            patched_methods['create_knowledge_node_student'].return_value = expected_knowledge_node_student
+            student = self.dummy_module.get_or_create_knowledge_node_student(block_id, user_id)
+            self.assertDictEqual(student, expected_knowledge_node_student)
+            patched_methods['get_or_create_student'].assert_called_once_with(user_id)
+            patched_methods['get_knowledge_node_student'].assert_called_once_with(block_id, user_id)
+            patched_methods['create_knowledge_node_student'].assert_not_called()
+
+    def test_get_knowledge_node_student_id(self):
+        """
+        Test the `get_knowledge_node_student_id` returns ID of a given 'knowledge node student' object.
+        """
+        block_id = 'knowledge-node-23'
+        user_id = 'student-23'
+        knowledge_node_student = {
+            'id': 42,
+            'knowledge_node_id': 23,
+            'knowledge_node_uid': block_id,
+            'student_id': 23,
+            'student_uid': user_id
+        }
+        with patch.object(self.dummy_module, 'get_or_create_knowledge_node_student') as patched_get_or_create_knowledge_node_student:
+            patched_get_or_create_knowledge_node_student.return_value = knowledge_node_student
+            knowledge_node_student_id = self.dummy_module.get_knowledge_node_student_id(block_id, user_id)
+            self.assertEqual(knowledge_node_student_id, 42)
+            patched_get_or_create_knowledge_node_student.assert_called_once_with(block_id, user_id)

--- a/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
@@ -19,12 +19,12 @@ ADAPTIVE_LEARNING_CONFIGURATION = {
 }
 
 URLS = {
-    'adaptive_learning_url': 'https://dummy.com/v42',
-    'instance_url': 'https://dummy.com/v42/instances/23',
-    'students_url': 'https://dummy.com/v42/instances/23/students',
-    'events_url': 'https://dummy.com/v42/instances/23/events',
-    'knowledge_node_students_url': 'https://dummy.com/v42/instances/23/knowledge_node_students',
-    'pending_reviews_url': 'https://dummy.com/v42/instances/23/review_utils/fetch_reviews'
+    '_adaptive_learning_url': 'https://dummy.com/v42',
+    '_instance_url': 'https://dummy.com/v42/instances/23',
+    '_students_url': 'https://dummy.com/v42/instances/23/students',
+    '_events_url': 'https://dummy.com/v42/instances/23/events',
+    '_knowledge_node_students_url': 'https://dummy.com/v42/instances/23/knowledge_node_students',
+    '_pending_reviews_url': 'https://dummy.com/v42/instances/23/review_utils/fetch_reviews'
 }
 
 class TestAdaptiveLearningConfiguration(unittest.TestCase):
@@ -99,19 +99,19 @@ class AdaptiveLearningServiceMixin(object):
         """
         Register a mock response listing students that external service knows about.
         """
-        self._mock_get_request(URLS['students_url'], students)
+        self._mock_get_request(URLS['_students_url'], students)
 
     def register_knowledge_node_students(self, knowledge_node_students):
         """
         Register a mock response listing students that external service knows about.
         """
-        self._mock_get_request(URLS['knowledge_node_students_url'], knowledge_node_students)
+        self._mock_get_request(URLS['_knowledge_node_students_url'], knowledge_node_students)
 
     def register_pending_reviews(self, pending_reviews):
         """
         Register a mock response listing students that external service knows about.
         """
-        self._mock_get_request(URLS['pending_reviews_url'], pending_reviews)
+        self._mock_get_request(URLS['_pending_reviews_url'], pending_reviews)
 
 
 @httpretty.activate
@@ -151,11 +151,11 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
     def setUp(self):
         self.dummy_module = DummyModule()
 
-    def test_adaptive_learning_configuration(self):
+    def test__adaptive_learning_configuration(self):
         """
-        Test `adaptive_learning_configuration` property.
+        Test `_adaptive_learning_configuration` property.
         """
-        adaptive_learning_configuration = self.dummy_module.adaptive_learning_configuration
+        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
         self.assertIsInstance(adaptive_learning_configuration, AdaptiveLearningConfiguration)
         for attribute, value in ADAPTIVE_LEARNING_CONFIGURATION.items():
             self.assertTrue(hasattr(adaptive_learning_configuration, attribute))
@@ -169,73 +169,73 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
             self.assertTrue(hasattr(self.dummy_module, url_property))
             self.assertEqual(getattr(self.dummy_module, url_property), expected_value)
 
-    def test_request_headers(self):
+    def test__request_headers(self):
         """
-        Test that `request_headers` property returns appropriate value.
+        Test that `_request_headers` property returns appropriate value.
         """
         expected_headers = {
             'Authorization': 'Token token=this-is-not-a-test'
         }
-        self.assertEqual(self.dummy_module.request_headers, expected_headers)
+        self.assertEqual(self.dummy_module._request_headers, expected_headers)
 
-    def test__make_anonymous_user_id(self):
+    def test_make_anonymous_user_id(self):
         """
-        Test that `_make_anonymous_user_id` returns the same ID when called multiple times.
+        Test that `make_anonymous_user_id` returns the same ID when called multiple times.
         """
         user_id = 23
-        expected_anonymous_user_id = self.dummy_module._make_anonymous_user_id(user_id)
+        expected_anonymous_user_id = self.dummy_module.make_anonymous_user_id(user_id)
         for dummy in range(5):
-            anonymous_user_id = self.dummy_module._make_anonymous_user_id(user_id)
+            anonymous_user_id = self.dummy_module.make_anonymous_user_id(user_id)
             self.assertEqual(anonymous_user_id, expected_anonymous_user_id)
 
-    def test_get_students(self):
+    def test__get_students(self):
         """
-        Test that `get_students` method returns list of all users that external service knows about.
+        Test that `_get_students` method returns list of all users that external service knows about.
         """
         self.register_students(self.STUDENTS)
-        students = self.dummy_module.get_students()
+        students = self.dummy_module._get_students()
         self.assertEqual(students, self.STUDENTS)
 
-    def test_get_knowledge_node_students(self):
+    def test__get_knowledge_node_students(self):
         """
-        Test that `get_students` method returns list of all users that external service knows about.
+        Test that `_get_students` method returns list of all users that external service knows about.
         """
         self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
-        knowledge_node_students = self.dummy_module.get_knowledge_node_students()
+        knowledge_node_students = self.dummy_module._get_knowledge_node_students()
         self.assertEqual(knowledge_node_students, self.KNOWLEDGE_NODE_STUDENTS)
 
-    def test_get_student(self):
+    def test__get_student(self):
         """
-        Test that `get_student` method returns appropriate information
+        Test that `_get_student` method returns appropriate information
         if external service knows about a given student,
         and `None` otherwise.
         """
         self.register_students(self.STUDENTS)
 
         # Unknown student
-        student = self.dummy_module.get_student('student-999')
+        student = self.dummy_module._get_student('student-999')
         self.assertIsNone(student)
 
         # Known students
         for expected_student in self.STUDENTS:
-            student = self.dummy_module.get_student(expected_student['uid'])
+            student = self.dummy_module._get_student(expected_student['uid'])
             self.assertDictEqual(student, expected_student)
 
-    def test_get_knowledge_node_student(self):
+    def test__get_knowledge_node_student(self):
         """
-        Test that `get_knowledge_node_student` method returns appropriate information
+        Test that `_get_knowledge_node_student` method returns appropriate information
         if 'knowledge node student' object exists on external service,
         and `None` otherwise.
         """
         self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
 
         # Unknown 'knowledge node student' object
-        knowledge_node_student = self.dummy_module.get_knowledge_node_student('knowledge-node-999', 'student-999')
+        knowledge_node_student = self.dummy_module._get_knowledge_node_student('knowledge-node-999', 'student-999')
         self.assertIsNone(knowledge_node_student)
 
         # Known 'knowledge node student' object
         for expected_knowledge_node_student in self.KNOWLEDGE_NODE_STUDENTS:
-            knowledge_node_student = self.dummy_module.get_knowledge_node_student(
+            knowledge_node_student = self.dummy_module._get_knowledge_node_student(
                 expected_knowledge_node_student['knowledge_node_uid'],
                 expected_knowledge_node_student['student_uid']
             )
@@ -243,7 +243,7 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
 
     def test_get_pending_reviews(self):
         """
-        Test that `get_student` method returns appropriate information
+        Test that `_get_student` method returns appropriate information
         if external service knows about a given student,
         and `None` otherwise.
         """
@@ -258,14 +258,14 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
             pending_reviews = self.dummy_module.get_pending_reviews(user_id)
             self.assertEqual(pending_reviews, expected_pending_reviews)
             patched_requests.get.assert_called_once_with(
-                self.dummy_module.pending_reviews_url,
-                headers=self.dummy_module.request_headers,
+                self.dummy_module._pending_reviews_url,
+                headers=self.dummy_module._request_headers,
                 data={'student_uid': user_id}
             )
 
-    def test_create_student(self):
+    def test__create_student(self):
         """
-        Test that `create_student` method creates student on external service, and returns it.
+        Test that `_create_student` method creates student on external service, and returns it.
         """
         user_id = 'student-42'
         expected_student = {
@@ -276,17 +276,17 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
         response.content = json.dumps(expected_student)
         with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
             patched_requests.post.return_value = response
-            student = self.dummy_module.create_student(user_id)
+            student = self.dummy_module._create_student(user_id)
             self.assertDictEqual(student, expected_student)
             patched_requests.post.assert_called_once_with(
-                self.dummy_module.students_url,
-                headers=self.dummy_module.request_headers,
+                self.dummy_module._students_url,
+                headers=self.dummy_module._request_headers,
                 data={'uid': user_id}
             )
 
-    def test_create_knowledge_node_student(self):
+    def test__create_knowledge_node_student(self):
         """
-        Test that `create_knowledge_node_student` method creates 'knowledge node student' object
+        Test that `_create_knowledge_node_student` method creates 'knowledge node student' object
         on external service, and returns it.
         """
         block_id = 'knowledge-node-42'
@@ -302,11 +302,11 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
         response.content = json.dumps(expected_knowledge_node_student)
         with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
             patched_requests.post.return_value = response
-            knowledge_node_student = self.dummy_module.create_knowledge_node_student(block_id, user_id)
+            knowledge_node_student = self.dummy_module._create_knowledge_node_student(block_id, user_id)
             self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
             patched_requests.post.assert_called_once_with(
-                self.dummy_module.knowledge_node_students_url,
-                headers=self.dummy_module.request_headers,
+                self.dummy_module._knowledge_node_students_url,
+                headers=self.dummy_module._request_headers,
                 data={'knowledge_node_uid': block_id, 'student_uid': user_id}
             )
 
@@ -318,7 +318,7 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
         block_ids = [knowledge_node_student['id'] for knowledge_node_student in self.KNOWLEDGE_NODE_STUDENTS]
         user_id = 'student-42'
         with patch.object(
-                self.dummy_module, 'get_or_create_knowledge_node_student'
+                self.dummy_module, '_get_or_create_knowledge_node_student'
         ) as patched_get_or_create_knowledge_node_student:
             patched_get_or_create_knowledge_node_student.side_effect = self.KNOWLEDGE_NODE_STUDENTS
             knowledge_node_students = self.dummy_module.create_knowledge_node_students(block_ids, user_id)
@@ -327,9 +327,9 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
                 [call(block_id, user_id) for block_id in block_ids]
             )
 
-    def test_create_event(self):
+    def test__create_event(self):
         """
-        Test that `create_event` method creates event of appropriate type on external service,
+        Test that `_create_event` method creates event of appropriate type on external service,
         and returns it.
         """
         block_id = 'knowledge-node-42'
@@ -343,16 +343,16 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
         }
         response = Mock()
         response.content = json.dumps(expected_event)
-        with patch.object(self.dummy_module, 'get_knowledge_node_student_id') as patched_get_knowledge_node_student_id, \
+        with patch.object(self.dummy_module, '_get_knowledge_node_student_id') as patched__get_knowledge_node_student_id, \
              patch('xmodule.util.adaptive_learning.requests') as patched_requests:
-            patched_get_knowledge_node_student_id.return_value = 23
+            patched__get_knowledge_node_student_id.return_value = 23
             patched_requests.post.return_value = response
-            event = self.dummy_module.create_event(block_id, user_id, event_type)
+            event = self.dummy_module._create_event(block_id, user_id, event_type)
             self.assertDictEqual(event, expected_event)
-            patched_get_knowledge_node_student_id.assert_called_once_with(block_id, user_id)
+            patched__get_knowledge_node_student_id.assert_called_once_with(block_id, user_id)
             patched_requests.post.assert_called_once_with(
-                self.dummy_module.events_url,
-                headers=self.dummy_module.request_headers,
+                self.dummy_module._events_url,
+                headers=self.dummy_module._request_headers,
                 data={'knowledge_node_student_id': 23, 'event_type': event_type}
             )
 
@@ -369,15 +369,15 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
             'type': 'EventRead',
             'payload': None,
         }
-        with patch.object(self.dummy_module, 'create_event') as patched_create_event:
-            patched_create_event.return_value = expected_event
+        with patch.object(self.dummy_module, '_create_event') as patched__create_event:
+            patched__create_event.return_value = expected_event
             event = self.dummy_module.create_read_event(block_id, user_id)
             self.assertDictEqual(event, expected_event)
-            patched_create_event.assert_called_once_with(block_id, user_id, 'EventRead')
+            patched__create_event.assert_called_once_with(block_id, user_id, 'EventRead')
 
-    def test_get_or_create_student(self):
+    def test__get_or_create_student(self):
         """
-        Test that `get_or_create_student` method creates student on external service if it doesn't exist,
+        Test that `_get_or_create_student` method creates student on external service if it doesn't exist,
         and returns it.
         """
         self.register_students(self.STUDENTS)
@@ -389,28 +389,28 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
         }
 
         # Student does not exist
-        with patch.object(self.dummy_module, 'get_student') as patched_get_student, \
-             patch.object(self.dummy_module, 'create_student') as patched_create_student:
-            patched_get_student.return_value = None
-            patched_create_student.return_value = expected_student
-            student = self.dummy_module.get_or_create_student(user_id)
+        with patch.object(self.dummy_module, '_get_student') as patched__get_student, \
+             patch.object(self.dummy_module, '_create_student') as patched__create_student:
+            patched__get_student.return_value = None
+            patched__create_student.return_value = expected_student
+            student = self.dummy_module._get_or_create_student(user_id)
             self.assertDictEqual(student, expected_student)
-            patched_get_student.assert_called_once_with(user_id)
-            patched_create_student.assert_called_once_with(user_id)
+            patched__get_student.assert_called_once_with(user_id)
+            patched__create_student.assert_called_once_with(user_id)
 
         # Student exists
-        with patch.object(self.dummy_module, 'get_student') as patched_get_student, \
-             patch.object(self.dummy_module, 'create_student') as patched_create_student:
-            patched_get_student.return_value = expected_student
-            patched_create_student.return_value = expected_student
-            student = self.dummy_module.get_or_create_student(user_id)
+        with patch.object(self.dummy_module, '_get_student') as patched__get_student, \
+             patch.object(self.dummy_module, '_create_student') as patched__create_student:
+            patched__get_student.return_value = expected_student
+            patched__create_student.return_value = expected_student
+            student = self.dummy_module._get_or_create_student(user_id)
             self.assertDictEqual(student, expected_student)
-            patched_get_student.assert_called_once_with(user_id)
-            patched_create_student.assert_not_called()
+            patched__get_student.assert_called_once_with(user_id)
+            patched__create_student.assert_not_called()
 
     def test_get_or_create_knowledge_node_student(self):
         """
-        Test that `get_or_create_knowledge_node_student` method creates 'knowledge node student' object
+        Test that `_get_or_create_knowledge_node_student` method creates 'knowledge node student' object
         on external service if it doesn't exist, and returns it.
         """
         self.register_students(self.STUDENTS)
@@ -429,38 +429,38 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
         # Student does not exist
         with patch.multiple(
                 self.dummy_module,
-                get_or_create_student=DEFAULT,
-                get_knowledge_node_student=DEFAULT,
-                create_knowledge_node_student=DEFAULT
+                _get_or_create_student=DEFAULT,
+                _get_knowledge_node_student=DEFAULT,
+                _create_knowledge_node_student=DEFAULT
         ) as patched_methods:
-            patched_methods['get_or_create_student'].return_value = student
-            patched_methods['get_knowledge_node_student'].return_value = None
-            patched_methods['create_knowledge_node_student'].return_value = expected_knowledge_node_student
-            knowledge_node_student = self.dummy_module.get_or_create_knowledge_node_student(block_id, user_id)
+            patched_methods['_get_or_create_student'].return_value = student
+            patched_methods['_get_knowledge_node_student'].return_value = None
+            patched_methods['_create_knowledge_node_student'].return_value = expected_knowledge_node_student
+            knowledge_node_student = self.dummy_module._get_or_create_knowledge_node_student(block_id, user_id)
             self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
-            patched_methods['get_or_create_student'].assert_called_once_with(user_id)
-            patched_methods['get_knowledge_node_student'].assert_called_once_with(block_id, user_id)
-            patched_methods['create_knowledge_node_student'].assert_called_once_with(block_id, user_id)
+            patched_methods['_get_or_create_student'].assert_called_once_with(user_id)
+            patched_methods['_get_knowledge_node_student'].assert_called_once_with(block_id, user_id)
+            patched_methods['_create_knowledge_node_student'].assert_called_once_with(block_id, user_id)
 
         # Student exists
         with patch.multiple(
                 self.dummy_module,
-                get_or_create_student=DEFAULT,
-                get_knowledge_node_student=DEFAULT,
-                create_knowledge_node_student=DEFAULT
+                _get_or_create_student=DEFAULT,
+                _get_knowledge_node_student=DEFAULT,
+                _create_knowledge_node_student=DEFAULT
         ) as patched_methods:
-            patched_methods['get_or_create_student'].return_value = student
-            patched_methods['get_knowledge_node_student'].return_value = expected_knowledge_node_student
-            patched_methods['create_knowledge_node_student'].return_value = expected_knowledge_node_student
-            student = self.dummy_module.get_or_create_knowledge_node_student(block_id, user_id)
+            patched_methods['_get_or_create_student'].return_value = student
+            patched_methods['_get_knowledge_node_student'].return_value = expected_knowledge_node_student
+            patched_methods['_create_knowledge_node_student'].return_value = expected_knowledge_node_student
+            student = self.dummy_module._get_or_create_knowledge_node_student(block_id, user_id)
             self.assertDictEqual(student, expected_knowledge_node_student)
-            patched_methods['get_or_create_student'].assert_called_once_with(user_id)
-            patched_methods['get_knowledge_node_student'].assert_called_once_with(block_id, user_id)
-            patched_methods['create_knowledge_node_student'].assert_not_called()
+            patched_methods['_get_or_create_student'].assert_called_once_with(user_id)
+            patched_methods['_get_knowledge_node_student'].assert_called_once_with(block_id, user_id)
+            patched_methods['_create_knowledge_node_student'].assert_not_called()
 
-    def test_get_knowledge_node_student_id(self):
+    def test__get_knowledge_node_student_id(self):
         """
-        Test the `get_knowledge_node_student_id` returns ID of a given 'knowledge node student' object.
+        Test the `_get_knowledge_node_student_id` returns ID of a given 'knowledge node student' object.
         """
         block_id = 'knowledge-node-23'
         user_id = 'student-23'
@@ -471,8 +471,8 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
             'student_id': 23,
             'student_uid': user_id
         }
-        with patch.object(self.dummy_module, 'get_or_create_knowledge_node_student') as patched_get_or_create_knowledge_node_student:
+        with patch.object(self.dummy_module, '_get_or_create_knowledge_node_student') as patched_get_or_create_knowledge_node_student:
             patched_get_or_create_knowledge_node_student.return_value = knowledge_node_student
-            knowledge_node_student_id = self.dummy_module.get_knowledge_node_student_id(block_id, user_id)
+            knowledge_node_student_id = self.dummy_module._get_knowledge_node_student_id(block_id, user_id)
             self.assertEqual(knowledge_node_student_id, 42)
             patched_get_or_create_knowledge_node_student.assert_called_once_with(block_id, user_id)

--- a/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
@@ -6,7 +6,7 @@ import json
 import unittest
 
 import httpretty
-from mock import DEFAULT, MagicMock, Mock, patch
+from mock import DEFAULT, MagicMock, Mock, patch, call
 
 from ..util.adaptive_learning import AdaptiveLearningConfiguration, AdaptiveLearningAPIMixin
 
@@ -308,6 +308,23 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
                 self.dummy_module.knowledge_node_students_url,
                 headers=self.dummy_module.request_headers,
                 data={'knowledge_node_uid': block_id, 'student_uid': user_id}
+            )
+
+    def test_create_knowledge_node_students(self):
+        """
+        Test that `create_knowledge_node_students` method creates 'knowledge node student' objects
+        on external service, and returns them.
+        """
+        block_ids = [knowledge_node_student['id'] for knowledge_node_student in self.KNOWLEDGE_NODE_STUDENTS]
+        user_id = 'student-42'
+        with patch.object(
+                self.dummy_module, 'get_or_create_knowledge_node_student'
+        ) as patched_get_or_create_knowledge_node_student:
+            patched_get_or_create_knowledge_node_student.side_effect = self.KNOWLEDGE_NODE_STUDENTS
+            knowledge_node_students = self.dummy_module.create_knowledge_node_students(block_ids, user_id)
+            self.assertEqual(knowledge_node_students, self.KNOWLEDGE_NODE_STUDENTS)
+            patched_get_or_create_knowledge_node_student.assert_has_calls(
+                [call(block_id, user_id) for block_id in block_ids]
             )
 
     def test_create_event(self):

--- a/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
@@ -66,6 +66,8 @@ class DummyModule(AdaptiveLearningAPIMixin):
     """
 
     def __init__(self):
+        self.course_id = Mock()
+        self.course_id.to_deprecated_string.return_value = 'abc'
         self.parent_course = MagicMock()
         self.parent_course.adaptive_learning_configuration = ADAPTIVE_LEARNING_CONFIGURATION
 
@@ -175,6 +177,16 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
             'Authorization': 'Token token=this-is-not-a-test'
         }
         self.assertEqual(self.dummy_module.request_headers, expected_headers)
+
+    def test__make_anonymous_user_id(self):
+        """
+        Test that `_make_anonymous_user_id` returns the same ID when called multiple times.
+        """
+        user_id = 23
+        expected_anonymous_user_id = self.dummy_module._make_anonymous_user_id(user_id)
+        for dummy in range(5):
+            anonymous_user_id = self.dummy_module._make_anonymous_user_id(user_id)
+            self.assertEqual(anonymous_user_id, expected_anonymous_user_id)
 
     def test_get_students(self):
         """

--- a/common/lib/xmodule/xmodule/util/adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/util/adaptive_learning.py
@@ -226,6 +226,18 @@ class AdaptiveLearningAPIMixin(object):
         knowledge_node_student = json.loads(response.content)
         return knowledge_node_student
 
+    def create_knowledge_node_students(self, block_ids, user_id):
+        """
+        Create 'knowledge node student' objects that link student identified by `user_id`
+        to review questions identified by block IDs listed in `block_ids`, and return them.
+        """
+        knowledge_node_students = []
+        for block_id in block_ids:
+            knowledge_node_student = self.get_or_create_knowledge_node_student(block_id, user_id)
+            knowledge_node_students.append(knowledge_node_student)
+        log.error("KNOWLEDGE_NODE_STUDENTS: {}".format(knowledge_node_students))
+        return knowledge_node_students
+
     def create_read_event(self, block_id, user_id):
         """
         Create read event for unit identified by `block_id` and student identified by `user_id`.

--- a/common/lib/xmodule/xmodule/util/adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/util/adaptive_learning.py
@@ -3,6 +3,7 @@
 Utilities for adaptive learning features.
 """
 
+import hashlib
 import json
 import logging
 import requests
@@ -111,6 +112,20 @@ class AdaptiveLearningAPIMixin(object):
         return {
             'Authorization': 'Token token={access_token}'.format(access_token=access_token)
         }
+
+    def _make_anonymous_user_id(self, user_id):
+        """
+        Return anonymous ID for user identified by `user_id`.
+
+        Incorporate `course_id` and access token for external service into digest.
+        """
+        # Include the access token for this course as a salt
+        hasher = hashlib.md5()
+        hasher.update(self.adaptive_learning_configuration.access_token)
+        hasher.update(unicode(user_id))
+        hasher.update(self.course_id.to_deprecated_string().encode('utf-8'))
+        anonymous_user_id = hasher.hexdigest()
+        return anonymous_user_id
 
     def get_knowledge_node_student_id(self, block_id, user_id):
         """

--- a/common/lib/xmodule/xmodule/util/adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/util/adaptive_learning.py
@@ -40,7 +40,7 @@ class AdaptiveLearningAPIMixin(object):
     """
 
     @lazy
-    def adaptive_learning_configuration(self):
+    def _adaptive_learning_configuration(self):
         """
         Return configuration for accessing external service that provides adaptive learning features.
 
@@ -53,150 +53,136 @@ class AdaptiveLearningAPIMixin(object):
         )
 
     @lazy
-    def adaptive_learning_url(self):
+    def _adaptive_learning_url(self):
         """
         Return base URL for external service that provides adaptive learning features.
 
         The base URL is a combination of the URL (url) and API version (api_version)
         specified in the adaptive learning configuration for the parent course.
         """
-        url = self.adaptive_learning_configuration.url
-        api_version = self.adaptive_learning_configuration.api_version
+        url = self._adaptive_learning_configuration.url
+        api_version = self._adaptive_learning_configuration.api_version
         return '{url}/{api_version}'.format(url=url, api_version=api_version)
 
     @lazy
-    def instance_url(self):
+    def _instance_url(self):
         """
         Return URL for requesting instance-specific data from external service
         that provides adaptive learning features.
         """
-        instance_id = self.adaptive_learning_configuration.instance_id
+        instance_id = self._adaptive_learning_configuration.instance_id
         return '{base_url}/instances/{instance_id}'.format(
-            base_url=self.adaptive_learning_url, instance_id=instance_id
+            base_url=self._adaptive_learning_url, instance_id=instance_id
         )
 
     @lazy
-    def students_url(self):
+    def _students_url(self):
         """
         Return URL for requests dealing with students.
         """
-        return '{base_url}/students'.format(base_url=self.instance_url)
+        return '{base_url}/students'.format(base_url=self._instance_url)
 
     @lazy
-    def events_url(self):
+    def _events_url(self):
         """
         Return URL for requests dealing with events.
         """
-        return '{base_url}/events'.format(base_url=self.instance_url)
+        return '{base_url}/events'.format(base_url=self._instance_url)
 
     @lazy
-    def knowledge_node_students_url(self):
+    def _knowledge_node_students_url(self):
         """
         Return URL for accessing 'knowledge node student' objects.
         """
-        return '{base_url}/knowledge_node_students'.format(base_url=self.instance_url)
+        return '{base_url}/knowledge_node_students'.format(base_url=self._instance_url)
 
     @lazy
-    def pending_reviews_url(self):
+    def _pending_reviews_url(self):
         """
         Return URL for accessing pending reviews.
         """
-        return '{base_url}/review_utils/fetch_reviews'.format(base_url=self.instance_url)
+        return '{base_url}/review_utils/fetch_reviews'.format(base_url=self._instance_url)
 
     @lazy
-    def request_headers(self):
+    def _request_headers(self):
         """
         Return custom headers for requests to external service that provides adaptive learning features.
         """
-        access_token = self.adaptive_learning_configuration.access_token
+        access_token = self._adaptive_learning_configuration.access_token
         return {
             'Authorization': 'Token token={access_token}'.format(access_token=access_token)
         }
 
-    def _make_anonymous_user_id(self, user_id):
-        """
-        Return anonymous ID for user identified by `user_id`.
-
-        Incorporate `course_id` and access token for external service into digest.
-        """
-        # Include the access token for this course as a salt
-        hasher = hashlib.md5()
-        hasher.update(self.adaptive_learning_configuration.access_token)
-        hasher.update(unicode(user_id))
-        hasher.update(self.course_id.to_deprecated_string().encode('utf-8'))
-        anonymous_user_id = hasher.hexdigest()
-        return anonymous_user_id
-
-    def get_knowledge_node_student_id(self, block_id, user_id):
+    def _get_knowledge_node_student_id(self, block_id, user_id):
         """
         Return ID of 'knowledge node student' object linking student identified by `user_id`
         to unit identified by `block_id`.
         """
-        knowledge_node_student = self.get_or_create_knowledge_node_student(block_id, user_id)
+        knowledge_node_student = self._get_or_create_knowledge_node_student(block_id, user_id)
         return knowledge_node_student.get('id')
 
-    def get_or_create_knowledge_node_student(self, block_id, user_id):
+    def _get_or_create_knowledge_node_student(self, block_id, user_id):
         """
         Return 'knowledge node student' object for user identified by `user_id`
         and unit identified by `block_id`.
         """
         # Create student
-        self.get_or_create_student(user_id)
+        self._get_or_create_student(user_id)
         # Link student to unit
-        knowledge_node_student = self.get_knowledge_node_student(block_id, user_id)
+        knowledge_node_student = self._get_knowledge_node_student(block_id, user_id)
         if knowledge_node_student is None:
-            knowledge_node_student = self.create_knowledge_node_student(block_id, user_id)
+            knowledge_node_student = self._create_knowledge_node_student(block_id, user_id)
         return knowledge_node_student
 
-    def get_or_create_student(self, user_id):
+    def _get_or_create_student(self, user_id):
         """
         Create a new student on external service if it doesn't exist,
         and return it.
         """
-        student = self.get_student(user_id)
+        student = self._get_student(user_id)
         if student is None:
-            student = self.create_student(user_id)
+            student = self._create_student(user_id)
         return student
 
-    def get_student(self, user_id):
+    def _get_student(self, user_id):
         """
         Return external information about student identified by `user_id`,
         or None if external service does not know about student.
         """
-        students = self.get_students()
+        students = self._get_students()
         try:
             student = next(s for s in students if s.get('uid') == user_id)
         except StopIteration:
             student = None
         return student
 
-    def get_students(self):
+    def _get_students(self):
         """
         Return list of all students that external service knows about.
         """
-        url = self.students_url
-        response = requests.get(url, headers=self.request_headers)
+        url = self._students_url
+        response = requests.get(url, headers=self._request_headers)
         students = json.loads(response.content)
         return students
 
-    def create_student(self, user_id):
+    def _create_student(self, user_id):
         """
         Create student identified by `user_id` on external service,
         and return it.
         """
-        url = self.students_url
+        url = self._students_url
         payload = {'uid': user_id}
-        response = requests.post(url, headers=self.request_headers, data=payload)
+        response = requests.post(url, headers=self._request_headers, data=payload)
         student = json.loads(response.content)
         return student
 
-    def get_knowledge_node_student(self, block_id, user_id):
+    def _get_knowledge_node_student(self, block_id, user_id):
         """
         Return 'knowledge node student' object for user identified by `user_id`
         and unit identified by `block_id`, or None if it does not exist.
         """
         # Get 'knowledge node student' objects
-        links = self.get_knowledge_node_students()
+        links = self._get_knowledge_node_students()
         # Filter them by `block_id` and `user_id`
         try:
             link = next(
@@ -206,25 +192,62 @@ class AdaptiveLearningAPIMixin(object):
             link = None
         return link
 
-    def get_knowledge_node_students(self):
+    def _get_knowledge_node_students(self):
         """
         Return list of all 'knowledge node student' objects for this course.
         """
-        url = self.knowledge_node_students_url
-        response = requests.get(url, headers=self.request_headers)
+        url = self._knowledge_node_students_url
+        response = requests.get(url, headers=self._request_headers)
         links = json.loads(response.content)
         return links
 
-    def create_knowledge_node_student(self, block_id, user_id):
+    def _create_knowledge_node_student(self, block_id, user_id):
         """
         Create 'knowledge node student' object that links student identified by `user_id`
         to unit identified by `block_id`, and return it.
         """
-        url = self.knowledge_node_students_url
+        url = self._knowledge_node_students_url
         payload = {'knowledge_node_uid': block_id, 'student_uid': user_id}
-        response = requests.post(url, headers=self.request_headers, data=payload)
+        response = requests.post(url, headers=self._request_headers, data=payload)
         knowledge_node_student = json.loads(response.content)
         return knowledge_node_student
+
+    def _create_event(self, block_id, user_id, event_type):
+        """
+        Create event of type `event_type` for unit identified by `block_id` and student identified by `user_id`.
+        """
+        url = self._events_url
+        knowledge_node_student_id = self._get_knowledge_node_student_id(block_id, user_id)
+        payload = {
+            'knowledge_node_student_id': knowledge_node_student_id,
+            'event_type': event_type,
+        }
+        # Send request
+        response = requests.post(url, headers=self._request_headers, data=payload)
+        event = json.loads(response.content)
+        return event
+
+    # Public API
+
+    def make_anonymous_user_id(self, user_id):
+        """
+        Return anonymous ID for user identified by `user_id`.
+
+        Incorporate `course_id` and access token for external service into digest.
+        """
+        # Include the access token for this course as a salt
+        hasher = hashlib.md5()
+        hasher.update(self._adaptive_learning_configuration.access_token)
+        hasher.update(unicode(user_id))
+        hasher.update(self.course_id.to_deprecated_string().encode('utf-8'))
+        anonymous_user_id = hasher.hexdigest()
+        return anonymous_user_id
+
+    def create_read_event(self, block_id, user_id):
+        """
+        Create read event for unit identified by `block_id` and student identified by `user_id`.
+        """
+        return self._create_event(block_id, user_id, 'EventRead')
 
     def create_knowledge_node_students(self, block_ids, user_id):
         """
@@ -233,38 +256,16 @@ class AdaptiveLearningAPIMixin(object):
         """
         knowledge_node_students = []
         for block_id in block_ids:
-            knowledge_node_student = self.get_or_create_knowledge_node_student(block_id, user_id)
+            knowledge_node_student = self._get_or_create_knowledge_node_student(block_id, user_id)
             knowledge_node_students.append(knowledge_node_student)
-        log.error("KNOWLEDGE_NODE_STUDENTS: {}".format(knowledge_node_students))
         return knowledge_node_students
-
-    def create_read_event(self, block_id, user_id):
-        """
-        Create read event for unit identified by `block_id` and student identified by `user_id`.
-        """
-        return self.create_event(block_id, user_id, 'EventRead')
-
-    def create_event(self, block_id, user_id, event_type):
-        """
-        Create event of type `event_type` for unit identified by `block_id` and student identified by `user_id`.
-        """
-        url = self.events_url
-        knowledge_node_student_id = self.get_knowledge_node_student_id(block_id, user_id)
-        payload = {
-            'knowledge_node_student_id': knowledge_node_student_id,
-            'event_type': event_type,
-        }
-        # Send request
-        response = requests.post(url, headers=self.request_headers, data=payload)
-        event = json.loads(response.content)
-        return event
 
     def get_pending_reviews(self, user_id):
         """
         Return pending reviews for user identified by `user_id`.
         """
-        url = self.pending_reviews_url
+        url = self._pending_reviews_url
         payload = {'student_uid': user_id}
-        response = requests.get(url, headers=self.request_headers, data=payload)
+        response = requests.get(url, headers=self._request_headers, data=payload)
         pending_reviews_user = json.loads(response.content)
         return pending_reviews_user

--- a/common/lib/xmodule/xmodule/util/adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/util/adaptive_learning.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for adaptive learning features.
+"""
+
+import json
+import logging
+import requests
+
+from lazy import lazy
+
+log = logging.getLogger(__name__)
+
+
+class AdaptiveLearningConfiguration(object):
+    """
+    Stores configuration that is necessary for interacting with external services
+    that provide adaptive learning features.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Creates an attribute for each key in `kwargs` and sets it to the corresponding value.
+        """
+        self._configuration = kwargs
+        for attr, value in kwargs.items():
+            setattr(self, attr, value)
+
+    def __str__(self):
+        """
+        Returns string listing all custom attributes set on `self`.
+        """
+        return str(self._configuration)
+
+
+class AdaptiveLearningAPIMixin(object):
+    """
+    Provides methods for interacting with external service that provides adaptive learning features.
+    """
+
+    @lazy
+    def adaptive_learning_configuration(self):
+        """
+        Return configuration for accessing external service that provides adaptive learning features.
+
+        This configuration is a course-wide setting, so in order to access it,
+        we need to (lazily) load the parent course from the DB.
+        """
+        course = self.parent_course
+        return AdaptiveLearningConfiguration(
+            **course.adaptive_learning_configuration
+        )
+
+    @lazy
+    def adaptive_learning_url(self):
+        """
+        Return base URL for external service that provides adaptive learning features.
+
+        The base URL is a combination of the URL (url) and API version (api_version)
+        specified in the adaptive learning configuration for the parent course.
+        """
+        url = self.adaptive_learning_configuration.url
+        api_version = self.adaptive_learning_configuration.api_version
+        return '{url}/{api_version}'.format(url=url, api_version=api_version)
+
+    @lazy
+    def instance_url(self):
+        """
+        Return URL for requesting instance-specific data from external service
+        that provides adaptive learning features.
+        """
+        instance_id = self.adaptive_learning_configuration.instance_id
+        return '{base_url}/instances/{instance_id}'.format(
+            base_url=self.adaptive_learning_url, instance_id=instance_id
+        )
+
+    @lazy
+    def students_url(self):
+        """
+        Return URL for requests dealing with students.
+        """
+        return '{base_url}/students'.format(base_url=self.instance_url)
+
+    @lazy
+    def event_url(self):
+        """
+        Return URL for requests dealing with events.
+        """
+        return '{base_url}/events'.format(base_url=self.instance_url)
+
+    @lazy
+    def knowledge_node_students_url(self):
+        """
+        Return URL for accessing 'knowledge node student' objects.
+        """
+        return '{base_url}/knowledge_node_students'.format(base_url=self.instance_url)
+
+    @lazy
+    def pending_reviews_url(self):
+        """
+        Return URL for accessing pending reviews.
+        """
+        return '{base_url}/review_utils/fetch_reviews'.format(base_url=self.instance_url)
+
+    @lazy
+    def request_headers(self):
+        """
+        Return custom headers for requests to external service that provides adaptive learning features.
+        """
+        access_token = self.adaptive_learning_configuration.access_token
+        return {
+            'Authorization': 'Token token={access_token}'.format(access_token=access_token)
+        }
+
+    def get_knowledge_node_student_id(self, block_id, user_id):
+        """
+        Return ID of 'knowledge node student' object linking student identified by `user_id`
+        to unit identified by `block_id`.
+        """
+        knowledge_node_student = self.get_or_create_knowledge_node_student(block_id, user_id)
+        return knowledge_node_student.get('id')
+
+    def get_or_create_knowledge_node_student(self, block_id, user_id):
+        """
+        Return 'knowledge node student' object for user identified by `user_id`
+        and unit identified by `block_id`.
+        """
+        # Create student
+        self.get_or_create_student(user_id)
+        # Link student to unit
+        knowledge_node_student = self.get_knowledge_node_student(block_id, user_id)
+        if knowledge_node_student is None:
+            knowledge_node_student = self.create_knowledge_node_student(block_id, user_id)
+        return knowledge_node_student
+
+    def get_or_create_student(self, user_id):
+        """
+        Create a new student on external service if it doesn't exist,
+        and return it.
+        """
+        student = self.get_student(user_id)
+        if student is None:
+            student = self.create_student(user_id)
+        return student
+
+    def get_student(self, user_id):
+        """
+        Return external information about student identified by `user_id`,
+        or None if external service does not know about student.
+        """
+        students = self.get_students()
+        try:
+            student = next(s for s in students if s.get('uid') == user_id)
+        except StopIteration:
+            student = None
+        return student
+
+    def get_students(self):
+        """
+        Return list of all students that external service knows about.
+        """
+        url = self.students_url
+        response = requests.get(url, headers=self.request_headers)
+        students = json.loads(response.content)
+        return students
+
+    def create_student(self, user_id):
+        """
+        Create student identified by `user_id` on external service,
+        and return it.
+        """
+        url = self.students_url
+        payload = {'uid': user_id}
+        response = requests.post(url, headers=self.request_headers, data=payload)
+        student = json.loads(response.content)
+        return student
+
+    def get_knowledge_node_student(self, block_id, user_id):
+        """
+        Return 'knowledge node student' object for user identified by `user_id`
+        and unit identified by `block_id`, or None if it does not exist.
+        """
+        # Get 'knowledge node student' objects
+        links = self.get_knowledge_node_students()
+        # Filter them by `block_id` and `user_id`
+        try:
+            link = next(
+                l for l in links if l.get('knowledge_node_uid') == block_id and l.get('student_uid') == user_id
+            )
+        except StopIteration:
+            link = None
+        return link
+
+    def get_knowledge_node_students(self):
+        """
+        Return list of all 'knowledge node student' objects for this course.
+        """
+        url = self.knowledge_node_students_url
+        response = requests.get(url, headers=self.request_headers)
+        links = json.loads(response.content)
+        return links
+
+    def create_knowledge_node_student(self, block_id, user_id):
+        """
+        Create 'knowledge node student' object that links student identified by `user_id`
+        to unit identified by `block_id`, and return it.
+        """
+        url = self.knowledge_node_students_url
+        payload = {'knowledge_node_uid': block_id, 'student_uid': user_id}
+        response = requests.post(url, headers=self.request_headers, data=payload)
+        knowledge_node_student = json.loads(response.content)
+        return knowledge_node_student
+
+    def create_read_event(self, block_id, user_id):
+        """
+        Create read event for unit identified by `block_id` and student identified by `user_id`.
+        """
+        self.create_event(block_id, user_id, 'EventRead')
+
+    def create_event(self, block_id, user_id, event_type):
+        """
+        Create event of type `event_type` for unit identified by `block_id` and student identified by `user_id`.
+        """
+        url = self.event_url
+        knowledge_node_student_id = self.get_knowledge_node_student_id(block_id, user_id)
+        payload = {
+            'knowledge_node_student_id': knowledge_node_student_id,
+            'event_type': event_type,
+        }
+        # Send request
+        response = requests.post(url, headers=self.request_headers, data=payload)
+        event = json.loads(response.content)
+        return event
+
+    def get_pending_reviews(self, user_id):
+        """
+        Return pending reviews for user identified by `user_id`.
+        """
+        url = self.pending_reviews_url
+        payload = {'student_uid': user_id}
+        response = requests.get(url, headers=self.request_headers, data=payload)
+        pending_reviews_user = json.loads(response.content)
+        return pending_reviews_user

--- a/common/lib/xmodule/xmodule/util/adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/util/adaptive_learning.py
@@ -82,7 +82,7 @@ class AdaptiveLearningAPIMixin(object):
         return '{base_url}/students'.format(base_url=self.instance_url)
 
     @lazy
-    def event_url(self):
+    def events_url(self):
         """
         Return URL for requests dealing with events.
         """
@@ -215,13 +215,13 @@ class AdaptiveLearningAPIMixin(object):
         """
         Create read event for unit identified by `block_id` and student identified by `user_id`.
         """
-        self.create_event(block_id, user_id, 'EventRead')
+        return self.create_event(block_id, user_id, 'EventRead')
 
     def create_event(self, block_id, user_id, event_type):
         """
         Create event of type `event_type` for unit identified by `block_id` and student identified by `user_id`.
         """
-        url = self.event_url
+        url = self.events_url
         knowledge_node_student_id = self.get_knowledge_node_student_id(block_id, user_id)
         payload = {
             'knowledge_node_student_id': knowledge_node_student_id,

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -115,6 +115,12 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
             ]
         }]
 
+    def _assert_default_selection(self, *verticals_selected):
+        """
+        Assert that at least one of the blocks in `verticals` is selected.
+        """
+        self.assertTrue(any(vertical_selected for vertical_selected in verticals_selected))
+
     def test_content_library(self):
         """
         Test when course has content library section.
@@ -146,7 +152,7 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
 
         vertical2_selected = self.get_block_key_set(self.blocks, 'vertical2').pop() in trans_keys
         vertical3_selected = self.get_block_key_set(self.blocks, 'vertical3').pop() in trans_keys
-        self.assertTrue(vertical2_selected or vertical3_selected)
+        self._assert_default_selection(vertical2_selected, vertical3_selected)
 
         # Check course structure again, with mocked selected modules for a user.
         with mock.patch(
@@ -182,3 +188,9 @@ class AdaptiveContentLibraryTransformerTestCase(ContentLibraryTransformerTestCas
     """
     TRANSFORMER_CLASS = AdaptiveContentLibraryTransformer
     CATEGORY = 'adaptive_library_content'
+
+    def _assert_default_selection(self, *verticals_selected):
+        """
+        Assert that none of the blocks in `verticals_selected` are selected.
+        """
+        self.assertTrue(not any(vertical_selected for vertical_selected in verticals_selected))


### PR DESCRIPTION
This PR extends the new Adaptive Content Block in two ways:

* It adds logic for notifying Domoscio that the parent unit of an ACB has been accessed by a learner.
* It changes the way child blocks are selected for display: Instead of selecting `max_count` children randomly, ACBs now query Domoscio for information about pending reviews to determine which children to show (if any).

The PR also adds a new course-wide setting called "Adaptive Learning Configuration" which can be used to specify necessary information for communicating with the Domoscio API.

cf. [OC-2150](https://tasks.opencraft.com/browse/OC-2150), [OC-2151](https://tasks.opencraft.com/browse/OC-2151)

**Implementation**

When sending a "Unit viewed" event, ACB assumes that the corresponding unit exists in Domoscio's database (in the form of a "knowledge node" whose `uid` is set to the `block_id` of the unit). This is a safe assumption to make because Domoscio staff will take care of creating entities representing relevant elements of the course structure (including units and review questions) prior to the start date of the course that will be using the new adaptive learning features.

In addition to knowledge nodes representing units, there are other entities that must exist in the Domoscio database to be able to send an event of the type that Domoscio expects: Events target objects that link students to specific knowledge nodes. This means that prior to sending a "Unit viewed" event, the Domoscio database must contain both a "student" entity corresponding to the learner viewing the unit in the LMS, and an object that links the student to the unit (knowledge node). In Domoscio terminology, an object linking a student to a knowledge node is called "knowledge node student". (The plural is "knowledge node students".) Since we can't assume that students and objects that link them to units will be created by Domoscio staff prior to the start date of the course, ACBs will create student and "knowledge node student" objects via the Domoscio API prior to sending "Unit viewed" events (if necessary).

As of this PR, ACBs will also create "knowledge node student" objects that link students to review questions when a learner accesses a unit containing an ACB. This is not a prerequisite for sending "Unit viewed" events (or for obtaining a list of review questions to display from Domoscio). However, when a learner submits an answer to a review question, we will need to notify Domoscio about the result (OC-2152). At that point, links between students and review questions need to exist so we can target them with appropriate `EventResult` events.

**Test instructions**

1. Follow instructions on the [epic](https://tasks.opencraft.com/browse/OC-2127) to set up a FUN box.

2. Switch to this branch (`adaptive-content-block`) and install the new block via

    ```sh
    pip install -r requirements/edx/local.txt
    ```

3. Create a new content library and add a few problems to it.

4. Create a new course and add `"adaptive_library_content"` to advanced modules.

5. Add an "Adaptive Content Block" that references the library created previously to a unit (optionally modifying the number of components to display to each student), and publish the unit. Do **not** access the unit in the LMS yet.

6. To be able to work with the Domoscio API, you'll need to specify a few course-level settings: In Studio, navigate to the Advanced Settings page for the course ("Paramètres" > "Paramètres avancés") and replace the default value for the "Adaptive Learning Configuration" setting with the following:

    ```json
    "url": "<see comment on internal ticket>",
    "instance_id": <see comment on internal ticket>,
    "access_token": "<see comment on internal ticket>",
    "api_version": "v1"
    ```

7. In a venv that has the `requests` library installed, create a knowledge node that corresponds to the unit you created earlier (`block_id` needs to be a 32-character hash), and review the results:

    ```python
    import requests, json
    response = requests.post("<url>/v1/instances/<instance_id>/knowledge_nodes", headers={"Authorization": "Token token=<access_token>"}, data={"knowledge_graph_id": <see comment on internal ticket>, "name": "Unit node", "uid": "<block_id of unit>"})
    json.loads(response.content)
    ```

    Then create a knowledge node for each of the problems that belong to the library you created earlier. Note that problems belonging to a content library are assigned unique block IDs for each Adaptive Content Block that references them; you'll need to use these context-specific IDs when creating corresponding knowledge nodes. Block IDs for problems are 20-character hashes.

8. Review the list of students that exist on the Domoscio test instance:

   ```python
   response = requests.get("<url>/v1/instances/<instance_id>/students", headers={"Authorization": "Token token=<access_token>"})
   json.loads(response.content)
   ```

9. Review the list of links between students and units ("knowledge node student" objects) on the Domoscio test instance:

    ```python
    response = requests.get("<url>/v1/instances/<instance_id>/knowledge_node_students", headers={"Authorization": "Token token=<access_token>"})
    json.loads(response.content)    
    ```

10. Access the unit that contains the ACB in the LMS. Observe that it does not display any child blocks.

11. Review the list of students and the list of "knowledge node student" objects as described above. Observe that the former contains a new student and the latter contains new "knowledge node student" objects, one for each knowledge node you created earlier. The `knowledge_node_id`/`knowledge_node_uid` and `student_id`/`student_uid` fields of the new "knowledge node student" objects should reference the knowledge nodes created earlier, and the student that was created when you accessed the unit for the first time.

12. Review the list of events that have been recorded for the Domoscio test instance, making sure that it contains an entry that references the "knowledge node student" object linking the unit you created earlier to the student that you used to access the unit in the LMS:

    ```python
    response = requests.get("<url>/v1/instances/<instance_id>/events", headers={"Authorization": "Token token=<access_token>"})
    json.loads(response.content)
    ```

**Reviewers**

- [ ] @e-kolpakov / @pomegranited

**Notes**

<!--
- This PR implements one possible approach for fetching pending reviews from the Domoscio API. Depending on how the course structure will be represented in the Domoscio database (details still pending), we might need to adjust the approach in a follow-up PR.
-->
- There is no way to force Domoscio to schedule a review, so it's not possible to manually test the logic for selectively displaying review questions (except the case where no pending reviews are available).