### PR TITLE
Adds "Correctness Visibility" settings to subsection.

### DIFF
--- a/cms/djangoapps/contentstore/features/problem-editor.py
+++ b/cms/djangoapps/contentstore/features/problem-editor.py
@@ -13,7 +13,6 @@ MAXIMUM_ATTEMPTS = "Maximum Attempts"
 PROBLEM_WEIGHT = "Problem Weight"
 RANDOMIZATION = 'Randomization'
 SHOW_ANSWER = "Show Answer"
-SHOW_CORRECTNESS = "Show Correctness"
 SUBMITTED_MESSAGE = "Submitted Message"
 SHOW_RESET_BUTTON = "Show Reset Button"
 TIMER_BETWEEN_ATTEMPTS = "Timer Between Attempts"
@@ -105,7 +104,6 @@ def i_see_advanced_settings_with_values(step):
             [PROBLEM_WEIGHT, "", False],
             [RANDOMIZATION, "Never", False],
             [SHOW_ANSWER, "Finished", False],
-            [SHOW_CORRECTNESS, "Always", False],
             [SHOW_RESET_BUTTON, "False", False],
             [SUBMITTED_MESSAGE, "Answer received.", False],
             [TIMER_BETWEEN_ATTEMPTS, "0", False],

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1159,6 +1159,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             'explanatory_message': explanatory_message,
             'group_access': xblock.group_access,
             'user_partitions': user_partitions,
+            'show_correctness': xblock.show_correctness,
         })
 
         if xblock.category == 'sequential':

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -54,6 +54,7 @@ class CourseMetadata(object):
         'exam_review_rules',
         'hide_after_due',
         'self_paced',
+        'show_correctness',
         'chrome',
         'default_tab',
     ]

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -26,7 +26,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>

--- a/cms/templates/js/show-correctness-editor.underscore
+++ b/cms/templates/js/show-correctness-editor.underscore
@@ -1,0 +1,48 @@
+<form>
+<h3 class="modal-section-title" id="show_correctness_label"><%- gettext('Correctness Visibility') %></h3>
+<div class="modal-section-content show-correctness">
+    <ul class="list-fields list-input" role="group" aria-labelledby="show_correctness_label">
+        <li class="field-radio">
+            <label class="label">
+                <input class="input input-radio" name="show-correctness" type="radio" value="always" aria-described-by="always_show_correctness_description">
+                <%- gettext('Always show correctness') %>
+            </label>
+            <p class='field-message' id='always_show_correctness_description'>
+                <%- gettext('Learners can see whether their answers to CAPA problems are correct or incorrect immediately upon submission.') %>
+            </p>
+        </li>
+        <li class="field-radio">
+            <label class="label">
+                <input class="input input-radio" name="show-correctness" type="radio" value="never" aria-described-by="never_show_correctness_description">
+                <%- gettext('Never show correctness') %>
+            </label>
+            <p class='field-message' id='never_show_correctness_description'>
+                <%- gettext('Learners are never allowed to see whether their answers to problems are correct or incorrect.  The subsection remains included in grade calculations, but the scores to individual problems are withheld.') %>
+            </p>
+        </li>
+        <li class="field-radio">
+            <label class="label">
+                <input class="input input-radio" name="show-correctness" type="radio" value="past_due" aria-described-by="show_correctness_past_due_description">
+                <%- gettext('Show correctness when subsection is past due') %>
+            </label>
+            <p class='field-message' id='show_correctness_past_due_description'>
+                <% if (self_paced) { %>
+                    <%- gettext('Learners are not allowed to see whether their answers to problems were correct or incorrect until after the Course End Date has passed.') %>
+                <% } else { %>
+                    <%- gettext('Learners are not allowed to see whether their answers to problems were correct or incorrect until after the Grading Due Date has passed.') %>
+                <% } %>
+            </p>
+        </li>
+    </ul>
+
+    <% if (self_paced) { %>
+        <p class="tip tip-warning">
+        <%- gettext('If no Course End Date is set, then this behaves the same as "Always show correctness."') %>
+        </p>
+    <% } else { %>
+        <p class="tip tip-warning">
+        <%- gettext('If no Grading Due Date is set, then this behaves the same as "Always show correctness."') %>
+        </p>
+    <% } %>
+</div>
+</form>

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -116,19 +116,20 @@ class CapaFields(object):
     )
     show_correctness = String(
         display_name=_("Show Correctness"),
-        help=_("Defines when to show whether a learner's answer to the problem is correct."),
+        help=_("Defines when to show whether a learner's answer to the problem is correct. "
+               "Configured on the subsection.  A default value can be set in Advanced Settings."),
         scope=Scope.settings,
         default=SHOW_CORRECTNESS.ALWAYS,
         values=[
             {"display_name": _("Always"), "value": SHOW_CORRECTNESS.ALWAYS},
             {"display_name": _("Never"), "value": SHOW_CORRECTNESS.NEVER},
             {"display_name": _("Past Due"), "value": SHOW_CORRECTNESS.PAST_DUE},
-            {"display_name": _("Closed"), "value": SHOW_CORRECTNESS.CLOSED},
         ],
     )
     submitted_message = String(
         display_name=_("Submitted Message"),
-        help=_("Text to show when an answer has been submitted, but correctness is being withheld."),
+        help=_("Text to show when an answer has been submitted, but correctness is being withheld by the subsection. "
+               "A default value can be set in Advanced Settings."),
         scope=Scope.settings,
         default=_("Answer received."),
     )
