### PR TITLE
Ensure correctness isn't leaked by AJAX response

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1294,6 +1294,10 @@ class CapaMixin(CapaFields):
         # render problem into HTML
         html = self.get_problem_html(encapsulate=False, submit_notification=True)
 
+        # Withhold success indicator if hiding correctness
+        if not self.correctness_available():
+            success = 'submitted'
+
         return {
             'success': success,
             'contents': html


### PR DESCRIPTION
Returns `success="submitted"` if correctness is withheld, and adds python tests.

**JIRA tickets**: [OC-2503](https://tasks.opencraft.com/browse/OC-2503)

**Discussions**: [Technical discovery document](https://docs.google.com/document/d/1yGAbIl5lZUXB_BTFDp5dx75fEypQHA7Ipg7M9PATKaw/edit)

**Dependencies**: None

**Screenshots**:

![screen shot 2017-04-03 at 8 04 31 pm](https://cloud.githubusercontent.com/assets/7556571/24605664/e1d2b24e-18a8-11e7-823a-3ff72ff6f0ad.png)

**Sandbox URL**: 

* LMS: https://pr14737.sandbox.opencraft.hosting/
* Studio: https://studio-pr14737.sandbox.opencraft.hosting/

[MIT CAPA test course](https://pr14737.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+CAPA1+2017/info) created with 
[show_correctness.course.tar.gz](https://github.com/open-craft/edx-platform/files/881752/show_correctness.course.tar.gz)

**Partner information**: 3rd party-hosted open edX instance

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: April 15th, 2017

**Testing instructions**:

1. In Studio, Import the [MIT CAPA test course](https://github.com/open-craft/edx-platform/files/881752/show_correctness.course.tar.gz).  Alternatively, just use the sandbox course.
1. In LMS, register for the course.
1. Open a Developer Console, and watch the network tab.
1. Navigate to the [Show Correctness: Always](https://pr14737.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+CAPA1+2017/courseware/1cff0102bcf44c01825640789f305221/f376ed2fc35148b9979d0da4ab07c944/) subsection.
1. Submit incorrect or correct answers to the problems in the subsection.  
1. Observe that the AJAX `problem_check` response reports `"success": "correct"` or `"success": "incorrect"` as appropriate.
1. Navigate to the [Show Correctness: Never](https://pr14737.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+CAPA1+2017/courseware/1cff0102bcf44c01825640789f305221/2b48603b26ec4d57bade4be6492caf60/) subsection, and submit incorrect or correct answers to the problems in the subsections.
1. Observe that the AJAX `problem_check` response reports only `"success": "submitted"`.
1. Navigate to the [Show Correctness: Past Due](https://pr14737.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+CAPA1+2017/courseware/1cff0102bcf44c01825640789f305221/3fbb95bc2c694ec096da855b4bc24cf2/) subsection, and note that correctness is similarly withheld.

To run new tests:

```bash
paver test_lib -l common/lib/xmodule/xmodule/
```

**Reviewers**
- [x] @e-kolpakov 