### PR TITLE
Adaptive Content Block: Send results to external service when learner submits review question

### DIFF
--- a/common/djangoapps/track/backends/adaptive_learning.py
+++ b/common/djangoapps/track/backends/adaptive_learning.py
@@ -2,7 +2,9 @@
 
 from __future__ import absolute_import
 
+from functools import reduce
 import logging
+import operator
 
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
@@ -29,21 +31,11 @@ class AdaptiveLearningBackend(BaseBackend):
 
     @staticmethod
     def _get_from_event(event, path, default=None):
-        """
-        Extract value of `path` from `event` dictionary and return it.
-
-        If `path` does not exist in `event`, return `default` value instead.
-        """
         path_components = path.split('.')
-        current_value = event
-        for path_component in path_components:
-            try:
-                current_value = current_value.get(path_component, default)
-            except AttributeError:
-                # Requested `path` exceeds depth of `event`:
-                # `current_value` is a leaf (not a dictionary)
-                return default
-        return current_value
+        try:
+            return reduce(operator.getitem, path_components, event)
+        except (KeyError, TypeError):
+            return default
 
     def is_problem_check(self, event):
         """

--- a/common/djangoapps/track/backends/adaptive_learning.py
+++ b/common/djangoapps/track/backends/adaptive_learning.py
@@ -1,0 +1,83 @@
+""" Event tracker backend that sends relevant data to adaptive learning service. """
+
+from __future__ import absolute_import
+
+import logging
+
+from opaque_keys.edx.keys import CourseKey, UsageKey
+
+from track.backends import BaseBackend
+from xmodule.library_content_module import AdaptiveLibraryContentModule
+from xmodule.modulestore.django import modulestore
+
+
+log = logging.getLogger(__name__)
+
+
+def _is_problem_check(event):
+    """
+    Return True if `event` is of type `problem_check`, else False.
+    """
+    event_type = event.get('event_type')
+    return event_type == 'problem_check'
+
+
+def _get_course(event):
+    """
+    Retrieve course corresponding to course ID mentioned in `event` from DB
+    and return it.
+    """
+    context = event.get('context')
+    course_id = context.get('course_id')
+    course_key = CourseKey.from_string(course_id)
+    course = modulestore().get_course(course_key)
+    return course
+
+
+def _get_block_id(event):
+    """
+    Return ID of block that `event` belongs to.
+    """
+    context = event.get('context')
+    module = context.get('module')
+    usage_key_string = module.get('usage_key')
+    usage_key = UsageKey.from_string(usage_key_string)
+    block_id = usage_key.block_id
+    return block_id
+
+
+def _get_user_id(event):
+    """
+    Return ID of user that triggered `event`.
+    """
+    context = event.get('context')
+    user_id = context.get('user_id')
+    return user_id
+
+
+def _get_success(event):
+    """
+    Return success information from `event`.
+    """
+    event = event.get('event')
+    success = event.get('success')
+    return success
+
+
+class AdaptiveLearningBackend(BaseBackend):
+    """
+    Event tracker backend for notifying external service that provides adaptive learning features
+    about relevant events.
+    """
+
+    def send(self, event):
+        """
+        Instruct AdaptiveLibraryContentModule to send result event
+        to external service that provides adaptive learning features.
+        """
+        if _is_problem_check(event):
+            course = _get_course(event)
+            block_id = _get_block_id(event)
+            user_id = _get_user_id(event)
+            success = _get_success(event)
+            AdaptiveLibraryContentModule.create_result_event(course, block_id, user_id, success)

--- a/common/djangoapps/track/backends/adaptive_learning.py
+++ b/common/djangoapps/track/backends/adaptive_learning.py
@@ -14,70 +14,85 @@ from xmodule.modulestore.django import modulestore
 log = logging.getLogger(__name__)
 
 
-def _is_problem_check(event):
-    """
-    Return True if `event` is of type `problem_check`, else False.
-    """
-    event_type = event.get('event_type')
-    return event_type == 'problem_check'
-
-
-def _get_course(event):
-    """
-    Retrieve course corresponding to course ID mentioned in `event` from DB
-    and return it.
-    """
-    context = event.get('context')
-    course_id = context.get('course_id')
-    course_key = CourseKey.from_string(course_id)
-    course = modulestore().get_course(course_key)
-    return course
-
-
-def _get_block_id(event):
-    """
-    Return ID of block that `event` belongs to.
-    """
-    context = event.get('context')
-    module = context.get('module')
-    usage_key_string = module.get('usage_key')
-    usage_key = UsageKey.from_string(usage_key_string)
-    block_id = usage_key.block_id
-    return block_id
-
-
-def _get_user_id(event):
-    """
-    Return ID of user that triggered `event`.
-    """
-    context = event.get('context')
-    user_id = context.get('user_id')
-    return user_id
-
-
-def _get_success(event):
-    """
-    Return success information from `event`.
-    """
-    event = event.get('event')
-    success = event.get('success')
-    return success
-
-
 class AdaptiveLearningBackend(BaseBackend):
     """
     Event tracker backend for notifying external service that provides adaptive learning features
     about relevant events.
     """
 
+    def __init__(self, store=None, **options):
+        """
+        Make modulestore available to this backend.
+        """
+        super(AdaptiveLearningBackend, self).__init__(**options)
+        self.modulestore = store or modulestore
+
+    @staticmethod
+    def _get_from_event(event, path, default=None):
+        """
+        Extract value of `path` from `event` dictionary and return it.
+
+        If `path` does not exist in `event`, return `default` value instead.
+        """
+        path_components = path.split('.')
+        current_value = event
+        for path_component in path_components:
+            try:
+                current_value = current_value.get(path_component, default)
+            except AttributeError:
+                # Requested `path` exceeds depth of `event`:
+                # `current_value` is a leaf (not a dictionary)
+                return default
+        return current_value
+
+    def is_problem_check(self, event):
+        """
+        Return True if `event` is of type `problem_check`, else False.
+        """
+        return self._get_from_event(event, 'event_type') == 'problem_check'
+
+    def get_course(self, event):
+        """
+        Retrieve course corresponding to course ID mentioned in `event` from DB
+        and return it.
+        """
+        course_id = self._get_from_event(event, 'context.course_id')
+        course_key = CourseKey.from_string(course_id)
+        return self.modulestore().get_course(course_key)
+
+    def get_block_id(self, event):
+        """
+        Return ID of block that `event` belongs to.
+        """
+        usage_key_string = self._get_from_event(event, 'context.module.usage_key')
+        usage_key = UsageKey.from_string(usage_key_string)
+        return usage_key.block_id
+
+    def get_user_id(self, event):
+        """
+        Return ID of user that triggered `event`.
+        """
+        return self._get_from_event(event, 'context.user_id')
+
+    def get_success(self, event):
+        """
+        Extract success information from `event`, convert it to format that adaptive learning service expects,
+        and return it.
+        """
+        success = self._get_from_event(event, 'event.success')
+        if success == 'correct':
+            return '100'
+        elif success == 'incorrect':
+            return '0'
+
     def send(self, event):
         """
         Instruct AdaptiveLibraryContentModule to send result event
         to external service that provides adaptive learning features.
         """
-        if _is_problem_check(event):
-            course = _get_course(event)
-            block_id = _get_block_id(event)
-            user_id = _get_user_id(event)
-            success = _get_success(event)
-            AdaptiveLibraryContentModule.create_result_event(course, block_id, user_id, success)
+        if self.is_problem_check(event):
+            course = self.get_course(event)
+            block_id = self.get_block_id(event)
+            user_id = self.get_user_id(event)
+            success = self.get_success(event)
+            AdaptiveLibraryContentModule.send_result_event(course, block_id, user_id, success)

--- a/common/djangoapps/track/backends/tests/test_adaptive_learning.py
+++ b/common/djangoapps/track/backends/tests/test_adaptive_learning.py
@@ -1,39 +1,52 @@
+"""
+Tests for `AdaptiveLearningBackend`.
+"""
 from __future__ import absolute_import
 
 import ddt
 from django.test import TestCase
 from mock import Mock, patch
 
-from track.backends.adaptive_learning import (
-    _is_problem_check, _get_course, _get_block_id, _get_user_id, _get_success, AdaptiveLearningBackend
-)
+from track.backends.adaptive_learning import AdaptiveLearningBackend
 
 
 @ddt.ddt
 class TestAdaptiveLearningBackend(TestCase):
     """