@@ -733,7 +734,6 @@ class CapaMixin(CapaFields):
             'reset_button': self.should_show_reset_button(),
             'save_button': self.should_show_save_button(),
             'answer_available': self.answer_available(),
-            'show_correctness': self.correctness_available(),
             'attempts_used': self.attempts,
             'attempts_allowed': self.max_attempts,
             'demand_hint_possible': demand_hint_possible,
@@ -931,16 +931,12 @@ class CapaMixin(CapaFields):
 
         Limits access to the correct/incorrect flags, messages, and problem score.
         """
-        if self.show_correctness == '':
-            return True
-        elif self.show_correctness == SHOW_CORRECTNESS.NEVER:
+        if self.show_correctness == SHOW_CORRECTNESS.NEVER:
             return False
         elif self.runtime.user_is_staff:
             # This is after the 'never' check because admins can see correctness
             # unless the problem explicitly prevents it
             return True
-        elif self.show_correctness == SHOW_CORRECTNESS.CLOSED:
-            return self.closed()
         elif self.show_correctness == SHOW_CORRECTNESS.PAST_DUE:
             return self.is_past_due()
         elif self.show_correctness == SHOW_CORRECTNESS.ALWAYS:

--- a/common/lib/xmodule/xmodule/capa_base_constants.py
+++ b/common/lib/xmodule/xmodule/capa_base_constants.py
@@ -9,7 +9,6 @@ class SHOW_CORRECTNESS(object):  # pylint: disable=invalid-name
     Constants for when to show correctness
     """
     ALWAYS = "always"
-    CLOSED = "closed"
     PAST_DUE = "past_due"
     NEVER = "never"
 

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -216,6 +216,7 @@ class CapaDescriptor(CapaFields, RawDescriptor):
             CapaDescriptor.force_save_button,
             CapaDescriptor.markdown,
             CapaDescriptor.use_latex_compiler,
+            CapaDescriptor.show_correctness,
         ])
         return non_editable_fields
 

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -100,6 +100,26 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings,
         default="finished",
     )
