### PR TITLE
Change the visibility warning in discussions

### DIFF
--- a/common/static/common/templates/discussion/thread-show.underscore
+++ b/common/static/common/templates/discussion/thread-show.underscore
@@ -73,7 +73,7 @@
             <% if (obj.group_name && is_commentable_divided) { %>
                 <%-
                 interpolate(
-                    gettext('This post is visible only to %(group_name)s.'),
+                    gettext('This post is visible to %(group_name)s.'),
                     {group_name: obj.group_name},
                     true
                 )


### PR DESCRIPTION
This changes the text of the visibility warning to 'This post is visible to %(group_name)s.', removing "only".

To test, ensure that on the Instructor Dashboard, Cohorts are enabled for the course.
Also on the Instructor Dashboard, under Discussion settings, discussion topics must be divided by cohort.

Once these options are set, create a test discussion topic, view the topic, and see that the warning states "This post is visible to Cohort", instead of "This post is visible to only Cohort"