-    Tests for AdaptiveLearningBackend and helper functions.
+    Tests for AdaptiveLearningBackend.
     """
 
     def setUp(self):
         super(TestAdaptiveLearningBackend, self).setUp()
-        self.backend = AdaptiveLearningBackend()
+        self.mock_modulestore_object = Mock()
+        self.mock_course_object = Mock()
+        self.mock_modulestore_object.get_course.return_value = self.mock_course_object
+        self.mock_modulestore = Mock(return_value=self.mock_modulestore_object)
+        self.backend = AdaptiveLearningBackend(self.mock_modulestore)
+
+    def _make_mock_usage_key(self, block_id):
+        """
+        Return mock UsageKey whose `block_id` is set to `block_id`.
+        """
+        mock_usage_key = Mock()
+        mock_usage_key.block_id = block_id
+        return mock_usage_key
 
     @ddt.data(
         ('problem_check', True),
         ('other', False)
     )
     @ddt.unpack
-    def test__is_problem_check(self, event_type, expected_result):
+    def test_is_problem_check(self, event_type, expected_result):
         """
         Test that `_is_problem_check` function returns True if event is of type "problem_check",
         and False otherwise.
         """
         event = {'event_type': event_type}
-        result = _is_problem_check(event)
+        result = self.backend.is_problem_check(event)
         self.assertEqual(result, expected_result)
 
-    def test__get_course(self):
+    def test_get_course(self):
         """
         Test that `_get_course` function extracts appropriate value from event and returns it.
         """
@@ -43,21 +56,16 @@ class TestAdaptiveLearningBackend(TestCase):
                 'course_id': course_id
             }
         }
-        with patch('track.backends.adaptive_learning.CourseKey') as patched_class, \
-             patch('track.backends.adaptive_learning.modulestore') as patched_modulestore:
+        with patch('track.backends.adaptive_learning.CourseKey') as patched_class:
             mock_course_key = Mock()
             patched_class.from_string.return_value = mock_course_key
-            mock_modulestore = Mock()
-            mock_course = Mock()
-            mock_modulestore.get_course.return_value = mock_course
-            patched_modulestore.return_value = mock_modulestore
-            course = _get_course(event)
-            self.assertEqual(course, mock_course)
+            course = self.backend.get_course(event)
+            self.assertEqual(course, self.mock_course_object)
             patched_class.from_string.assert_called_once_with(course_id)
-            patched_modulestore.assert_called_once_with()
-            mock_modulestore.get_course.assert_called_once_with(mock_course_key)
+            self.mock_modulestore.assert_called_once_with()
+            self.mock_modulestore_object.get_course.assert_called_once_with(mock_course_key)
 
-    def test__get_block_id(self):
+    def test_get_block_id(self):
         """
         Test that `_get_block_id` function extracts appropriate value from event and returns it.
         """
@@ -71,14 +79,12 @@ class TestAdaptiveLearningBackend(TestCase):
         }
         with patch('track.backends.adaptive_learning.UsageKey') as patched_class:
             expected_block_id = '8e52e13fc4g696gb8g33'
-            mock_usage_key = Mock()
-            mock_usage_key.block_id = expected_block_id
-            patched_class.from_string.return_value = mock_usage_key
-            block_id = _get_block_id(event)
+            patched_class.from_string.return_value = self._make_mock_usage_key(expected_block_id)
+            block_id = self.backend.get_block_id(event)
             self.assertEqual(block_id, expected_block_id)
             patched_class.from_string.assert_called_once_with(usage_key_string)
 
-    def test__get_user_id(self):
+    def test_get_user_id(self):
         """
         Test that `_get_user_id` function extracts appropriate value from event and returns it.
         """
@@ -87,20 +93,21 @@ class TestAdaptiveLearningBackend(TestCase):
                 'user_id': 23
             }
         }
-        user_id = _get_user_id(event)
+        user_id = self.backend.get_user_id(event)
         self.assertEqual(user_id, 23)
 
-    @ddt.data('correct', 'incorrect')
-    def test__get_success(self, expected_success):
+    @ddt.data(('correct', '100'), ('incorrect', '0'))
+    @ddt.unpack
+    def test_get_success(self, success, expected_success):
         """
         Test that `_get_success` function extracts appropriate value from event and returns it.
         """
         event = {
             'event': {
-                'success': expected_success
+                'success': success
             }
         }
-        success = _get_success(event)
+        success = self.backend.get_success(event)
         self.assertEqual(success, expected_success)
 
     @ddt.data(True, False)
@@ -125,30 +132,30 @@ class TestAdaptiveLearningBackend(TestCase):
                 'success': success
             }
         }
-        with patch('track.backends.adaptive_learning._is_problem_check') as patched__is_problem_check, \
-             patch('track.backends.adaptive_learning._get_course') as patched__get_course, \
-             patch('track.backends.adaptive_learning._get_block_id') as patched__get_block_id, \
-             patch('track.backends.adaptive_learning._get_user_id') as patched__get_user_id, \
-             patch('track.backends.adaptive_learning._get_success') as patched__get_success, \
-             patch('track.backends.adaptive_learning.AdaptiveLibraryContentModule') as patched_class:
-            patched__is_problem_check.return_value = is_problem_check
+        with patch.object(self.backend, 'is_problem_check') as patched_is_problem_check, \
+                patch.object(self.backend, 'get_course') as patched_get_course, \
+                patch.object(self.backend, 'get_block_id') as patched_get_block_id, \
+                patch.object(self.backend, 'get_user_id') as patched_get_user_id, \
+                patch.object(self.backend, 'get_success') as patched_get_success, \
+                patch('track.backends.adaptive_learning.AdaptiveLibraryContentModule') as patched_class:
+            patched_is_problem_check.return_value = is_problem_check
             course_mock = Mock()
-            patched__get_course.return_value = course_mock
-            patched__get_block_id.return_value = block_id
-            patched__get_user_id.return_value = user_id
-            patched__get_success.return_value = success
-            mock_create_result_event = Mock()
-            patched_class.create_result_event = mock_create_result_event
+            patched_get_course.return_value = course_mock
+            patched_get_block_id.return_value = block_id
+            patched_get_user_id.return_value = user_id
+            patched_get_success.return_value = success
+            mock_send_result_event = Mock()
+            patched_class.send_result_event = mock_send_result_event
             self.backend.send(event)
             if is_problem_check:
-                patched__get_course.assert_called_once_with(event)
-                patched__get_block_id.assert_called_once_with(event)
-                patched__get_user_id.assert_called_once_with(event)
-                patched__get_success.assert_called_once_with(event)
-                mock_create_result_event.assert_called_once_with(course_mock, block_id, user_id, success)
+                patched_get_course.assert_called_once_with(event)
+                patched_get_block_id.assert_called_once_with(event)
+                patched_get_user_id.assert_called_once_with(event)
+                patched_get_success.assert_called_once_with(event)
+                mock_send_result_event.assert_called_once_with(course_mock, block_id, user_id, success)
             else:
-                patched__get_course.assert_not_called()
-                patched__get_block_id.assert_not_called()
-                patched__get_user_id.assert_not_called()
-                patched__get_success.assert_not_called()
-                mock_create_result_event.assert_not_called()
+                patched_get_course.assert_not_called()
+                patched_get_block_id.assert_not_called()
+                patched_get_user_id.assert_not_called()
+                patched_get_success.assert_not_called()
+                mock_send_result_event.assert_not_called()

--- a/common/djangoapps/track/backends/tests/test_adaptive_learning.py
+++ b/common/djangoapps/track/backends/tests/test_adaptive_learning.py
@@ -1,0 +1,154 @@
+from __future__ import absolute_import
+
+import ddt
+from django.test import TestCase
+from mock import Mock, patch
+
+from track.backends.adaptive_learning import (
+    _is_problem_check, _get_course, _get_block_id, _get_user_id, _get_success, AdaptiveLearningBackend
+)
+
+
+@ddt.ddt
+class TestAdaptiveLearningBackend(TestCase):
+    """
+    Tests for AdaptiveLearningBackend and helper functions.
+    """
+
+    def setUp(self):
+        super(TestAdaptiveLearningBackend, self).setUp()
+        self.backend = AdaptiveLearningBackend()
+
+    @ddt.data(
+        ('problem_check', True),
+        ('other', False)
+    )
+    @ddt.unpack
+    def test__is_problem_check(self, event_type, expected_result):
+        """
+        Test that `_is_problem_check` function returns True if event is of type "problem_check",
+        and False otherwise.
+        """
+        event = {'event_type': event_type}
+        result = _is_problem_check(event)
+        self.assertEqual(result, expected_result)
+
+    def test__get_course(self):
+        """
+        Test that `_get_course` function extracts appropriate value from event and returns it.
+        """
+        course_id = 'block-v1:org+course+run+type@course+block@course'
+        event = {
+            'context': {
+                'course_id': course_id
+            }
+        }
+        with patch('track.backends.adaptive_learning.CourseKey') as patched_class, \
+             patch('track.backends.adaptive_learning.modulestore') as patched_modulestore:
+            mock_course_key = Mock()
+            patched_class.from_string.return_value = mock_course_key
+            mock_modulestore = Mock()
+            mock_course = Mock()
+            mock_modulestore.get_course.return_value = mock_course
+            patched_modulestore.return_value = mock_modulestore
+            course = _get_course(event)
+            self.assertEqual(course, mock_course)
+            patched_class.from_string.assert_called_once_with(course_id)
+            patched_modulestore.assert_called_once_with()
+            mock_modulestore.get_course.assert_called_once_with(mock_course_key)
+
+    def test__get_block_id(self):
+        """
+        Test that `_get_block_id` function extracts appropriate value from event and returns it.
+        """
+        usage_key_string = 'block-v1:org+course+run+type@problem+block@8e52e13fc4g696gb8g33'
+        event = {
+            'context': {
+                'module': {
+                    'usage_key': usage_key_string
+                }
+            }
+        }
+        with patch('track.backends.adaptive_learning.UsageKey') as patched_class:
+            expected_block_id = '8e52e13fc4g696gb8g33'
+            mock_usage_key = Mock()
+            mock_usage_key.block_id = expected_block_id
+            patched_class.from_string.return_value = mock_usage_key
+            block_id = _get_block_id(event)
+            self.assertEqual(block_id, expected_block_id)
+            patched_class.from_string.assert_called_once_with(usage_key_string)
+
+    def test__get_user_id(self):
+        """
+        Test that `_get_user_id` function extracts appropriate value from event and returns it.
+        """
+        event = {
+            'context': {
+                'user_id': 23
+            }
+        }
+        user_id = _get_user_id(event)
+        self.assertEqual(user_id, 23)
+
+    @ddt.data('correct', 'incorrect')
+    def test__get_success(self, expected_success):
+        """
+        Test that `_get_success` function extracts appropriate value from event and returns it.
+        """
+        event = {
+            'event': {
+                'success': expected_success
+            }
+        }
+        success = _get_success(event)
+        self.assertEqual(success, expected_success)
+
+    @ddt.data(True, False)
+    def test_adaptive_learning_backend(self, is_problem_check):
+        """
+        Test that `send` method of AdaptiveLearningBackend triggers logic for sending result event
+        to external service that provides adaptive learning features, when appropriate.
+        """
+        block_id = '8e52e13fc4g696gb8g33'
+        user_id = 23
+        success = 'correct'
+        event = {
+            'event_type': 'problem_check',
+            'context': {
+                'course_id': 'block-v1:org+course+run+type@course+block@course',
+                'user_id': user_id,
+                'module': {
+                    'usage_key': 'block-v1:org+course+run+type@problem+block@{block_id}'.format(block_id=block_id)
+                },
+            },
+            'event': {
+                'success': success
+            }
+        }
+        with patch('track.backends.adaptive_learning._is_problem_check') as patched__is_problem_check, \
+             patch('track.backends.adaptive_learning._get_course') as patched__get_course, \
+             patch('track.backends.adaptive_learning._get_block_id') as patched__get_block_id, \
+             patch('track.backends.adaptive_learning._get_user_id') as patched__get_user_id, \
+             patch('track.backends.adaptive_learning._get_success') as patched__get_success, \
+             patch('track.backends.adaptive_learning.AdaptiveLibraryContentModule') as patched_class:
+            patched__is_problem_check.return_value = is_problem_check
+            course_mock = Mock()
+            patched__get_course.return_value = course_mock
+            patched__get_block_id.return_value = block_id
+            patched__get_user_id.return_value = user_id
+            patched__get_success.return_value = success
+            mock_create_result_event = Mock()
+            patched_class.create_result_event = mock_create_result_event
+            self.backend.send(event)
+            if is_problem_check:
+                patched__get_course.assert_called_once_with(event)
+                patched__get_block_id.assert_called_once_with(event)
+                patched__get_user_id.assert_called_once_with(event)
+                patched__get_success.assert_called_once_with(event)
+                mock_create_result_event.assert_called_once_with(course_mock, block_id, user_id, success)
+            else:
+                patched__get_course.assert_not_called()
+                patched__get_block_id.assert_not_called()
+                patched__get_user_id.assert_not_called()
+                patched__get_success.assert_not_called()
+                mock_create_result_event.assert_not_called()

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -2,7 +2,8 @@
 """
 LibraryContent: The XBlock used to include blocks from a library in a course.
 """
-import json, logging
+import json
+import logging
 from lxml import etree
 from copy import copy
 from capa.responsetypes import registry
@@ -16,7 +17,7 @@ from webob import Response
 from xblock.core import XBlock
 from xblock.fields import Scope, String, List, Integer, Boolean
 from xblock.fragment import Fragment
-from xmodule.util.adaptive_learning import AdaptiveLearningAPIMixin
+from xmodule.util.adaptive_learning import AdaptiveLearningAPIClient
 from xmodule.validation import StudioValidationMessage, StudioValidation
 from xmodule.x_module import XModule, STUDENT_VIEW
 from xmodule.studio_editable import StudioEditableModule, StudioEditableDescriptor
@@ -150,7 +151,7 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
     """
 
     @classmethod
-    def make_selection(cls, selected, children, max_count, mode, **kwargs):
+    def make_selection(cls, selected, children, max_count, mode, **kwargs):  # pylint: disable=unused-argument
         """
         Dynamically selects block_ids indicating which of the possible children are displayed to the current user.
 
@@ -390,11 +391,18 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
 
 @XBlock.wants('user')
 @XBlock.wants('library_tools')  # Only needed in studio
-class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentModule, AdaptiveLearningAPIMixin):
+class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentModule):
     """
     A specialized version of Randomized Content Block that communicates
     with an external service to determine when to show its children, and which ones.
     """
+
+    @lazy
+    def api_client(self):
+        """
+        Return instance of `AdaptiveLearningAPIClient` for parent course of this block.
+        """
+        return AdaptiveLearningAPIClient(self.parent_course)
 
     @lazy
     def parent_course(self):
@@ -412,28 +420,18 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         return parent_unit.scope_ids.usage_id.block_id
 
     @lazy
-    def anonymous_user_id(self):
+    def current_user_id(self):
         """
-        Return anonymous ID for current user.
-
-        Note that we can't use `user_service.get_anonymous_user_id` here
-        because it only produces meaningful results for staff users.
+        Return ID of current user.
         """
-        user_service = self.runtime.service(self, 'user')
-        if user_service:
-            current_user = user_service.get_current_user()
-            user_id = current_user.opt_attrs.get('edx-platform.user_id')
-            anonymous_user_id = self.make_anonymous_user_id(user_id)
-        else:
-            anonymous_user_id = None
-        return anonymous_user_id
+        return self.descriptor.get_user_id()
 
     @lazy
     def child_block_ids(self):
         """
         Return list of `block_id`s identifying children of this block.
         """
-        return [child.block_id for child in self.children]
+        return [child.block_id for child in self.children]  # pylint: disable=no-member
 
     @classmethod
     def make_selection(cls, selected, children, max_count, mode, **kwargs):
@@ -518,7 +516,7 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         # Determine children to display based on information about pending reviews from external service.
         # This needs to happen here (at instance level) because we need access to course and block-specific data,
         # which is not available at the class level.
-        selected = self.get_selections_current_user(self.children)
+        selected = self.get_selections_current_user(self.children)  # pylint: disable=no-member
         block_keys = self.make_selection(
             selected, self.children, self.max_count, "adaptive", previously_selected=self.selected  # pylint: disable=no-member
         )
@@ -537,7 +535,7 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         Check with external service whether any children of this block
         are scheduled for review by the current user, and return them.
         """
-        pending_reviews = self.get_pending_reviews(self.anonymous_user_id)
+        pending_reviews = self.api_client.get_pending_reviews(self.current_user_id)
         valid_block_keys = {
             c.block_id: (c.block_type, c.block_id) for c in children
         }
@@ -572,10 +570,10 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         """
         # Get block ID of parent unit
         block_id = self.parent_unit_id
-        # Get student ID for current user
-        user_id = self.anonymous_user_id
+        # Get ID of current user
+        user_id = self.current_user_id
         # Send "Unit viewed" event
-        self.create_read_event(block_id, user_id)
+        self.api_client.create_read_event(block_id, user_id)
 
     def link_current_user_to_children(self):
         """
