### PR TITLE
Improve "empty state" for Adaptive Content Blocks

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -7,6 +7,7 @@ import logging
 import random
 from copy import copy
 from gettext import ngettext
+from django.utils.translation import ugettext as _
 
 from lazy import lazy
 from lxml import etree
@@ -553,7 +554,32 @@ class AdaptiveLibraryContentModule(AdaptiveLibraryContentFields, LibraryContentM
         # Link current user to children of this block
         self.link_current_user_to_children()
 
-        return super(AdaptiveLibraryContentModule, self).student_view(context)
+        # Renders children that are scheduled for review, or returns a message.
+        fragment = Fragment()
+        contents = []
+        child_context = {} if not context else copy(context)
+
+        for child in self._get_selected_child_blocks():
+            for displayable in child.displayable_items():
+                rendered_child = displayable.render(STUDENT_VIEW, child_context)
+                fragment.add_frag_resources(rendered_child)
+                contents.append({
+                    'id': displayable.location.to_deprecated_string(),
+                    'content': rendered_child.content,
+                })
+
+        if not contents:
+            contents.append({
+                'id': 'adaptive-learning-no-reviews-message',
+                'content': _('No questions are currently scheduled for review. Please check back later.'),
+            })
+
+        fragment.add_content(self.system.render_template('vert_module.html', {
+            'items': contents,
+            'xblock_context': context,
+            'show_bookmark_button': False,
+        }))
+        return fragment
 
     def send_unit_viewed_event(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -499,6 +499,23 @@ class AdaptiveLibraryContentModuleTestMixin(LibraryContentModuleTestMixin):
             patched_methods['send_unit_viewed_event'].assert_called_once_with()
             patched_methods['link_current_user_to_children'].assert_called_once_with()
 
+    def test_student_view_no_reviews(self):
+        """
+        Tests that when no questions are scheduled for review, a message is shown instead of blocks.
+        """
+        self._bind_course_module(self.lc_block)
+        module = self.lc_block._xmodule  # pylint: disable=protected-access
+        with patch.multiple(
+                module,
+                send_unit_viewed_event=DEFAULT,
+                link_current_user_to_children=DEFAULT,
+                _get_selected_child_blocks=DEFAULT
+        ) as patched_methods:
+            patched_methods['_get_selected_child_blocks'].return_value = []
+            context = {}
+            fragment = module.student_view(context)
+            self.assertIn('No questions are currently scheduled for review. Please check back later.', fragment.content)
+
 
 @patch('xmodule.library_tools.SearchEngine.get_search_engine', Mock(return_value=None, autospec=True))
 class TestLibraryContentModuleNoSearchIndex(LibraryContentModuleTestMixin, LibraryContentTest):


### PR DESCRIPTION
This pull requests adds a user friendly message to adaptive content blocks that do not have any reviews returned. Instead of the current functionality which displays nothing, this displays a message that says 'No questions are currently scheduled for review. Please check back later.'

**JIRA tickets**: Implements OC-3297

**Dependencies**: None

**Screenshots**:
![screenshot](https://user-images.githubusercontent.com/2694231/32294634-b3ae1c2e-bf14-11e7-8d3f-c3dbe332a702.jpg)


**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" 

**Testing instructions**:

1. Open an LMS instance
2. Navigate to a course / subsection that contains an Adaptive Content Block where no problems will show.
3. Ensure that the user friendly message is displayed.

**Author notes and concerns**:
1. None

**Reviewers**
- [ ] @itsjeyd 
- [ ] TBD