### PR TITLE
set discussion_default_topic_id in lms discussion single_thread view to prevent 500s when linked directly

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -400,6 +400,7 @@ def single_thread(request, course_key, discussion_id, thread_id):
             'course_settings': course_settings,
             'disable_courseware_js': True,
             'uses_pattern_library': True,
+            'discussion_default_topic_id': _get_discussion_default_topic_id(course),
         }
         return render_to_response('discussion/discussion_board.html', context)
 


### PR DESCRIPTION
The view that renders single discussion threads when linked to directly did not set a key in the template context that sets the default 'Add Post' topic area. This PR fixes that by imitating the correct view's method of assignment.

**JIRA tickets**: [OC-2984](https://tasks.opencraft.com/browse/OC-2984)

**Merge deadline**: None

**Testing instructions**:

1. Navigate to a forum post
2. Copy link and paste in a new browser tab
3. Without patch, server should 500 with NameError. With patch, should display the forum post.

**Reviewers**
- [ ] @smarnach 