@@ -584,10 +582,19 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         """
         # Get IDs of children
         block_ids = self.child_block_ids
-        # Get student ID for current user
-        user_id = self.anonymous_user_id
+        # Get ID of current user
+        user_id = self.current_user_id
         # Establish links
-        self.create_knowledge_node_students(block_ids, user_id)
+        self.api_client.create_knowledge_node_students(block_ids, user_id)
+
+    @classmethod
+    def send_result_event(cls, course, block_id, user_id, result):
+        """
+        Create result event for unit identified by `block_id` and student identified by `user_id`
+        using adaptive learning configuration from `course`.
+        """
+        api_client = AdaptiveLearningAPIClient(course)
+        api_client.create_result_event(block_id, user_id, result)
 
 
 @XBlock.wants('user')

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -547,10 +547,6 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
             question_id = pending_review.get('review_question_uid')
             if unit_id == self.parent_unit_id and question_id in valid_block_keys:
                 selections.append(valid_block_keys[question_id])
-        # FIXME:
-        # Make it possible to test changes manually by temporarily showing all children.
-        # Will revert this before merging PR.
-        selections += valid_block_keys.values()
         return selections
 
     def student_view(self, context):

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -549,6 +549,10 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
             question_id = pending_review.get('review_question_uid')
             if unit_id == self.parent_unit_id and question_id in valid_block_keys:
                 selections.append(valid_block_keys[question_id])
+        # FIXME:
+        # Make it possible to test changes manually by temporarily showing all children.
+        # Will revert this before merging PR.
+        selections += valid_block_keys.values()
         return selections
 
     def student_view(self, context):

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -282,15 +282,13 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
     """
     Basic unit tests for AdaptiveLibraryContentModule
     """
-    @patch('xmodule.library_content_module.AdaptiveLearningAPIMixin.get_pending_reviews')
-    def test_children_seen_by_a_user(self, mock_get_pending_reviews):
+    @patch('xmodule.library_content_module.AdaptiveLearningAPIClient.get_pending_reviews', Mock(return_value=[]))
+    def test_children_seen_by_a_user(self):
         """
         Test that each student sees zero child blocks for AdaptiveLibraryContent block by default.
         """
-        mock_get_pending_reviews.return_value = []
-
         self.lc_block.refresh_children()
-        self.lc_block = self.store.get_item(self.lc_block.location)
+        self.lc_block = self.store.get_item(self.lc_block.location)  # pylint: disable=attribute-defined-outside-init
         self._bind_course_module(self.lc_block)
 
         # Make sure the runtime knows that the block's children vary per-user:
@@ -309,7 +307,7 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
         calls it with appropriate arguments, and returns appropriate value.
         """
         self._bind_course_module(self.lc_block)
-        module = self.lc_block._xmodule
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
         with patch.object(module.runtime.modulestore, 'get_course') as patched_get_course:
             patched_get_course.return_value = self.course
             parent_course = module.parent_course
@@ -322,7 +320,7 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
         calls it with appropriate arguments, and returns appropriate value.
         """
         self._bind_course_module(self.lc_block)
-        module = self.lc_block._xmodule
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
         with patch.object(module, 'get_parent') as patched_get_parent:
             patched_get_parent.return_value = self.vertical
             parent_unit_id = module.parent_unit_id
@@ -330,36 +328,28 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
             self.assertEqual(parent_unit_id, expected_parent_unit_id)
             patched_get_parent.assert_called_once_with()
 
-    def test_anonymous_user_id(self):
+    def test_current_user_id(self):
         """
-        Test that `parent_unit_id` property uses expected API for obtaining parent course,
+        Test that `current_user_id` property uses expected API for obtaining ID of current user,
         calls it with appropriate arguments, and returns appropriate value.
         """
         self._bind_course_module(self.lc_block)
-        module = self.lc_block._xmodule
-        with patch.object(module, 'make_anonymous_user_id') as patched_make_anonymous_user_id, \
-             patch.object(module.runtime, 'service') as patched_service:
-            user_service_mock = Mock()
-            current_user_mock = Mock()
-            current_user_mock.opt_attrs.get.return_value = 42
-            user_service_mock.get_current_user.return_value = current_user_mock
-            patched_service.return_value = user_service_mock
-            patched_make_anonymous_user_id.return_value = 'dummy-id'
-            user_id = module.anonymous_user_id
-            self.assertEqual(user_id, 'dummy-id')
-            patched_service.assert_called_once_with(module, 'user')
-            current_user_mock.opt_attrs.get.assert_called_once_with('edx-platform.user_id')
-            patched_make_anonymous_user_id.assert_called_once_with(42)
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
+        with patch.object(self.lc_block, 'get_user_id') as patched_get_user_id:
+            patched_get_user_id.return_value = 42
+            user_id = module.current_user_id
+            self.assertEqual(user_id, 42)
+            patched_get_user_id.assert_called_once_with()
 
-    def test_anonymous_user_id_no_user_service(self):
+    def test_current_user_id_no_user_service(self):
         """
-        Test that `parent_unit_id` property returns `None` if user service is not available.
+        Test that `current_user_id` property returns `None` if user service is not available.
         """
         self._bind_course_module(self.lc_block)
-        module = self.lc_block._xmodule
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
         with patch.object(module.runtime, 'service') as patched_service:
             patched_service.return_value = None
-            user_id = module.anonymous_user_id
+            user_id = module.current_user_id
             self.assertIsNone(user_id)
 
     def test_child_block_ids(self):
@@ -367,35 +357,9 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
         Test that `child_block_ids` property returns correct list containing correct IDs.
         """
         self._bind_course_module(self.lc_block)
-        module = self.lc_block._xmodule
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
         expected_child_block_ids = [child.block_id for child in module.children]
         self.assertEqual(module.child_block_ids, expected_child_block_ids)
-
-    def test_send_unit_viewed_event(self):
-        """
-        Test that `send_unit_viewed_event` calls method for notifying external service
-        with appropriate arguments.
-        """
-        self._bind_course_module(self.lc_block)
-        module = self.lc_block._xmodule
-        block_id = module.parent_unit_id
-        user_id = module.anonymous_user_id
-        with patch.object(module, 'create_read_event') as patched_create_read_event:
-            module.send_unit_viewed_event()
-            patched_create_read_event.assert_called_once_with(block_id, user_id)
-
-    def test_link_current_user_to_children(self):
-        """
-        Test that `link_current_user_to_children` calls method for linking current user
-        to children of adaptive content block with appropriate arguments.
-        """
-        self._bind_course_module(self.lc_block)
-        module = self.lc_block._xmodule
-        block_ids = module.child_block_ids
-        user_id = module.anonymous_user_id
-        with patch.object(module, 'create_knowledge_node_students') as patched_create_knowledge_node_students:
-            module.link_current_user_to_children()
-            patched_create_knowledge_node_students.assert_called_once_with(block_ids, user_id)
 
     def test_get_selections_current_user(self):
         """
@@ -403,9 +367,9 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
         for current user, and returns selection appropriate for current unit and block.
         """
         self._bind_course_module(self.lc_block)
-        module = self.lc_block._xmodule
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
         parent_unit_id = module.parent_unit_id
-        user_id = module.anonymous_user_id
+        user_id = module.current_user_id
         children = module.children
         relevant_reviews = [
             {
@@ -421,12 +385,66 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
             } for n in range(5)
         ]
         pending_reviews = relevant_reviews + irrelevant_reviews
-        expected_selections_current_user = [(c.block_type, c.block_id) for c in children]
-        with patch.object(module, 'get_pending_reviews') as patched_get_pending_reviews:
+        expected_selections = [(c.block_type, c.block_id) for c in children]
+        with patch(
+            'xmodule.library_content_module.AdaptiveLearningAPIClient.get_pending_reviews'
+        ) as patched_get_pending_reviews:
             patched_get_pending_reviews.return_value = pending_reviews
             selections_current_user = module.get_selections_current_user(children)
-            self.assertEqual(selections_current_user, expected_selections_current_user)
+            self.assertEqual(selections_current_user, expected_selections)
             patched_get_pending_reviews.assert_called_once_with(user_id)
+
+    def test_send_unit_viewed_event(self):
+        """
+        Test that `send_unit_viewed_event` calls method for notifying external service
+        with appropriate arguments.
+        """
+        self._bind_course_module(self.lc_block)
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
+        block_id = module.parent_unit_id
+        user_id = module.current_user_id
+        with patch(
+            'xmodule.library_content_module.AdaptiveLearningAPIClient.create_read_event'
+        ) as patched_create_read_event:
+            module.send_unit_viewed_event()
+            patched_create_read_event.assert_called_once_with(block_id, user_id)
+
+    def test_link_current_user_to_children(self):
+        """
+        Test that `link_current_user_to_children` calls method for linking current user
+        to children of adaptive content block with appropriate arguments.
+        """
+        self._bind_course_module(self.lc_block)
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
+        block_ids = module.child_block_ids
+        user_id = module.current_user_id
+        with patch(
+            'xmodule.library_content_module.AdaptiveLearningAPIClient.create_knowledge_node_students'
+        ) as patched_create:
+            module.link_current_user_to_children()
+            patched_create.assert_called_once_with(block_ids, user_id)
+
+    def test_send_result_event(self):
+        """
+        Test that `send_result_event` calls method for notifying external service
+        with appropriate arguments.
+        """
+        self.lc_block.refresh_children()
+        self.lc_block = self.store.get_item(self.lc_block.location)  # pylint: disable=attribute-defined-outside-init
+        self._bind_course_module(self.lc_block)
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
+        course = module.parent_course
+        block_id = module.child_block_ids[0]
+        user_id = module.current_user_id
+        result = '100'
+        with patch(
+            'xmodule.library_content_module.AdaptiveLearningAPIClient'
+        ) as patched_class:
+            mock_client = Mock(autospec=True)
+            patched_class.return_value = mock_client
+            AdaptiveLibraryContentModule.send_result_event(course, block_id, user_id, result)
+            patched_class.assert_called_once_with(course)
+            mock_client.create_result_event.assert_called_once_with(block_id, user_id, result)
 
     def test_student_view(self):
         """
@@ -434,12 +452,12 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
         and creates links between current user and children of block under test.
         """
         self._bind_course_module(self.lc_block)
-        module = self.lc_block._xmodule
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
         with patch.multiple(
-                module,
-                send_unit_viewed_event=DEFAULT,
-                link_current_user_to_children=DEFAULT,
-                _get_selected_child_blocks=DEFAULT
+            module,
+            send_unit_viewed_event=DEFAULT,
+            link_current_user_to_children=DEFAULT,
+            _get_selected_child_blocks=DEFAULT
         ) as patched_methods:
             patched_methods['_get_selected_child_blocks'].return_value = []
             context = {}
@@ -798,69 +816,71 @@ class AdaptiveLibraryContentAnalyticsMixin(LibraryContentAnalyticsMixin):
         pending_reviews = relevant_reviews + irrelevant_reviews
         return pending_reviews
 
-    def _assert_event_not_published(self, event_type):
+    def _assert_event_not_published(self):
         """
         Check that *no* AdaptiveLibraryContentModule analytics event was published by self.lc_block.
         """
         self.publisher.assert_not_called()
 
-    @patch('xmodule.library_content_module.AdaptiveLearningAPIMixin.get_pending_reviews')
-    def test_assigned_event(self, mock_get_pending_reviews):
+    def test_assigned_event(self):
         """
         Test the "assigned" event emitted when a student is assigned specific blocks.
         """
-        mock_get_pending_reviews.return_value = self.pending_reviews[:1]
+        with patch(
+            'xmodule.library_content_module.AdaptiveLearningAPIClient.get_pending_reviews'
+        ) as patched_get_pending_reviews:
+            # In the beginning was the lc_block and it assigned one child to the student:
+            patched_get_pending_reviews.return_value = self.pending_reviews[:1]
+            child = self.lc_block.get_child_descriptors()[0]
+            child_lib_location, child_lib_version = self.store.get_block_original_usage(child.location)
+            self.assertIsInstance(child_lib_version, ObjectId)
+            event_data = self._assert_event_was_published("assigned")
+            block_info = {
+                "usage_key": unicode(child.location),
+                "original_usage_key": unicode(child_lib_location),
+                "original_usage_version": unicode(child_lib_version),
+                "descendants": [],
+            }
+            self.assertEqual(event_data, {
+                "location": unicode(self.lc_block.location),
+                "added": [block_info],
+                "result": [block_info],
+                "previous_count": 0,
+                "max_count": 1,
+            })
+            self.publisher.reset_mock()
 
