### PR TITLE
OC-3339: Cloudera Barclays students unable to view discussion posts

### DIFF
--- a/lms/static/js/ie11_find_array.js
+++ b/lms/static/js/ie11_find_array.js
@@ -1,0 +1,43 @@
+if (!Array.prototype.find) {
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+     // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      var thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      var k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        var kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return undefined.
+      return undefined;
+    }
+  });
+}

--- a/lms/static/js/ie11_find_array.js
+++ b/lms/static/js/ie11_find_array.js
@@ -1,3 +1,5 @@
+// Polyfill for patching IE11 Browsers
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Polyfill
 if (!Array.prototype.find) {
   Object.defineProperty(Array.prototype, 'find', {
     value: function(predicate) {

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -56,9 +56,11 @@ from pipeline_mako import render_require_js_path_overrides
 
   <%
     jsi18n_path = "js/i18n/{language}/djangojs.js".format(language=LANGUAGE_CODE)
+    ie11_fix_path = "js/ie11_find_array.js"
   %>
 
   <script type="text/javascript" src="${static.url(jsi18n_path)}"></script>
+  <script type="text/javascript" src="${static.url(ie11_fix_path)}"></script>
 
   <link rel="icon" type="image/x-icon" href="${static.url(static.get_value('favicon_path', settings.FAVICON_PATH))}" />
 


### PR DESCRIPTION
Fixes a bug that makes discussion posts unable to be viewed by IE11 browsers. The bug uses invalid JavaScript  when cohorts are used in the discussion.

**JIRA tickets**: OC-3339

**Dependencies**: None

**Sandbox URL**: TBD

**Merge deadline**:  ASAP

**Testing instructions**:

1. Setup a Cloudera templated site.
2. Setup a course that has [cohorts](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohort_config.html#enabling-cohorts-in-your-course).
3. Setup [divided discussions.](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/manage_discussions/set_up_divided_discussions.html#setting-up-divided-discussions)
4. On IE11 open up the created site on LMS.
5. Go to the course with cohorts and divided discussions.
6. View the discussions page. 
7. Create a new discussion.
8. Should be able to see posts on the right hand side of the screen.

**Reviewers**
- [ ] @pomegranited 

