### PR TITLE
Ability to set HOMEPAGE_COURSE_MAX via SiteConfiguration.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -196,6 +196,11 @@ def index(request, extra_context=None, user=AnonymousUser()):
     # 1) Change False to True
     context['show_homepage_promo_video'] = configuration_helpers.get_value('show_homepage_promo_video', False)
 
+    # Maximum number of courses to display on the homepage.
+    context['homepage_course_max'] = configuration_helpers.get_value(
+        'HOMEPAGE_COURSE_MAX', settings.HOMEPAGE_COURSE_MAX
+    )
+
     # 2) Add your video's YouTube ID (11 chars, eg "123456789xX"), or specify via site configuration
     # Note: This value should be moved into a configuration setting and plumbed-through to the
     # context via the site configuration workflow, versus living here

--- a/lms/templates/courses_list.html
+++ b/lms/templates/courses_list.html
@@ -9,7 +9,7 @@
       <section class="courses">
         <ul class="courses-listing">
           ## limiting the course number by using HOMEPAGE_COURSE_MAX as the maximum number of courses
-          %for course in courses[:settings.HOMEPAGE_COURSE_MAX]:
+          %for course in courses[:homepage_course_max]:
           <li class="courses-listing-item">
               <%include file="course.html" args="course=course" />
           </li>
@@ -17,7 +17,7 @@
         </ul>
       </section>
     ## in case there are courses that are not shown on the homepage, a 'View all Courses' link should appear
-      % if settings.HOMEPAGE_COURSE_MAX and len(courses) > settings.HOMEPAGE_COURSE_MAX:
+      % if homepage_course_max and len(courses) > homepage_course_max:
       <div class="courses-more">
         <a class="courses-more-cta" href="${marketing_link('COURSES')}"> ${_("View all Courses")} </a>
       </div>


### PR DESCRIPTION
The setting controls the number of courses displayed on the homepage.

Cherry-picks https://github.com/edx/edx-platform/pull/15476.

**Reviewers**:

- [x] @pomegranited 