-        # In the beginning was the lc_block and it assigned one child to the student:
-        child = self.lc_block.get_child_descriptors()[0]
-        child_lib_location, child_lib_version = self.store.get_block_original_usage(child.location)
-        self.assertIsInstance(child_lib_version, ObjectId)
-        event_data = self._assert_event_was_published("assigned")
-        block_info = {
-            "usage_key": unicode(child.location),
-            "original_usage_key": unicode(child_lib_location),
-            "original_usage_version": unicode(child_lib_version),
-            "descendants": [],
-        }
-        self.assertEqual(event_data, {
-            "location": unicode(self.lc_block.location),
-            "added": [block_info],
-            "result": [block_info],
-            "previous_count": 0,
-            "max_count": 1,
-        })
-        self.publisher.reset_mock()
+            # Now increase the number of pending reviews so that one more child will be added:
+            patched_get_pending_reviews.return_value = self.pending_reviews[:2]
 
-        # Now increase the number of pending reviews so that one more child will be added:
-        mock_get_pending_reviews.return_value = self.pending_reviews[:2]
+            # Clear data
+            del self.lc_block._xmodule._selected_set  # pylint: disable=protected-access
 
-        # Clear data
-        del self.lc_block._xmodule._selected_set
+            # Check children
+            children = self.lc_block.get_child_descriptors()
+            self.assertEqual(len(children), 2)
+            child, new_child = children if children[0].location == child.location else reversed(children)
 
-        # Check children
-        children = self.lc_block.get_child_descriptors()
-        self.assertEqual(len(children), 2)
-        child, new_child = children if children[0].location == child.location else reversed(children)
+            # Check event data
+            event_data = self._assert_event_was_published("assigned")
+            self.assertEqual(event_data["added"][0]["usage_key"], unicode(new_child.location))
+            self.assertEqual(len(event_data["result"]), 2)
+            self.assertEqual(event_data["previous_count"], 1)
 
-        # Check event data
-        event_data = self._assert_event_was_published("assigned")
-        self.assertEqual(event_data["added"][0]["usage_key"], unicode(new_child.location))
-        self.assertEqual(len(event_data["result"]), 2)
-        self.assertEqual(event_data["previous_count"], 1)
-
-    @patch('xmodule.library_content_module.AdaptiveLearningAPIMixin.get_pending_reviews')
-    def test_assigned_event_no_pending_reviews(self, mock_get_pending_reviews):
+    def test_assigned_event_no_pending_reviews(self):
         """
         Test that no "assigned" event is emitted if student is not assigned any blocks.
         """
-        # In the beginning was the lc_block and it assigned zero children to the student:
-        mock_get_pending_reviews.return_value = []
-        children = self.lc_block.get_child_descriptors()
-        self.assertEqual(len(children), 0)
-        self._assert_event_not_published("assigned")
+        with patch(
+            'xmodule.library_content_module.AdaptiveLearningAPIClient.get_pending_reviews'
+        ) as patched_get_pending_reviews:
+            # In the beginning was the lc_block and it assigned zero children to the student:
+            patched_get_pending_reviews.return_value = []
+            children = self.lc_block.get_child_descriptors()
+            self.assertEqual(len(children), 0)
+            self._assert_event_not_published()
 
-    @patch('xmodule.library_content_module.AdaptiveLearningAPIMixin.get_pending_reviews')
-    def test_assigned_descendants(self, mock_get_pending_reviews):
+    def test_assigned_descendants(self):
         """
         Test the "assigned" event emitted includes descendant block information.
         """
@@ -870,93 +890,101 @@ class AdaptiveLibraryContentAnalyticsMixin(LibraryContentAnalyticsMixin):
         # Reload lc_block and set it up for a student:
         self._refresh_lc_block()
 
-        mock_get_pending_reviews.return_value = self.pending_reviews
+        with patch(
+            'xmodule.library_content_module.AdaptiveLearningAPIClient.get_pending_reviews'
+        ) as patched_get_pending_reviews:
+            patched_get_pending_reviews.return_value = self.pending_reviews
 
-        # Check "assigned" event data:
-        self._assert_assigned_descendants(inner_vertical, html_block, problem_block)
+            # Check "assigned" event data:
+            self._assert_assigned_descendants(inner_vertical, html_block, problem_block)
 
-    @patch('xmodule.library_content_module.AdaptiveLearningAPIMixin.get_pending_reviews')
-    def test_removed_overlimit(self, mock_get_pending_reviews):
+    def test_removed_overlimit(self):
         """
         Test that block never drops any elements based on value of `max_count` setting.
         """
         children = self.lc_block.children
-        mock_get_pending_reviews.return_value = self.pending_reviews
+        with patch(
+            'xmodule.library_content_module.AdaptiveLearningAPIClient.get_pending_reviews'
+        ) as patched_get_pending_reviews:
+            patched_get_pending_reviews.return_value = self.pending_reviews
 
-        # `max_count` less than number of pending reviews (initial value is 1):
-        child_descriptors = self.lc_block.get_child_descriptors()
-        self.assertEqual(len(child_descriptors), len(children))
-        self._assert_event_not_published("removed")
+            # `max_count` less than number of pending reviews (initial value is 1):
+            child_descriptors = self.lc_block.get_child_descriptors()
+            self.assertEqual(len(child_descriptors), len(children))
+            self._assert_event_not_published()
 
-        # Clear data
-        del self.lc_block._xmodule._selected_set  # pylint: disable=protected-access
+            # Clear data
+            del self.lc_block._xmodule._selected_set  # pylint: disable=protected-access
 
-        # `max_count` equal to number of pending reviews:
-        self.lc_block.max_count = 4
-        child_descriptors = self.lc_block.get_child_descriptors()
-        self.assertEqual(len(child_descriptors), len(children))
-        self._assert_event_not_published("removed")
+            # `max_count` equal to number of pending reviews:
+            self.lc_block.max_count = 4
+            child_descriptors = self.lc_block.get_child_descriptors()
+            self.assertEqual(len(child_descriptors), len(children))
+            self._assert_event_not_published()
 
-        # Clear data
-        del self.lc_block._xmodule._selected_set   # pylint: disable=protected-access
+            # Clear data
+            del self.lc_block._xmodule._selected_set   # pylint: disable=protected-access
 
-        # `max_count` greater than number of pending reviews:
-        self.lc_block.max_count = 8
-        child_descriptors = self.lc_block.get_child_descriptors()
-        self.assertEqual(len(child_descriptors), len(children))
-        self._assert_event_not_published("removed")
+            # `max_count` greater than number of pending reviews:
+            self.lc_block.max_count = 8
+            child_descriptors = self.lc_block.get_child_descriptors()
+            self.assertEqual(len(child_descriptors), len(children))
+            self._assert_event_not_published()
 
-    @patch('xmodule.library_content_module.AdaptiveLearningAPIMixin.get_pending_reviews')
-    def test_removed_invalid(self, mock_get_pending_reviews):
+    def test_removed_invalid(self):
         """
         Test the "removed" event emitted when we un-assign blocks previously assigned to a student.
         We go from four blocks assigned, to one because the others have been deleted from the library.
         """
         children = self.lc_block.children
-        mock_get_pending_reviews.return_value = self.pending_reviews
+        with patch(
+            'xmodule.library_content_module.AdaptiveLearningAPIClient.get_pending_reviews'
+        ) as patched_get_pending_reviews:
+            patched_get_pending_reviews.return_value = self.pending_reviews
 
-        # Start by assigning four child blocks to the student:
-        initial_blocks_assigned = self.lc_block.get_child_descriptors()
-        self.assertEqual(len(initial_blocks_assigned), len(children))
+            # Start by assigning four child blocks to the student:
+            initial_blocks_assigned = self.lc_block.get_child_descriptors()
+            self.assertEqual(len(initial_blocks_assigned), len(children))
 
-        # Now make sure that all but one of the assigned blocks will have to be un-assigned.
-        # To cause an "invalid" event, we delete all blocks from the content library
-        # except for one of the four already assigned to the student:
-        keep_block_key = initial_blocks_assigned[0].location
-        keep_block_lib_usage_key, keep_block_lib_version = self.store.get_block_original_usage(keep_block_key)
-        self.assertIsNotNone(keep_block_lib_usage_key)
-        deleted_block_keys = [block.location for block in initial_blocks_assigned[1:]]
-        self.library.children = [keep_block_lib_usage_key]
-        self.store.update_item(self.library, self.user_id)
-        self.lc_block.refresh_children()
+            # Now make sure that all but one of the assigned blocks will have to be un-assigned.
+            # To cause an "invalid" event, we delete all blocks from the content library
+            # except for one of the four already assigned to the student:
+            keep_block_key = initial_blocks_assigned[0].location
+            keep_block_lib_usage_key, keep_block_lib_version = self.store.get_block_original_usage(keep_block_key)
+            self.assertIsNotNone(keep_block_lib_usage_key)
+            deleted_block_keys = [block.location for block in initial_blocks_assigned[1:]]
+            self.library.children = [keep_block_lib_usage_key]
+            self.store.update_item(self.library, self.user_id)
+            self.lc_block.refresh_children()
 
-        # Clear data
-        del self.lc_block._xmodule._selected_set  # pylint: disable=protected-access
+            # Clear data
+            del self.lc_block._xmodule._selected_set  # pylint: disable=protected-access
 
-        # Update selected blocks
-        child_descriptors = self.lc_block.get_child_descriptors()
+            # Update selected blocks
+            child_descriptors = self.lc_block.get_child_descriptors()
 
-        # Check that the event says that three blocks were removed, leaving one block:
-        event_data = self._assert_event_was_published("removed")
-        self.assertEqual(len(child_descriptors), 1)
-        expected_deleted_block_keys = [{
-            "usage_key": unicode(deleted_block_key),
-            "original_usage_key": None,  # Note: original_usage_key info is sadly unavailable because the block has been
-                                         # deleted so that info can no longer be retrieved
-            "original_usage_version": None,
-            "descendants": [],
-        } for deleted_block_key in deleted_block_keys]
-        self.assertEqual(len(event_data["removed"]), len(expected_deleted_block_keys))
-        for expected_deleted_block_key in expected_deleted_block_keys:
-            self.assertIn(expected_deleted_block_key, event_data["removed"])
+            # Check that the event says that three blocks were removed, leaving one block:
+            event_data = self._assert_event_was_published("removed")
+            self.assertEqual(len(child_descriptors), 1)
+            expected_deleted_block_keys = [{
+                "usage_key": unicode(deleted_block_key),
+                # Note: original_usage_key info is sadly unavailable
+                # because the block has been deleted so that info can no longer be retrieved
+                "original_usage_key": None,
+                "original_usage_version": None,
+                "descendants": [],
+            } for deleted_block_key in deleted_block_keys]
+            self.assertEqual(len(event_data["removed"]), len(expected_deleted_block_keys))
+            for expected_deleted_block_key in expected_deleted_block_keys:
+                self.assertIn(expected_deleted_block_key, event_data["removed"])
 
-        self.assertEqual(event_data["result"], [{
-            "usage_key": unicode(keep_block_key),
-            "original_usage_key": unicode(keep_block_lib_usage_key),
-            "original_usage_version": unicode(keep_block_lib_version),
-            "descendants": [],
-        }])
-        self.assertEqual(event_data["reason"], "invalid")
+            self.assertEqual(event_data["result"], [{
+                "usage_key": unicode(keep_block_key),
+                "original_usage_key": unicode(keep_block_lib_usage_key),
+                "original_usage_version": unicode(keep_block_lib_version),
+                "descendants": [],
+            }])
+            self.assertEqual(event_data["reason"], "invalid")
 
 
 class TestLibraryContentAnalytics(LibraryContentAnalyticsMixin, LibraryContentTest):

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -641,7 +641,6 @@ class LibraryContentAnalyticsMixin(object):
             for descendant in block_list[0]["descendants"]:
                 self.assertEqual(descendant, descendant_data_expected.get(descendant["usage_key"]))
 
