### PR TITLE
Adaptive Learning: Adjustments to learner dashboard and filtering logic for pending reviews

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -541,9 +541,8 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         }
         selections = []
         for pending_review in pending_reviews:
-            unit_id = pending_review.get('knowledge_node_uid')
             question_id = pending_review.get('review_question_uid')
-            if unit_id == self.parent_unit_id and question_id in valid_block_keys:
+            if question_id in valid_block_keys:
                 selections.append(valid_block_keys[question_id])
         return selections
 

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -4,6 +4,9 @@ Basic unit tests for LibraryContentModule
 
 Higher-level tests are in `cms/djangoapps/contentstore/tests/test_libraries.py`.
 """
+from random import choice
+from string import ascii_lowercase, digits
+
 from bson.objectid import ObjectId
 from mock import DEFAULT, Mock, patch
 
@@ -364,25 +367,30 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
     def test_get_selections_current_user(self):
         """
         Test that `get_selections_current_user` calls method for obtaining list of pending reviews
-        for current user, and returns selection appropriate for current unit and block.
+        for current user, and returns selection appropriate for current block.
         """
+        def generate_random_block_id(length):
+            """
+            Return random block ID of length `length`.
+            """
+            return ''.join(choice(ascii_lowercase + digits) for dummy in range(length))
+
         self._bind_course_module(self.lc_block)
         module = self.lc_block._xmodule  # pylint: disable=protected-access
-        parent_unit_id = module.parent_unit_id
         user_id = module.current_user_id
         children = module.children
         relevant_reviews = [
             {
-                'knowledge_node_uid': parent_unit_id,
+                'knowledge_node_uid': generate_random_block_id(32),
                 'review_question_uid': child.block_id,
 
             } for child in children
         ]
         irrelevant_reviews = [
             {
-                'knowledge_node_uid': 'knowledge-node-{n}'.format(n=n),
-                'review_question_uid': 'review-question-{n}'.format(n=n),
-            } for n in range(5)
+                'knowledge_node_uid': generate_random_block_id(32),
+                'review_question_uid': generate_random_block_id(20),
+            } for dummy in range(5)
         ]
         pending_reviews = relevant_reviews + irrelevant_reviews
         expected_selections = [(c.block_type, c.block_id) for c in children]

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -34,8 +34,7 @@
 
   .dashboard-revisions {
     margin: ($baseline*2) 0;
-    border-top: 3px solid #f72c30;
-    border-bottom: 3px solid #f72c30 !important;
+    border-top: 3px solid #0078b0;
     padding: $baseline 0;
     color: $link-color;
     li {
@@ -1457,4 +1456,3 @@ a.fade-cover{
     }
   }
 }
-

--- a/lms/templates/revisions/dashboard_revision_list.underscore
+++ b/lms/templates/revisions/dashboard_revision_list.underscore
@@ -9,8 +9,6 @@
             { num_items: totalCount },
             true
         ) %>
-    <% } else { %>
-        <%= gettext("You have no pending revisions.") %>
     <% } %>
 </span>
 <ul class="revision-list"></ul>


### PR DESCRIPTION
This PR introduces a couple of small adjustments to the code that implements adaptive learning functionality:

* The learner dashboard no longer displays any information about pending revisions if there are no pending reviews for the current user: Only a small subset of students registered with FUN will be taking the upcoming course that makes use of adaptive learning features. To avoid getting (a potentially large amount of) questions from users that are *not* taking the upcoming course, FUN decided that they do not want to show "You have no pending revisions." information on the dashboard.

* The logic for computing the list of questions to show for a given Adaptive Content Block has been modified to no longer check whether the block ID of the unit represented by the `"knowledge_node_uid"` property of a pending review matched the block ID of the parent unit of the Adaptive Content Block: This is necessary to support a use case where the external service providing adaptive learning features internally links review questions to units other than the parent unit of a given Adaptive Content Block.

Part of the scope of [OC-2251](https://tasks.opencraft.com/browse/OC-2251).

**Screenshots**

Dashboard with no pending revisions available:

![dashboard-no-revisions](https://cloud.githubusercontent.com/assets/961441/22027881/94bdd9ac-dcd5-11e6-8b38-6314bfd067da.png)

Dashboard with pending revisions:

![dashboard-revisions](https://cloud.githubusercontent.com/assets/961441/22027917/ae343a2a-dcd5-11e6-9205-7ff01ca4c14b.png)

**Test instructions**

At FUN's request, the changes introduced here have already been deployed to the Dogwood sandbox for testing. There is also a (secret) gist containing a write-up of the full workflow for testing the adaptive learning features. See [OC-2251](https://tasks.opencraft.com/browse/OC-2251) for links.

(It's not strictly necessary to complete every single step of the test instructions to verify the changes from this PR, but I think it would be useful to have someone else from our team go through the entire workflow once.)

To get the credentials for the parts of the test instructions that involve querying the Domoscio API, access the SciencesPo course (SciencesPo+05008+session01) in Studio, and check the value of the "Adaptive Learning Configuration" setting.

Note that the Domoscio database does not contain appropriate data for all sections of the SciencesPo course (SciencesPo+05008+session01). When following the test instructions, please limit your interactions with course content to the first section ("Séance 1").

**Reviewers**

- [x] @pomegranited 

**Notes**

- FUN has already signed off on the updated UI for displaying pending revisions.