### PR TITLE
Learner dashboard: Make sure users don't get confused by due dates that are in the past

### DIFF
--- a/lms/templates/revisions/dashboard_revision_item.underscore
+++ b/lms/templates/revisions/dashboard_revision_item.underscore
@@ -2,7 +2,7 @@
     <a href="<%- url %>">
         <%- name %>
         <% if (due_date) { %>
-            (<%= gettext("before") %> <%
+            (<%= gettext("since") %> <%
                 var d = new Date(due_date*1000),
                     fragments = [
                         d.getDate(),


### PR DESCRIPTION
The Domoscio API will only return a pending review for a given unit and user if the date that its `"next_review_at"` property specifies is in the past.

As a result, users will never see a date on a pending revision that is in the future. But up until this commit, the UI would display the due date as "before DD/MM/YYYY". This is confusing because it suggests to a user that they are constantly missing deadlines for pending revisions.

To eliminate (or at least reduce) the potential for confusion, we now interpret the due date of a pending revision as "the date that this revision became due" (instead of "the date that this revision needs to be completed by"), and display "since DD/MM/YYYY" on the dashboard.

This approach was agreed upon at our status meeting with FUN and Domoscio.

Belongs to the scope of [OC-2229](https://tasks.opencraft.com/browse/OC-2229).

**Screenshots**

![learner-dashboard](https://cloud.githubusercontent.com/assets/961441/21861439/257a7f36-d835-11e6-9c4a-57e00f481a1a.png)

**Basic setup**

1. Follow instructions on the [epic](https://tasks.opencraft.com/browse/OC-2127) to set up a FUN box.

2. Switch to this branch (`revision-list-improvement`) and install the new block via

    ```sh
    pip install -r requirements/edx/local.txt
    ```

3. Create a new content library and add a few problems to it.

4. Create a new course and add `"adaptive_library_content"` to advanced modules.

5. Add an "Adaptive Content Block" that references the library created previously to a unit (optionally modifying the number of components to display to each student), and publish the unit. Do **not** access the unit in the LMS yet.

6. To be able to work with the Domoscio API, you'll need to specify a few course-level settings: In Studio, navigate to the Advanced Settings page for the course ("Paramètres" > "Paramètres avancés") and replace the default value for the "Adaptive Learning Configuration" setting with the following:

    ```json
    "url": "<see comment on internal ticket>",
    "instance_id": <see comment on internal ticket>,
    "access_token": "<see comment on internal ticket>",
    "api_version": "v1"
    ```

7. In a venv that has the `requests` library installed, create a knowledge node that corresponds to the unit you created earlier (`block_id` needs to be a 32-character hash), and review the results:

    ```python
    import requests, json
    response = requests.post("<url>/v1/instances/<instance_id>/knowledge_nodes", headers={"Authorization": "Token token=<access_token>"}, data={"knowledge_graph_id": <see comment on internal ticket>, "name": "Unit node", "uid": "<block_id of unit>"})
    json.loads(response.content)
    ```

    Then create a knowledge node for each of the problems that belong to the library you created earlier. Note that problems belonging to a content library are assigned unique block IDs for each Adaptive Content Block that references them; you'll need to use these context-specific IDs when creating corresponding knowledge nodes. Block IDs for problems are 20-character hashes.

**Test instructions**

1. Review the list of links between students and units ("knowledge node student" objects) on the Domoscio test instance:

    ```python
    response = requests.get("<url>/v1/instances/<instance_id>/knowledge_node_students", headers={"Authorization": "Token token=<access_token>"})
    json.loads(response.content)    
    ```
2. Access the unit that contains the ACB in the LMS.

3. Review the list of "knowledge node student" objects as described above. Observe that it contains new "knowledge node student" objects, one for each knowledge node you created earlier.

4. Identify the "knowledge node student" object that links the current user to the *unit* containing the ACB. Make a note of its `"id"`. Also make a note of the `"knowledge_node_uid"` of one of the "knowledge node student" objects that link the current user to a *problem* belonging to the ACB.

5. Update the `"next_review_at"` field of the "knowledge node student" object, to force a review to become available for this object:

    ```python
    from datetime import datetime
    d = datetime(2016, 12, 24)
    # Replace <knowledge_node_student_id> with the "id" you wrote down in the previous step:
    response = requests.put("<url>/<instance_id>/knowledge_node_students/<knowledge_node_student_id>", headers={"Authorization": "Token token=<token>"}, data={"next_review_at": d.isoformat()})
    # Status should be 204
    response.status_code  
    ```

6. Temporarily change [utils.py#L35](https://github.com/open-craft/edx-platform/blob/display-revisions/common/djangoapps/adaptive_learning/utils.py#L35) to:

    ```python
    # Replace <knowledge_node_uid> with "knowledge_node_uid" you wrote down two steps back
    pending_review['review_question_uid'] or '<knowledge_node_uid>': pending_review['next_review_at']
    ```

    **Explanation**: This step is necessary because the data on the Domoscio test instance that we've been using is missing links between units and problems belonging to ACBs. (Domoscio staff are creating these links manually for the production instance; our code does not have to create them. We can't perform this step on the test instance ourselves because Domoscio has not disclosed the necessary details.) Because of this, any results returned by the API for fetching pending reviews will have the `"review_question_uid"` property set to `None`. As a result, even though we forced a review to become available in the previous step, the (unmodified) code will not find a matching block for that review in the modulestore.

7. Finally, navigate to the dashboard by clicking the name of the current user in the top right corner. Observe that the review that you forced to become available earlier is listed on the right. The name and due date for the review should be equal to the `display_name` of the corresponding problem and the date you forced for the review earlier, respectively. *The due date should be specified as "since DD/MM/YYYY", not "before DD/MM/YYYY"*. 

**Reviewers**

- [x] @pomegranited