-
     def test_assigned_event(self):
         """
         Test the "assigned" event emitted when a student is assigned specific blocks.

--- a/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
@@ -7,9 +7,11 @@ import unittest
 
 import ddt
 import httpretty
-from mock import DEFAULT, MagicMock, Mock, patch, call
+from mock import DEFAULT, Mock, patch, call
 
-from ..util.adaptive_learning import AdaptiveLearningConfiguration, AdaptiveLearningAPIMixin
+from ..util.adaptive_learning import (
+    AdaptiveLearningConfiguration, AdaptiveLearningAPIClient, AdaptiveLearningAPIMixin
+)
 
 
 ADAPTIVE_LEARNING_CONFIGURATION = {
@@ -19,17 +21,24 @@ ADAPTIVE_LEARNING_CONFIGURATION = {
     'access_token': 'this-is-not-a-test',
 }
 
-URL_METHODS = {
-    '_adaptive_learning_url': 'https://dummy.com/v42',
-    '_instance_url': 'https://dummy.com/v42/instances/23',
-    '_students_url': 'https://dummy.com/v42/instances/23/students',
-    '_events_url': 'https://dummy.com/v42/instances/23/events',
-    '_knowledge_node_students_url': 'https://dummy.com/v42/instances/23/knowledge_node_students',
+URLS = {
+    'adaptive_learning_url': 'https://dummy.com/v42',
+    'instance_url': 'https://dummy.com/v42/instances/23',
+    'students_url': 'https://dummy.com/v42/instances/23/students',
+    'events_url': 'https://dummy.com/v42/instances/23/events',
+    'knowledge_node_students_url': 'https://dummy.com/v42/instances/23/knowledge_node_students',
+    'pending_reviews_url': 'https://dummy.com/v42/instances/23/review_utils/fetch_reviews'
 }
 
-URL_PROPERTIES = {
-    '_pending_reviews_url': 'https://dummy.com/v42/instances/23/review_utils/fetch_reviews'
-}
+
+def make_mock_course():
+    """
+    Return mock course with attributes and methods that are relevant for testing adaptive learning features.
+    """
+    course = Mock()
+    course.id.to_deprecated_string.return_value = 'abc'
+    course.adaptive_learning_configuration = ADAPTIVE_LEARNING_CONFIGURATION
+    return course
 
 
 class TestAdaptiveLearningConfiguration(unittest.TestCase):
@@ -39,6 +48,7 @@ class TestAdaptiveLearningConfiguration(unittest.TestCase):
     """
 
     def setUp(self):
+        super(TestAdaptiveLearningConfiguration, self).setUp()
         self.attributes = {
             'foo': None,
             'bar': 42,
@@ -50,7 +60,7 @@ class TestAdaptiveLearningConfiguration(unittest.TestCase):
         """
         Test that constructor correctly sets attributes.
         """
-        self.assertEqual(self.adaptive_learning_configuration._configuration, self.attributes)
+        self.assertEqual(self.adaptive_learning_configuration._configuration, self.attributes)  # pylint: disable=protected-access
         for attribute, value in self.attributes.items():
             self.assertTrue(hasattr(self.adaptive_learning_configuration, attribute))
             self.assertEqual(getattr(self.adaptive_learning_configuration, attribute), value)
@@ -61,20 +71,17 @@ class TestAdaptiveLearningConfiguration(unittest.TestCase):
         """
         self.assertEqual(
             str(self.adaptive_learning_configuration),
-            str(self.adaptive_learning_configuration._configuration)
+            str(self.adaptive_learning_configuration._configuration)  # pylint: disable=protected-access
         )
 
 
-class DummyModule(AdaptiveLearningAPIMixin):
+class DummyClient(AdaptiveLearningAPIMixin):
     """
     Helper class for testing functionality provided by AdaptiveLearningAPIMixin.
     """
 
     def __init__(self):
-        self.course_id = Mock()
-        self.course_id.to_deprecated_string.return_value = 'abc'
-        self.parent_course = MagicMock()
-        self.parent_course.adaptive_learning_configuration = ADAPTIVE_LEARNING_CONFIGURATION
+        self._course = make_mock_course()
 
 
 class AdaptiveLearningServiceMixin(object):
@@ -104,26 +111,41 @@ class AdaptiveLearningServiceMixin(object):
         """
         Register a mock response listing students that external service knows about.
         """
-        self._mock_get_request(URL_METHODS['_students_url'], students)
+        self._mock_get_request(URLS['students_url'], students)
 
     def register_knowledge_node_students(self, knowledge_node_students):
         """
         Register a mock response listing students that external service knows about.
         """
-        self._mock_get_request(URL_METHODS['_knowledge_node_students_url'], knowledge_node_students)
+        self._mock_get_request(URLS['knowledge_node_students_url'], knowledge_node_students)
 
     def register_pending_reviews(self, pending_reviews):
         """
         Register a mock response listing students that external service knows about.
         """
-        self._mock_get_request(URL_PROPERTIES['_pending_reviews_url'], pending_reviews)
+        self._mock_get_request(URLS['pending_reviews_url'], pending_reviews)
 
 
-@ddt.ddt
-@httpretty.activate
-class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMixin):
+class AdaptiveLearningAPITestMixin(unittest.TestCase, AdaptiveLearningServiceMixin):
     """
-    Tests for mixin that provides methods for interacting with external adaptive learning service.
+    Base class for testing interactions with external adaptive learning service.
+    """
+
+    KNOWLEDGE_NODE_STUDENTS = [
+        {
+            'id': n,
+            'knowledge_node_id': n,
+            'knowledge_node_uid': 'knowledge-node-{n}'.format(n=n),
+            'student_id': n,
+            'student_uid': 'student-{n}'.format(n=n)
+        } for n in range(5)
+    ]
+
+
+@httpretty.activate
+class TestAdaptiveLearningAPIMixin(AdaptiveLearningAPITestMixin):
+    """
+    Tests for class that provides low-level methods for interacting with external adaptive learning service.
 
     Note that example data only lists properties of corresponding entities (students, events, etc.)
     that are relevant in the context of individual tests. The external service that provides
@@ -137,15 +159,294 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
         } for n in range(5)
     ]
 