+
+    show_correctness = String(
+        display_name=_("Show Correctness"),
+        help=_(
+            # Translators: DO NOT translate the words in quotes here, they are
+            # specific words for the acceptable values.
+            'Specify when to show problem correctness. '
+            'Valid values are "always", "never", and "past_due".'
+        ),
+        scope=Scope.settings,
+        default="always",
+    )
+
+    submitted_message = String(
+        display_name=_("Submitted Message"),
+        help=_("Text to show when an answer has been submitted, but Show Correctness is set to withhold correctness."),
+        scope=Scope.settings,
+        default=_("Answer received."),
+    )
+
     rerandomize = String(
         display_name=_("Randomization"),
         help=_(

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -438,49 +438,6 @@ class CapaModuleTest(unittest.TestCase):
         self.assertFalse(problem.correctness_available())
 
     @ddt.data(
-        # Correctness visible after using up all attempts, even if due date in the future
-        ({
-            'show_correctness': 'closed',
-            'max_attempts': '1',
-            'attempts': '1',
-            'due': 'tomorrow_str',
-        }, True),
-        # Correctness visible if due date in the past
-        ({
-            'show_correctness': 'closed',
-            'max_attempts': '1',
-            'attempts': '0',
-            'due': 'yesterday_str',
-        }, True),
-        # Correctness not visible if attempts left
-        ({
-            'show_correctness': 'closed',
-            'max_attempts': '1',
-            'attempts': '0',
-            'due': 'tomorrow_str',
-        }, False),
-        # Correctness not visible because grace period hasn't expired
-        ({
-            'show_correctness': 'closed',
-            'max_attempts': '1',
-            'attempts': '0',
-            'due': 'yesterday_str',
-            'graceperiod': 'two_day_delta_str',
-        }, False),
-    )
-    @ddt.unpack
-    def test_show_correctness_closed(self, problem_data, expected_result):
-        """
-        Test that correctness is visible when learner is no longer allowed to submit answers,
-        and hidden if they are.
-        """
-        problem_data['due'] = getattr(self, problem_data['due'])
-        if 'graceperiod' in problem_data:
-            problem_data['graceperiod'] = getattr(self, problem_data['graceperiod'])
-        problem = CapaFactory.create(**problem_data)
-        self.assertEqual(problem.correctness_available(), expected_result)
-
-    @ddt.data(
         # Correctness not visible if due date in the future, even after using up all attempts
         ({
             'show_correctness': 'past_due',


### PR DESCRIPTION
Adds `show_correctness` as a modulestore inherited setting.  This is editable from the sequence (subsection) XBlock.

**JIRA tickets**: [OC-2487](https://tasks.opencraft.com/browse/OC-2487)

**Discussions**: [Technical discovery document](https://docs.google.com/document/d/1yGAbIl5lZUXB_BTFDp5dx75fEypQHA7Ipg7M9PATKaw/edit)

**Dependencies**: None

**Screenshots**:

![screen shot 2017-03-29 at 4 00 00 pm](https://cloud.githubusercontent.com/assets/7556571/24439948/d2829390-1498-11e7-9e74-7362538eb449.png)

**Sandbox URLs**:

* Studio: https://studio-pr14737.sandbox.opencraft.hosting/
* LMS: https://pr14737.sandbox.opencraft.hosting/

[MIT CAPA test course](https://pr14737.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+CAPA1+2017/info) created with 
[show_correctness.course.tar.gz](https://github.com/open-craft/edx-platform/files/881752/show_correctness.course.tar.gz)

**Partner information**: 3rd party-hosted open edX instance

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: April 15th, 2017

**Testing instructions**:

1. In Studio, create a course.
1. Add a section, and a subsection.
1. Click the subsection "settings" icon to raise the settings modal.
1. Click on the "Advanced" tab.
1. Observe the new "Correctness Visibility" section, with default value "Always show correctness".
1. Select  "Show correctness when subsection is past due", and note the warning message about due dates.
1. Change the "Correctness Visibility" to change the setting, and Save.
1. Refresh the page, and observe that the selected "Correctness Visibility" is preserved.
1. Navigate to the "Advanced Settings" page, and scroll down to "Show Correctness".
1. Observe that changing this field's default changes the default "Correctness Visibility" for subsections.
1. Create a Unit, and add a CAPA problem.
1. Observe that changing the subsection's "Correctness Visibility" filters down to the CAPA problem in the subsection.
    Note: [Staff users are always be able to see correctness when "Correctness Visibility" is "Show correctness when subsection is past due"](https://github.com/open-craft/edx-platform/pull/60/files#diff-0c9995bbce7571d2d55664680e485452R934), which follows the convention of the "Show Answer" setting.
1. Edit the CAPA problem, and go to the Settings tab.  
1. Observe that "Show Correctness" is no longer configurable here, but "Submitted Message" still is.
1. Navigate to the "Advanced Settings" page, and scroll down to "Submitted Message".
1. Observe that changing this field's default changes the default "Submitted Message" for CAPA problems.
1. Export the course, and re-import.
1. Note that your selected "Correctness Visibility" and "Submitted Message" settings are preserved for all subsections and units.

To run js tests on devstack:

```bash
paver test_js_run -s cms
paver test_lib -l common/lib/xmodule
```

**Author notes and concerns**:

1. Do we need to add a visual indicator of the "show correctness" setting change on the subsection itself?  E.g., when we change Subsection Visibility, we can see a message like "Subsection is hidden after due date".  If we need this change, then we may also need an icon to show with it.
1. Had to drop `"closed"` from the list of options for hiding correctness, because it relates to the number of attempts made by a learner on a given problem, which isn't something we can determine at the subsection level.

**Reviewer**
- [x] @e-kolpakov 