### PR TITLE
Learner dashboard: Handle unknown student when displaying pending reviews

### DIFF
--- a/common/lib/xmodule/xmodule/util/adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/util/adaptive_learning.py
@@ -311,10 +311,16 @@ class AdaptiveLearningAPIClient(AdaptiveLearningAPIMixin):
     def get_pending_reviews(self, user_id):
         """
         Return pending reviews for user identified by `user_id`.
+
+        If external service does not know about user (because user is not enrolled in current course,
+        or has never interacted with adaptive learning content in current course), return an empty list.
         """
         url = self.pending_reviews_url
         student_uid = self.generate_student_uid(user_id)
         payload = {'student_uid': student_uid, 'nested': True}
         response = requests.get(url, headers=self.request_headers, data=payload)
-        pending_reviews_user = json.loads(response.content)
+        if response.content == 'No Student Found':
+            pending_reviews_user = []
+        else:
+            pending_reviews_user = json.loads(response.content)
         return pending_reviews_user


### PR DESCRIPTION
This PR extends the logic for obtaining pending reviews to handle the case where the external adaptive learning service does not know about a given student. This can happen if the student:

* is not enrolled in the course that the system is fetching pending reviews for.
* has never interacted with adaptive learning content in the course (i.e., student is enrolled in current course but has never visited a unit containing an Adaptive Content Block before).

Follows up on #51.

**Basic setup**

1. Follow instructions on the [epic](https://tasks.opencraft.com/browse/OC-2127) to set up a FUN box.

2. Switch to this branch (`fix-display-revisions`) and install the new block via

    ```sh
    pip install -r requirements/edx/local.txt
    ```

3. Create a new course.

4. To be able to work with the Domoscio API, you'll need to specify a few course-level settings: In Studio, navigate to the Advanced Settings page for the course ("Paramètres" > "Paramètres avancés") and replace the default value for the "Adaptive Learning Configuration" setting with the following:

    ```json
    "url": "<see comment on internal ticket>",
    "instance_id": <see comment on internal ticket>,
    "access_token": "<see comment on internal ticket>",
    "api_version": "v1"
    ```

**Test instructions**

1. Log in as a user who is not enrolled in the course created previously, and visit the user's dashboard. Observe that the area for displaying pending revisions says "You have no pending revisions". (It should not say: "Error fetching revisions.")

2. Enroll the user in the course created previously, and visit the dashboard again. Observe that the area for displaying pending revisions says "You have no pending revisions". (It should not say: "Error fetching revisions.")

**Relevant tests**

The commands for running relevant tests are:

```sh
paver test_lib -l common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
```

**Reviewers**

- [x] @pomegranited

**Notes**

Theoretically, it would be possible to create an entity representing a given student on the external adaptive learning service when that student visits their dashboard (and pending reviews for courses with meaningful adaptive learning configurations are computed). However, that could lead to a situation where the code would create entities for students that are not enrolled in a given course. So instead, we have the method that obtains pending reviews for a given user check the content of the response from the external service, and return an empty list if the response indicates that the external service does not know about the student.