-    KNOWLEDGE_NODE_STUDENTS = [
-        {
-            'id': n,
-            'knowledge_node_id': n,
-            'knowledge_node_uid': 'knowledge-node-{n}'.format(n=n),
-            'student_id': n,
-            'student_uid': 'student-{n}'.format(n=n)
-        } for n in range(5)
-    ]
+    def setUp(self):
+        super(TestAdaptiveLearningAPIMixin, self).setUp()
+        self.dummy_client = DummyClient()
+
+    def test_adaptive_learning_configuration(self):
+        """
+        Test `adaptive_learning_configuration` property.
+        """
+        adaptive_learning_configuration = self.dummy_client.adaptive_learning_configuration
+        self.assertIsInstance(adaptive_learning_configuration, AdaptiveLearningConfiguration)
+        for attribute, value in ADAPTIVE_LEARNING_CONFIGURATION.items():
+            self.assertTrue(hasattr(adaptive_learning_configuration, attribute))
+            self.assertEqual(getattr(adaptive_learning_configuration, attribute), value)
+
+    def test_urls(self):
+        """
+        Test that `*_url` properties return appropriate values.
+        """
+        for url_property, expected_value in URLS.items():
+            self.assertTrue(hasattr(self.dummy_client, url_property))
+            self.assertEqual(getattr(self.dummy_client, url_property), expected_value)
+
+    def test_request_headers(self):
+        """
+        Test that `request_headers` property returns appropriate value.
+        """
+        expected_headers = {
+            'Authorization': 'Token token=this-is-not-a-test'
+        }
+        self.assertEqual(self.dummy_client.request_headers, expected_headers)
+
+    def test_get_knowledge_node_student_id(self):
+        """
+        Test the `get_knowledge_node_student_id` returns ID of a given 'knowledge node student' object.
+        """
+        knowledge_node_uid = 'knowledge-node-23'
+        student_uid = 'student-23'
+        knowledge_node_student = {
+            'id': 42,
+            'knowledge_node_id': 23,
+            'knowledge_node_uid': knowledge_node_uid,
+            'student_id': 23,
+            'student_uid': student_uid
+        }
+        with patch.object(self.dummy_client, 'get_or_create_knowledge_node_student') as patched_get_or_create:
+            patched_get_or_create.return_value = knowledge_node_student
+            knowledge_node_student_id = self.dummy_client.get_knowledge_node_student_id(knowledge_node_uid, student_uid)
+            self.assertEqual(knowledge_node_student_id, 42)
+            patched_get_or_create.assert_called_once_with(knowledge_node_uid, student_uid)
+
+    def test_get_or_create_knowledge_node_student(self):
+        """
+        Test that `get_or_create_knowledge_node_student` method creates 'knowledge node student' object
+        on external service if it doesn't exist, and returns it.
+        """
+        self.register_students(self.STUDENTS)
+        self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
+
+        student = self.STUDENTS[0]
+        knowledge_node_uid = 'knowledge-node-42'
+        student_uid = student['uid']
+        expected_knowledge_node_student = {
+            'id': 23,
+            'knowledge_node_id': 23,
+            'knowledge_node_uid': knowledge_node_uid,
+            'student_id': 23,
+            'student_uid': student_uid,
+        }
+        # 'Knowledge node student' object does not exist
+        with patch.multiple(
+            self.dummy_client,
+            get_or_create_student=DEFAULT,
+            get_knowledge_node_student=DEFAULT,
+            create_knowledge_node_student=DEFAULT
+        ) as patched_methods:
+            patched_methods['get_or_create_student'].return_value = student
+            patched_methods['get_knowledge_node_student'].return_value = None
+            patched_methods['create_knowledge_node_student'].return_value = expected_knowledge_node_student
+            knowledge_node_student = self.dummy_client.get_or_create_knowledge_node_student(
+                knowledge_node_uid, student_uid
+            )
+            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
+            patched_methods['get_or_create_student'].assert_called_once_with(student_uid)
+            patched_methods['get_knowledge_node_student'].assert_called_once_with(knowledge_node_uid, student_uid)
+            patched_methods['create_knowledge_node_student'].assert_called_once_with(knowledge_node_uid, student_uid)
+
+        # 'Knowledge node student' object exists
+        with patch.multiple(
+            self.dummy_client,
+            get_or_create_student=DEFAULT,
+            get_knowledge_node_student=DEFAULT,
+            create_knowledge_node_student=DEFAULT
+        ) as patched_methods:
+            patched_methods['get_or_create_student'].return_value = student
+            patched_methods['get_knowledge_node_student'].return_value = expected_knowledge_node_student
+            patched_methods['create_knowledge_node_student'].return_value = expected_knowledge_node_student
+            knowledge_node_student = self.dummy_client.get_or_create_knowledge_node_student(
+                knowledge_node_uid, student_uid
+            )
+            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
+            patched_methods['get_or_create_student'].assert_called_once_with(student_uid)
+            patched_methods['get_knowledge_node_student'].assert_called_once_with(knowledge_node_uid, student_uid)
+            patched_methods['create_knowledge_node_student'].assert_not_called()
+
+    def test_get_or_create_student(self):
+        """
+        Test that `get_or_create_student` method creates student on external service if it doesn't exist,
+        and returns it.
+        """
+        self.register_students(self.STUDENTS)
+
+        student_uid = 'student-42'
+        expected_student = {
+            'id': 42,
+            'uid': student_uid,
+        }
+
+        # Student does not exist
+        with patch.object(self.dummy_client, 'get_student') as patched_get_student, \
+                patch.object(self.dummy_client, 'create_student') as patched_create_student:
+            patched_get_student.return_value = None
+            patched_create_student.return_value = expected_student
+            student = self.dummy_client.get_or_create_student(student_uid)
+            self.assertDictEqual(student, expected_student)
+            patched_get_student.assert_called_once_with(student_uid)
+            patched_create_student.assert_called_once_with(student_uid)
+
+        # Student exists
+        with patch.object(self.dummy_client, 'get_student') as patched_get_student, \
+                patch.object(self.dummy_client, 'create_student') as patched_create_student:
+            patched_get_student.return_value = expected_student
+            patched_create_student.return_value = expected_student
+            student = self.dummy_client.get_or_create_student(student_uid)
+            self.assertDictEqual(student, expected_student)
+            patched_get_student.assert_called_once_with(student_uid)
+            patched_create_student.assert_not_called()
+
+    def test_get_student(self):
+        """
+        Test that `_get_student` method returns appropriate information
+        if external service knows about a given student,
+        and `None` otherwise.
+        """
+        self.register_students(self.STUDENTS)
+
+        # Unknown student
+        student = self.dummy_client.get_student('student-999')
+        self.assertIsNone(student)
+
+        # Known students
+        for expected_student in self.STUDENTS:
+            student = self.dummy_client.get_student(expected_student['uid'])
+            self.assertDictEqual(student, expected_student)
+
+    def test_create_student(self):
+        """
+        Test that `create_student` method creates student on external service, and returns it.
+        """
+        student_uid = 'student-42'
+        expected_student = {
+            'id': 42,
+            'uid': student_uid,
+        }
+        response = Mock()
+        response.content = json.dumps(expected_student)
+        with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
+            patched_requests.post.return_value = response
+            student = self.dummy_client.create_student(student_uid)
+            self.assertDictEqual(student, expected_student)
+            patched_requests.post.assert_called_once_with(
+                self.dummy_client.students_url,
+                headers=self.dummy_client.request_headers,
+                data={'uid': student_uid}
+            )
+
+    def test_get_students(self):
+        """
+        Test that `get_students` method returns list of all users that external service knows about.
+        """
+        self.register_students(self.STUDENTS)
+        students = self.dummy_client.get_students()
+        self.assertEqual(students, self.STUDENTS)
+
+    def test_get_knowledge_node_student(self):
+        """
+        Test that `_get_knowledge_node_student` method returns appropriate information
+        if 'knowledge node student' object exists on external service,
+        and `None` otherwise.
+        """
+        self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
+
+        # Unknown 'knowledge node student' object
+        knowledge_node_student = self.dummy_client.get_knowledge_node_student('knowledge-node-999', 'student-999')
+        self.assertIsNone(knowledge_node_student)
+
+        # Known 'knowledge node student' object
+        for expected_knowledge_node_student in self.KNOWLEDGE_NODE_STUDENTS:
+            knowledge_node_student = self.dummy_client.get_knowledge_node_student(
+                expected_knowledge_node_student['knowledge_node_uid'],
+                expected_knowledge_node_student['student_uid']
+            )
+            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
+
+    def test_get_knowledge_node_students(self):
+        """
+        Test that `_get_students` method returns list of all users that external service knows about.
+        """
+        self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
+        knowledge_node_students = self.dummy_client.get_knowledge_node_students()
+        self.assertEqual(knowledge_node_students, self.KNOWLEDGE_NODE_STUDENTS)
+
+    def test_create_knowledge_node_student(self):
+        """
+        Test that `create_knowledge_node_student` method creates 'knowledge node student' object
+        on external service, and returns it.
+        """
+        block_id = 'knowledge-node-42'
+        student_uid = 'student-42'
+        expected_knowledge_node_student = {
+            'id': 23,
+            'knowledge_node_id': 23,
+            'knowledge_node_uid': block_id,
+            'student_id': 23,
+            'student_uid': student_uid,
+        }
+        response = Mock()
+        response.content = json.dumps(expected_knowledge_node_student)
+        with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
+            patched_requests.post.return_value = response
+            knowledge_node_student = self.dummy_client.create_knowledge_node_student(block_id, student_uid)
+            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
+            patched_requests.post.assert_called_once_with(
+                self.dummy_client.knowledge_node_students_url,
+                headers=self.dummy_client.request_headers,
+                data={'knowledge_node_uid': block_id, 'student_uid': student_uid}
+            )
+
+    def test_create_event(self):
+        """
+        Test that `create_event` method creates event of appropriate type on external service,
+        and returns it.
+        """
+        knowledge_node_student_id = 42
+        knowledge_node_uid = 'knowledge-node-42'
+        student_uid = 'student-42'
+        event_type = 'DummyEventType'
+        expected_event = {
+            'id': 23,
+            'knowledge_node_student_id': knowledge_node_student_id,
+            'type': 'DummyEventType',
+            'payload': None,
+        }
+        response = Mock()
+        response.content = json.dumps(expected_event)
+        with patch.object(self.dummy_client, 'get_knowledge_node_student_id') as patched_get_id, \
+                patch('xmodule.util.adaptive_learning.requests') as patched_requests:
+            patched_get_id.return_value = knowledge_node_student_id
+            patched_requests.post.return_value = response
+            event = self.dummy_client.create_event(knowledge_node_uid, student_uid, event_type)
+            self.assertDictEqual(event, expected_event)
+            patched_get_id.assert_called_once_with(knowledge_node_uid, student_uid)
+            patched_requests.post.assert_called_once_with(
+                self.dummy_client.events_url,
+                headers=self.dummy_client.request_headers,
+                data={'knowledge_node_student_id': knowledge_node_student_id, 'event_type': event_type}
+            )
+
+    def test_generate_student_uid(self):
+        """
+        Test that `generate_student_uid` returns the same ID when called multiple times.
+        """
+        user_id = 23
+        expected_student_uid = self.dummy_client.generate_student_uid(user_id)
+        for dummy in range(5):
+            student_uid = self.dummy_client.generate_student_uid(user_id)
+            self.assertEqual(student_uid, expected_student_uid)
+
+
+@ddt.ddt
+@httpretty.activate
+class TestAdaptiveLearningAPIClient(AdaptiveLearningAPITestMixin):
+    """
+    Tests for class that handles communication with external adaptive learning service.
+
+    Note that example data only lists properties of corresponding entities (students, events, etc.)
+    that are relevant in the context of individual tests. The external service that provides
+    adaptive learning features may return additional properties for different types of entities.
+    """
 
     PENDING_REVIEWS = [
         {
@@ -155,108 +456,88 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
     ]
 
     def setUp(self):
-        self.dummy_module = DummyModule()
+        super(TestAdaptiveLearningAPIClient, self).setUp()
+        mock_course = make_mock_course()
+        self.api_client = AdaptiveLearningAPIClient(mock_course)
 
-    def test__adaptive_learning_configuration(self):
+    def test_create_read_event(self):
         """
-        Test `_adaptive_learning_configuration` property.
+        Test that `create_read_event` method creates an event of type `EventRead` on external service,
+        and returns it.
         """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        self.assertIsInstance(adaptive_learning_configuration, AdaptiveLearningConfiguration)
-        for attribute, value in ADAPTIVE_LEARNING_CONFIGURATION.items():
-            self.assertTrue(hasattr(adaptive_learning_configuration, attribute))
-            self.assertEqual(getattr(adaptive_learning_configuration, attribute), value)
-
-    def test_url_methods(self):
-        """
-        Test that `*_url` methods and properties return appropriate values.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        for url_method, expected_value in URL_METHODS.items():
-            self.assertTrue(hasattr(self.dummy_module, url_method))
-            self.assertEqual(getattr(self.dummy_module, url_method)(adaptive_learning_configuration), expected_value)
-        for url_property, expected_value in URL_PROPERTIES.items():
-            self.assertTrue(hasattr(self.dummy_module, url_property))
-            self.assertEqual(getattr(self.dummy_module, url_property), expected_value)
-
-    def test__request_headers(self):
-        """
-        Test that `_request_headers` property returns appropriate value.
-        """
-        expected_headers = {
-            'Authorization': 'Token token=this-is-not-a-test'
+        knowledge_node_uid = 'knowledge-node-42'
+        user_id = 42
+        student_uid = 'student-42'
+        expected_event = {
+            'id': 23,
+            'knowledge_node_student_id': 42,
+            'type': 'EventRead',
+            'payload': None,
         }
-        self.assertEqual(self.dummy_module._request_headers, expected_headers)
+        with patch.multiple(
+            'xmodule.util.adaptive_learning.AdaptiveLearningAPIMixin',
+            generate_student_uid=DEFAULT,
+            create_event=DEFAULT
+        ) as patched_methods:
+            patched_methods['generate_student_uid'].return_value = student_uid
+            patched_methods['create_event'].return_value = expected_event
+            event = self.api_client.create_read_event(knowledge_node_uid, user_id)
+            self.assertDictEqual(event, expected_event)
+            patched_methods['generate_student_uid'].assert_called_once_with(user_id)
+            patched_methods['create_event'].assert_called_once_with(knowledge_node_uid, student_uid, 'EventRead')
 
-    def test_make_anonymous_user_id(self):
+    @ddt.data('100', '0')
+    def test_create_result_event(self, success):
         """
-        Test that `make_anonymous_user_id` returns the same ID when called multiple times.
+        Test that `create_result_event` method creates an event of type `EventResult` on external service,
+        and returns it.
         """
-        user_id = 23
-        expected_anonymous_user_id = self.dummy_module.make_anonymous_user_id(user_id)
-        for dummy in range(5):
-            anonymous_user_id = self.dummy_module.make_anonymous_user_id(user_id)
-            self.assertEqual(anonymous_user_id, expected_anonymous_user_id)
-
-    def test__get_students(self):
-        """
-        Test that `_get_students` method returns list of all users that external service knows about.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        self.register_students(self.STUDENTS)
-        students = self.dummy_module._get_students(adaptive_learning_configuration)
-        self.assertEqual(students, self.STUDENTS)
-
-    def test__get_knowledge_node_students(self):
-        """
-        Test that `_get_students` method returns list of all users that external service knows about.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
-        knowledge_node_students = self.dummy_module._get_knowledge_node_students(adaptive_learning_configuration)
-        self.assertEqual(knowledge_node_students, self.KNOWLEDGE_NODE_STUDENTS)
-
-    def test__get_student(self):
-        """
-        Test that `_get_student` method returns appropriate information
-        if external service knows about a given student,
-        and `None` otherwise.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        self.register_students(self.STUDENTS)
-
-        # Unknown student
-        student = self.dummy_module._get_student(adaptive_learning_configuration, 'student-999')
-        self.assertIsNone(student)
-
-        # Known students
-        for expected_student in self.STUDENTS:
-            student = self.dummy_module._get_student(adaptive_learning_configuration, expected_student['uid'])
-            self.assertDictEqual(student, expected_student)
-
-    def test__get_knowledge_node_student(self):
-        """
-        Test that `_get_knowledge_node_student` method returns appropriate information
-        if 'knowledge node student' object exists on external service,
-        and `None` otherwise.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
-
-        # Unknown 'knowledge node student' object
-        knowledge_node_student = self.dummy_module._get_knowledge_node_student(
-            adaptive_learning_configuration, 'knowledge-node-999', 'student-999'
-        )
-        self.assertIsNone(knowledge_node_student)
-
-        # Known 'knowledge node student' object
-        for expected_knowledge_node_student in self.KNOWLEDGE_NODE_STUDENTS:
-            knowledge_node_student = self.dummy_module._get_knowledge_node_student(
-                adaptive_learning_configuration,
-                expected_knowledge_node_student['knowledge_node_uid'],
-                expected_knowledge_node_student['student_uid']
+        knowledge_node_uid = 'knowledge-node-42'
+        user_id = 42
+        student_uid = 'student-42'
+        expected_event = {
+            'id': 23,
+            'knowledge_node_student_id': 42,
+            'type': 'EventResult',
+            'payload': success,
+        }
+        with patch.multiple(
+            'xmodule.util.adaptive_learning.AdaptiveLearningAPIMixin',
+            generate_student_uid=DEFAULT,
+            create_event=DEFAULT
+        ) as patched_methods:
+            patched_methods['generate_student_uid'].return_value = student_uid
+            patched_methods['create_event'].return_value = expected_event
+            event = self.api_client.create_result_event(knowledge_node_uid, user_id, success)
+            self.assertDictEqual(event, expected_event)
+            patched_methods['generate_student_uid'].assert_called_once_with(user_id)
+            patched_methods['create_event'].assert_called_once_with(
+                knowledge_node_uid, student_uid, 'EventResult', payload=success
             )
-            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
+
+    def test_create_knowledge_node_students(self):
+        """
+        Test that `create_knowledge_node_students` method creates 'knowledge node student' objects
+        on external service, and returns them.
+        """
+        block_ids = [
+            knowledge_node_student['knowledge_node_uid'] for knowledge_node_student in self.KNOWLEDGE_NODE_STUDENTS
+        ]
+        user_id = 42
+        student_uid = 'student-42'
+        with patch.multiple(
+            'xmodule.util.adaptive_learning.AdaptiveLearningAPIMixin',
+            generate_student_uid=DEFAULT,
+            get_or_create_knowledge_node_student=DEFAULT
+        ) as patched_methods:
+            patched_methods['generate_student_uid'].return_value = student_uid
+            patched_methods['get_or_create_knowledge_node_student'].side_effect = self.KNOWLEDGE_NODE_STUDENTS
+            knowledge_node_students = self.api_client.create_knowledge_node_students(block_ids, user_id)
+            self.assertEqual(knowledge_node_students, self.KNOWLEDGE_NODE_STUDENTS)
+            patched_methods['generate_student_uid'].assert_called_once_with(user_id)
+            patched_methods['get_or_create_knowledge_node_student'].assert_has_calls(
+                [call(block_id, student_uid) for block_id in block_ids]
+            )
 
     def test_get_pending_reviews(self):
         """
@@ -266,318 +547,22 @@ class TestAdaptiveLearningAPIMixin(unittest.TestCase, AdaptiveLearningServiceMix
         """
         self.register_pending_reviews(self.PENDING_REVIEWS)
 
-        user_id = 'student-0'
+        user_id = 23
+        student_uid = 'student-23'
         expected_pending_reviews = self.PENDING_REVIEWS[:1]
         response = Mock()
         response.content = json.dumps(expected_pending_reviews)
-        with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
+        with patch(
+            'xmodule.util.adaptive_learning.AdaptiveLearningAPIMixin.generate_student_uid'
+        ) as patched_generate_student_uid, \
+                patch('xmodule.util.adaptive_learning.requests') as patched_requests:
+            patched_generate_student_uid.return_value = student_uid
             patched_requests.get.return_value = response
-            pending_reviews = self.dummy_module.get_pending_reviews(user_id)
+            pending_reviews = self.api_client.get_pending_reviews(user_id)
             self.assertEqual(pending_reviews, expected_pending_reviews)
+            patched_generate_student_uid.assert_called_once_with(user_id)
             patched_requests.get.assert_called_once_with(
-                self.dummy_module._pending_reviews_url,
-                headers=self.dummy_module._request_headers,
-                data={'student_uid': user_id}
-            )
-
-    def test__create_student(self):
-        """
-        Test that `_create_student` method creates student on external service, and returns it.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        url = self.dummy_module._students_url(adaptive_learning_configuration)
-        user_id = 'student-42'
-        expected_student = {
-            'id': 42,
-            'uid': user_id,
-        }
-        response = Mock()
-        response.content = json.dumps(expected_student)
-        with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
-            patched_requests.post.return_value = response
-            student = self.dummy_module._create_student(adaptive_learning_configuration, user_id)
-            self.assertDictEqual(student, expected_student)
-            patched_requests.post.assert_called_once_with(
-                url,
-                headers=self.dummy_module._request_headers,
-                data={'uid': user_id}
-            )
-
-    def test__create_knowledge_node_student(self):
-        """
-        Test that `_create_knowledge_node_student` method creates 'knowledge node student' object
-        on external service, and returns it.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        url = self.dummy_module._knowledge_node_students_url(adaptive_learning_configuration)
-        block_id = 'knowledge-node-42'
-        user_id = 'student-42'
-        expected_knowledge_node_student = {
-            'id': 23,
-            'knowledge_node_id': 23,
-            'knowledge_node_uid': block_id,
-            'student_id': 23,
-            'student_uid': user_id,
-        }
-        response = Mock()
-        response.content = json.dumps(expected_knowledge_node_student)
-        with patch('xmodule.util.adaptive_learning.requests') as patched_requests:
-            patched_requests.post.return_value = response
-            knowledge_node_student = self.dummy_module._create_knowledge_node_student(
-                adaptive_learning_configuration, block_id, user_id
-            )
-            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
-            patched_requests.post.assert_called_once_with(
-                url,
-                headers=self.dummy_module._request_headers,
-                data={'knowledge_node_uid': block_id, 'student_uid': user_id}
-            )
-
-    def test_create_knowledge_node_students(self):
-        """
-        Test that `create_knowledge_node_students` method creates 'knowledge node student' objects
-        on external service, and returns them.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        block_ids = [knowledge_node_student['id'] for knowledge_node_student in self.KNOWLEDGE_NODE_STUDENTS]
-        user_id = 'student-42'
-        with patch.object(
-                DummyModule, '_get_or_create_knowledge_node_student'
-        ) as patched__get_or_create_knowledge_node_student:
-            patched__get_or_create_knowledge_node_student.side_effect = self.KNOWLEDGE_NODE_STUDENTS
-            knowledge_node_students = self.dummy_module.create_knowledge_node_students(block_ids, user_id)
-            self.assertEqual(knowledge_node_students, self.KNOWLEDGE_NODE_STUDENTS)
-            patched__get_or_create_knowledge_node_student.assert_has_calls(
-                [call(adaptive_learning_configuration, block_id, user_id) for block_id in block_ids]
-            )
-
-    def test__create_event(self):
-        """
-        Test that `_create_event` method creates event of appropriate type on external service,
-        and returns it.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        url = self.dummy_module._events_url(adaptive_learning_configuration)
-        block_id = 'knowledge-node-42'
-        user_id = 'student-42'
-        event_type = 'DummyEventType'
-        expected_event = {
-            'id': 42,
-            'knowledge_node_student_id': 42,
-            'type': 'DummyEventType',
-            'payload': None,
-        }
-        response = Mock()
-        response.content = json.dumps(expected_event)
-        with patch.object(DummyModule, '_get_knowledge_node_student_id') as patched__get_knowledge_node_student_id, \
-             patch('xmodule.util.adaptive_learning.requests') as patched_requests:
-            patched__get_knowledge_node_student_id.return_value = 23
-            patched_requests.post.return_value = response
-            event = self.dummy_module._create_event(adaptive_learning_configuration, block_id, user_id, event_type)
-            self.assertDictEqual(event, expected_event)
-            patched__get_knowledge_node_student_id.assert_called_once_with(
-                adaptive_learning_configuration, block_id, user_id
-            )
-            patched_requests.post.assert_called_once_with(
-                url,
-                headers=self.dummy_module._request_headers,
-                data={'knowledge_node_student_id': 23, 'event_type': event_type}
-            )
-
-    def test_create_read_event(self):
-        """
-        Test that `create_read_event` method creates an event of type `EventRead` on external service,
-        and returns it.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        block_id = 'knowledge-node-42'
-        user_id = 'student-42'
-        expected_event = {
-            'id': 42,
-            'knowledge_node_student_id': 42,
-            'type': 'EventRead',
-            'payload': None,
-        }
-        with patch.object(DummyModule, '_create_event') as patched__create_event:
-            patched__create_event.return_value = expected_event
-            event = self.dummy_module.create_read_event(block_id, user_id)
-            self.assertDictEqual(event, expected_event)
-            patched__create_event.assert_called_once_with(
-                adaptive_learning_configuration, block_id, user_id, 'EventRead'
-            )
-
-    @ddt.data(
-        ('correct', '100'), ('incorrect', '0')
-    )
-    @ddt.unpack
-    def test_create_result_event(self, success, payload):
-        """
-        Test that `create_result_event` method creates an event of type `EventResult` on external service,
-        and returns it.
-        """
-        course = self.dummy_module.parent_course
-        adaptive_learning_configuration = AdaptiveLearningConfiguration(**course.adaptive_learning_configuration)
-        block_id = 'knowledge-node-42'
-        user_id = 'student-42'
-        expected_event = {
-            'id': 42,
-            'knowledge_node_student_id': 42,
-            'type': 'EventResult',
-            'payload': payload,
-        }
-        with patch.object(DummyModule, '_make_anonymous_user_id') as patched__make_anonymous_user_id, \
-             patch.object(DummyModule, '_create_event') as patched__create_event:
-            patched__make_anonymous_user_id.return_value = user_id
-            patched__create_event.return_value = expected_event
-            event = self.dummy_module.create_result_event(course, block_id, user_id, success)
-            self.assertDictEqual(event, expected_event)
-            # Assert that _create_event was called with appropriate arguments.
-            # Note that we can't use `assert_called_once_with` here.
-            # This is because `create_result_event` instantiates a new AdaptiveLearningConfiguration object,
-            # and this test has no way of obtaining a reference to this object.
-            # As a result, we can't pass the right object to `assert_called_once_with` here,
-            # and need to check the arguments "manually" instead.
-            patched__create_event.assert_called_once()
-            args, kwargs = patched__create_event.call_args
-            adaptive_learning_configuration_arg, block_id_arg, user_id_arg, event_type_arg = args
-            self.assertIsInstance(adaptive_learning_configuration_arg, AdaptiveLearningConfiguration)
-            self.assertEqual(
-                adaptive_learning_configuration_arg.url, adaptive_learning_configuration.url
-            )
-            self.assertEqual(
-                adaptive_learning_configuration_arg.api_version, adaptive_learning_configuration.api_version
-            )
-            self.assertEqual(
-                adaptive_learning_configuration_arg.instance_id, adaptive_learning_configuration.instance_id
-            )
-            self.assertEqual(
-                adaptive_learning_configuration_arg.access_token, adaptive_learning_configuration.access_token
-            )
-            self.assertEqual(block_id_arg, block_id)
-            self.assertEqual(user_id_arg, user_id)
-            self.assertEqual(event_type_arg, 'EventResult')
-            self.assertEqual(kwargs, {'payload': payload})
-
-    def test__get_or_create_student(self):
-        """
-        Test that `_get_or_create_student` method creates student on external service if it doesn't exist,
-        and returns it.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        self.register_students(self.STUDENTS)
-
-        user_id = 'student-42'
-        expected_student = {
-            'id': 42,
-            'uid': user_id,
-        }
-
-        # Student does not exist
-        with patch.object(DummyModule, '_get_student') as patched__get_student, \
-             patch.object(DummyModule, '_create_student') as patched__create_student:
-            patched__get_student.return_value = None
-            patched__create_student.return_value = expected_student
-            student = self.dummy_module._get_or_create_student(adaptive_learning_configuration, user_id)
-            self.assertDictEqual(student, expected_student)
-            patched__get_student.assert_called_once_with(adaptive_learning_configuration, user_id)
-            patched__create_student.assert_called_once_with(adaptive_learning_configuration, user_id)
-
-        # Student exists
-        with patch.object(DummyModule, '_get_student') as patched__get_student, \
-             patch.object(DummyModule, '_create_student') as patched__create_student:
-            patched__get_student.return_value = expected_student
-            patched__create_student.return_value = expected_student
-            student = self.dummy_module._get_or_create_student(adaptive_learning_configuration, user_id)
-            self.assertDictEqual(student, expected_student)
-            patched__get_student.assert_called_once_with(adaptive_learning_configuration, user_id)
-            patched__create_student.assert_not_called()
-
-    def test__get_or_create_knowledge_node_student(self):
-        """
-        Test that `_get_or_create_knowledge_node_student` method creates 'knowledge node student' object
-        on external service if it doesn't exist, and returns it.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        self.register_students(self.STUDENTS)
-        self.register_knowledge_node_students(self.KNOWLEDGE_NODE_STUDENTS)
-
-        student = self.STUDENTS[0]
-        block_id = 'knowledge-node-42'
-        user_id = student['uid']
-        expected_knowledge_node_student = {
-            'id': 23,
-            'knowledge_node_id': 23,
-            'knowledge_node_uid': block_id,
-            'student_id': 23,
-            'student_uid': user_id,
-        }
-        # Student does not exist
-        with patch.multiple(
-                DummyModule,
-                _get_or_create_student=DEFAULT,
-                _get_knowledge_node_student=DEFAULT,
-                _create_knowledge_node_student=DEFAULT
-        ) as patched_methods:
-            patched_methods['_get_or_create_student'].return_value = student
-            patched_methods['_get_knowledge_node_student'].return_value = None
-            patched_methods['_create_knowledge_node_student'].return_value = expected_knowledge_node_student
-            knowledge_node_student = self.dummy_module._get_or_create_knowledge_node_student(
-                adaptive_learning_configuration, block_id, user_id
-            )
-            self.assertDictEqual(knowledge_node_student, expected_knowledge_node_student)
-            patched_methods['_get_or_create_student'].assert_called_once_with(
-                adaptive_learning_configuration, user_id
-            )
-            patched_methods['_get_knowledge_node_student'].assert_called_once_with(
-                adaptive_learning_configuration, block_id, user_id
-            )
-            patched_methods['_create_knowledge_node_student'].assert_called_once_with(
-                adaptive_learning_configuration, block_id, user_id
-            )
-
-        # Student exists
-        with patch.multiple(
-                DummyModule,
-                _get_or_create_student=DEFAULT,
-                _get_knowledge_node_student=DEFAULT,
-                _create_knowledge_node_student=DEFAULT
-        ) as patched_methods:
-            patched_methods['_get_or_create_student'].return_value = student
-            patched_methods['_get_knowledge_node_student'].return_value = expected_knowledge_node_student
-            patched_methods['_create_knowledge_node_student'].return_value = expected_knowledge_node_student
-            student = self.dummy_module._get_or_create_knowledge_node_student(
-                adaptive_learning_configuration, block_id, user_id
-            )
-            self.assertDictEqual(student, expected_knowledge_node_student)
-            patched_methods['_get_or_create_student'].assert_called_once_with(
-                adaptive_learning_configuration, user_id
-            )
-            patched_methods['_get_knowledge_node_student'].assert_called_once_with(
-                adaptive_learning_configuration, block_id, user_id
-            )
-            patched_methods['_create_knowledge_node_student'].assert_not_called()
-
-    def test__get_knowledge_node_student_id(self):
-        """
-        Test the `_get_knowledge_node_student_id` returns ID of a given 'knowledge node student' object.
-        """
-        adaptive_learning_configuration = self.dummy_module._adaptive_learning_configuration
-        block_id = 'knowledge-node-23'
-        user_id = 'student-23'
-        knowledge_node_student = {
-            'id': 42,
-            'knowledge_node_id': 23,
-            'knowledge_node_uid': block_id,
-            'student_id': 23,
-            'student_uid': user_id
-        }
-        with patch.object(DummyModule, '_get_or_create_knowledge_node_student') as \
-             patched_get_or_create_knowledge_node_student:
-            patched_get_or_create_knowledge_node_student.return_value = knowledge_node_student
-            knowledge_node_student_id = self.dummy_module._get_knowledge_node_student_id(
-                adaptive_learning_configuration, block_id, user_id
-            )
-            self.assertEqual(knowledge_node_student_id, 42)
-            patched_get_or_create_knowledge_node_student.assert_called_once_with(
-                adaptive_learning_configuration, block_id, user_id
+                self.api_client.pending_reviews_url,
+                headers=self.api_client.request_headers,
+                data={'student_uid': student_uid}
             )

--- a/common/lib/xmodule/xmodule/util/adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/util/adaptive_learning.py
@@ -53,50 +53,12 @@ class AdaptiveLearningAPIMixin(object):
         )
 
     @lazy
-    def _adaptive_learning_url(self):
-        """
-        Return base URL for external service that provides adaptive learning features.
-
-        The base URL is a combination of the URL (url) and API version (api_version)
-        specified in the adaptive learning configuration for the parent course.
-        """
-        return self.__adaptive_learning_url(self._adaptive_learning_configuration)
-
-    @lazy
-    def _instance_url(self):
-        """
-        Return URL for requesting instance-specific data from external service
-        that provides adaptive learning features.
-        """
-        return self.__instance_url(self._adaptive_learning_configuration)
-
-    @lazy
-    def _students_url(self):
-        """
-        Return URL for requests dealing with students.
-        """
-        return self.__students_url(self._adaptive_learning_configuration)
-
-    @lazy
-    def _events_url(self):
-        """
-        Return URL for requests dealing with events.
-        """
-        return self.__events_url(self._adaptive_learning_configuration)
-
-    @lazy
-    def _knowledge_node_students_url(self):
-        """
-        Return URL for accessing 'knowledge node student' objects.
-        """
-        return self.__knowledge_node_students_url(self._adaptive_learning_configuration)
-
-    @lazy
     def _pending_reviews_url(self):
         """
         Return URL for accessing pending reviews.
         """
-        return '{base_url}/review_utils/fetch_reviews'.format(base_url=self._instance_url)
+        instance_url = self._instance_url(self._adaptive_learning_configuration)
+        return '{base_url}/review_utils/fetch_reviews'.format(base_url=instance_url)
 
     @lazy
     def _request_headers(self):
@@ -106,7 +68,7 @@ class AdaptiveLearningAPIMixin(object):
         return self.__request_headers(self._adaptive_learning_configuration)
 
     @classmethod
-    def __adaptive_learning_url(cls, adaptive_learning_configuration):
+    def _adaptive_learning_url(cls, adaptive_learning_configuration):
         """
         Return base URL for external service that provides adaptive learning features.
 
@@ -118,39 +80,39 @@ class AdaptiveLearningAPIMixin(object):
         return '{url}/{api_version}'.format(url=url, api_version=api_version)
 
     @classmethod
-    def __instance_url(cls, adaptive_learning_configuration):
+    def _instance_url(cls, adaptive_learning_configuration):
         """
         Return URL for requesting instance-specific data from external service
         that provides adaptive learning features.
         """
         instance_id = adaptive_learning_configuration.instance_id
-        adaptive_learning_url = cls.__adaptive_learning_url(adaptive_learning_configuration)
+        adaptive_learning_url = cls._adaptive_learning_url(adaptive_learning_configuration)
         return '{base_url}/instances/{instance_id}'.format(
             base_url=adaptive_learning_url, instance_id=instance_id
         )
 
     @classmethod
-    def __students_url(cls, adaptive_learning_configuration):
+    def _students_url(cls, adaptive_learning_configuration):
         """
         Return URL for requests dealing with students.
         """
-        instance_url = cls.__instance_url(adaptive_learning_configuration)
+        instance_url = cls._instance_url(adaptive_learning_configuration)
         return '{base_url}/students'.format(base_url=instance_url)
 
     @classmethod
-    def __events_url(cls, adaptive_learning_configuration):
+    def _events_url(cls, adaptive_learning_configuration):
         """
         Return URL for requests dealing with events.
         """
-        instance_url = cls.__instance_url(adaptive_learning_configuration)
+        instance_url = cls._instance_url(adaptive_learning_configuration)
         return '{base_url}/events'.format(base_url=instance_url)
 
     @classmethod
-    def __knowledge_node_students_url(cls, adaptive_learning_configuration):
+    def _knowledge_node_students_url(cls, adaptive_learning_configuration):
         """
         Return URL for accessing 'knowledge node student' objects.
         """
-        instance_url = cls.__instance_url(adaptive_learning_configuration)
+        instance_url = cls._instance_url(adaptive_learning_configuration)
         return '{base_url}/knowledge_node_students'.format(base_url=instance_url)
 
     @classmethod
@@ -221,7 +183,7 @@ class AdaptiveLearningAPIMixin(object):
         """
         Return list of all students that external service knows about.
         """
-        url = cls.__students_url(adaptive_learning_configuration)
+        url = cls._students_url(adaptive_learning_configuration)
         request_headers = cls.__request_headers(adaptive_learning_configuration)
         response = requests.get(url, headers=request_headers)
         students = json.loads(response.content)
@@ -233,7 +195,7 @@ class AdaptiveLearningAPIMixin(object):
         Create student identified by `user_id` on external service,
         and return it.
         """
-        url = cls.__students_url(adaptive_learning_configuration)
+        url = cls._students_url(adaptive_learning_configuration)
         payload = {'uid': user_id}
         request_headers = cls.__request_headers(adaptive_learning_configuration)
         response = requests.post(url, headers=request_headers, data=payload)
@@ -262,7 +224,7 @@ class AdaptiveLearningAPIMixin(object):
         """
         Return list of all 'knowledge node student' objects for this course.
         """
-        url = cls.__knowledge_node_students_url(adaptive_learning_configuration)
+        url = cls._knowledge_node_students_url(adaptive_learning_configuration)
         request_headers = cls.__request_headers(adaptive_learning_configuration)
         response = requests.get(url, headers=request_headers)
         links = json.loads(response.content)
@@ -274,7 +236,7 @@ class AdaptiveLearningAPIMixin(object):
         Create 'knowledge node student' object that links student identified by `user_id`
         to unit identified by `block_id`, and return it.
         """
-        url = cls.__knowledge_node_students_url(adaptive_learning_configuration)
+        url = cls._knowledge_node_students_url(adaptive_learning_configuration)
         request_headers = cls.__request_headers(adaptive_learning_configuration)
         payload = {'knowledge_node_uid': block_id, 'student_uid': user_id}
         response = requests.post(url, headers=request_headers, data=payload)
@@ -287,7 +249,7 @@ class AdaptiveLearningAPIMixin(object):
         Create event of type `event_type` for unit identified by `block_id` and student identified by `user_id`,
         sending any kwargs in `data` along with the default payload.
         """
-        url = cls.__events_url(adaptive_learning_configuration)
+        url = cls._events_url(adaptive_learning_configuration)
         request_headers = cls.__request_headers(adaptive_learning_configuration)
         knowledge_node_student_id = cls._get_knowledge_node_student_id(
             adaptive_learning_configuration, block_id, user_id

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -182,7 +182,7 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
             )
 
 
-class AdaptiveContentLibraryTransformerTestCase(ContentLibraryTransformerTestCase):
+class AdaptiveContentLibraryTransformerTestCase(ContentLibraryTransformerTestCase):  # pylint: disable=test-inherits-tests
     """
     AdaptiveContentLibraryTransformer Test
     """

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -617,7 +617,10 @@ TRACKING_BACKENDS = {
         'OPTIONS': {
             'name': 'tracking'
         }
-    }
+    },
+    'adaptive_learning': {
+        'ENGINE': 'track.backends.adaptive_learning.AdaptiveLearningBackend',
+    },
 }
 
 # We're already logging events, and we don't want to capture user

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         ],
         "openedx.block_structure_transformer": [
             "library_content = lms.djangoapps.course_blocks.transformers.library_content:ContentLibraryTransformer",
-            "adaptive_library_content = lms.djangoapps.course_blocks.transformers.library_content:AdaptiveContentLibraryTransformer",
+            "adaptive_library_content = lms.djangoapps.course_blocks.transformers.library_content:AdaptiveContentLibraryTransformer",  # pylint: disable=line-too-long
             "split_test = lms.djangoapps.course_blocks.transformers.split_test:SplitTestTransformer",
             "start_date = lms.djangoapps.course_blocks.transformers.start_date:StartDateTransformer",
             "user_partitions = lms.djangoapps.course_blocks.transformers.user_partitions:UserPartitionTransformer",


### PR DESCRIPTION
This PR adds logic for notifying Domoscio when a learner submits a review question.

cf. [OC-2152](https://tasks.opencraft.com/browse/OC-2152)

**Implementation**

When a learner submits a review question, ACB needs to send an `EventResult` event for the "knowledge node student" object that links the learner to the review question to Domoscio. The event must include information about the result that the learner obtained (pass/fail).

To make this possible, this PR introduces a new `TRACKING_BACKEND` called `AdaptiveLearningBackend`. Like other existing backends, the `AdaptiveLearningBackend` listens to events that the platform generates when users interact with courses. When it receives a [`problem_check` event](https://edx.readthedocs.io/projects/devdata/en/latest/internal_data_formats/tracking_logs.html#problem-check), it extracts relevant information from it and passes it to `AdaptiveLibraryContentModule`, which takes care of sending an appropriate event to Domoscio.

**Test instructions**

1. Follow instructions on the [epic](https://tasks.opencraft.com/browse/OC-2127) to set up a FUN box.

2. Switch to this branch (`adaptive-content-block`) and install the new block via

    ```sh
    pip install -r requirements/edx/local.txt
    ```

3. Create a new content library and add a few problems to it.

4. Create a new course and add `"adaptive_library_content"` to advanced modules.

5. Add an "Adaptive Content Block" that references the library created previously to a unit (optionally modifying the number of components to display to each student), and publish the unit. Do **not** access the unit in the LMS yet.

6. To be able to work with the Domoscio API, you'll need to specify a few course-level settings: In Studio, navigate to the Advanced Settings page for the course ("Paramètres" > "Paramètres avancés") and replace the default value for the "Adaptive Learning Configuration" setting with the following:

    ```json
    "url": "<see comment on internal ticket>",
    "instance_id": <see comment on internal ticket>,
    "access_token": "<see comment on internal ticket>",
    "api_version": "v1"
    ```

7. In a venv that has the `requests` library installed, create a knowledge node that corresponds to the unit you created earlier (`block_id` needs to be a 32-character hash), and review the results:

    ```python
    import requests, json
    response = requests.post("<url>/v1/instances/<instance_id>/knowledge_nodes", headers={"Authorization": "Token token=<access_token>"}, data={"knowledge_graph_id": <see comment on internal ticket>, "name": "Unit node", "uid": "<block_id of unit>"})
    json.loads(response.content)
    ```

    Then create a knowledge node for each of the problems that belong to the library you created earlier. Note that problems belonging to a content library are assigned unique block IDs for each Adaptive Content Block that references them; you'll need to use these context-specific IDs when creating corresponding knowledge nodes. Block IDs for problems are 20-character hashes.

8. Review the list of events that exist on the Domoscio test instance:

    ```python
    events = requests.get("<url>/v1/instances/<instance_id>/events", headers={"Authorization": "Token token=<access_token>"})
    json.loads(events.content)
    ```

9. Access the unit that contains the ACB in the LMS. It will display all of the child blocks belonging to the ACB. *This is just for testing purposes.* (You won't want to wait until reviews become available :)) I'll remove the [line](https://github.com/open-craft/edx-platform/pull/50/files#diff-5b223f1aa12d0cba135cf45dade27de3R555) that disables the selection logic introduced in #49 before merging this PR.

10. Review the list of events as described above. It should now contain one more event (this is a "Unit viewed" event that gets sent when accessing a unit containing an ACB in the LMS; it should reference the "knowledge node student" object linking the unit you created earlier to the student that you used to access the unit in the LMS).

11. Answer one of the review questions and submit it (click "Vérifier").

12. Review the list of events as described above. It should now contain one more event. This is the result event that notified Domoscio about the fact that you submitted a review question, and what the results were. It should reference the "knowledge node student" object linking the review question you submitted to the current user, and its `"payload"` property should be set to the value corresponding to the result you obtained for the review question (`"0"` if you got the question wrong, `"100"` if you got it right).

**Relevant tests**

Before running any of the commands listed below, remove (or comment out) the [line](https://github.com/open-craft/edx-platform/pull/50/files#diff-5b223f1aa12d0cba135cf45dade27de3R555) that disables the selection logic introduced in #49.

The commands for running relevant tests are:

```sh
paver test_system -t lms/djangoapps/course_blocks/transformers/tests/test_library_content.py --fasttest  # Didn't make changes to this file, but the tests it defines should still be passing
paver test_lib -l common/lib/xmodule/xmodule/tests/test_library_content.py
paver test_lib -l common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
paver test_system -t common/djangoapps/track/backends/tests/test_adaptive_learning.py --fasttest
```

**Reviewers**

- [ ] @e-kolpakov / @pomegranited

**Notes**

- The choice of result values that get sent to Domoscio on pass/fail (`"100"` and `"0"`, respectively) is based on information from the Domoscio API documentation. I'm just mentioning this here because I was surprised initially that the values had to be sent as strings.