### PR TITLE
Adaptive Content Block: Adjust payload that gets sent when notifying Domoscio about an event

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
@@ -448,7 +448,7 @@ class TestAdaptiveLearningAPIMixin(AdaptiveLearningAPITestMixin):
         expected_event = {
             'id': 23,
             'knowledge_node_student_id': knowledge_node_student_id,
-            'type': 'DummyEventType',
+            'type': event_type,
             'payload': None,
         }
         response = Mock()
@@ -463,7 +463,7 @@ class TestAdaptiveLearningAPIMixin(AdaptiveLearningAPITestMixin):
             patched_requests.post.assert_called_once_with(
                 self.dummy_client.events_url,
                 headers=self.dummy_client.request_headers,
-                data={'knowledge_node_student_id': knowledge_node_student_id, 'event_type': event_type}
+                data={'knowledge_node_student_id': knowledge_node_student_id, 'type': event_type}
             )
 
     def test_generate_student_uid(self):

--- a/common/lib/xmodule/xmodule/util/adaptive_learning.py
+++ b/common/lib/xmodule/xmodule/util/adaptive_learning.py
@@ -240,7 +240,7 @@ class AdaptiveLearningAPIMixin(object):
         knowledge_node_student_id = self.get_knowledge_node_student_id(knowledge_node_uid, student_uid)
         payload = {
             'knowledge_node_student_id': knowledge_node_student_id,
-            'event_type': event_type,
+            'type': event_type,
         }
         payload.update(data)
 


### PR DESCRIPTION
Specify event type as `"type"` instead of `"event_type"` when sending an event notification to Domoscio.

This is necessary to trigger appropriate computations when sending a result event (upon submitting answer to review question).

The changes are supposed to fix an issue where Domoscio would keep sending back a pending review for a given unit after submitting an answer to a review question.

Part of the scope of [OC-2229](https://tasks.opencraft.com/browse/OC-2229).

**Test instructions**

The commands for running relevant tests are:

```sh
paver test_lib -l common/lib/xmodule/xmodule/tests/test_util_adaptive_learning.py
```

**Notes**

The changes introduced here are based on suggestions from Domoscio staff. I applied them to the Dogwood sandbox, but haven't been able to confirm that they completely fix the issue. There is a chance that further changes to the way Domoscio behaves when receiving events will be necessary to achieve the desired behavior. Domoscio staff have been notified that the changes don't seem to fully address the issue, and asked to investigate on their end.

Update <2017-01-13 Fri>: After applying the changes from this PR to the Dogwood sandbox, the issue was still present because the Domoscio test instance was missing one or more links between knowledge nodes. With the necessary links in place, I could:

1. Force a review; go to dashboard, see it displayed.
2. Click link to go to corresponding unit; ACB displays review question.
3. Submit answer to review question.
4. Go back to dashboard; review no longer displayed.

Finally, when checking the `"next_review_at"` property of the knowledge node student that I forced a review for in the first step, I could see that it had been updated to a date in the future.

**Reviewers**

- [x] @pomegranited
