### PR TITLE
Add course-level option to enable/disable Adaptive Learning feature.

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -14,7 +14,7 @@ from pytz import UTC
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 
-from adaptive_learning.config.models import AdaptiveLearningEnabledFlag
+from adaptive_learning.config.models import AdaptiveLearningEnabledFlag, CourseAdaptiveLearningFlag
 from contentstore.utils import reverse_course_url, reverse_usage_url
 from milestones.models import MilestoneRelationshipType
 from models.settings.course_grading import CourseGradingModel, GRADING_POLICY_CHANGED_EVENT_TYPE, hash_grading_policy
@@ -946,11 +946,15 @@ class CourseMetadataEditingTest(CourseTestCase):
     def test_allow_adaptive_learning_configuration(self):
         """
         Test that `adaptive_learning_configuration` is only shown in Advanced Settings
-        if AdaptiveLearningEnabledFlag is enabled.
+        if both AdaptiveLearningEnabledFlag and CourseAdaptiveLearningFlag are enabled.
         """
         self.assertNotIn('adaptive_learning_configuration', CourseMetadata.fetch(self.fullcourse))
         AdaptiveLearningEnabledFlag(enabled=True).save()
+        self.assertNotIn('adaptive_learning_configuration', CourseMetadata.fetch(self.fullcourse))
+        CourseAdaptiveLearningFlag.create(course_id=self.fullcourse.id, enabled=True)
         self.assertIn('adaptive_learning_configuration', CourseMetadata.fetch(self.fullcourse))
+        AdaptiveLearningEnabledFlag.objects.all().update(enabled=False)
+        self.assertNotIn('adaptive_learning_configuration', CourseMetadata.fetch(self.fullcourse))
 
     def test_validate_from_json_correct_inputs(self):
         is_valid, errors, test_model = CourseMetadata.validate_and_update_from_json(

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -62,6 +62,15 @@ class CourseMetadata(object):
         'default_tab',
     ]
 
+    # A list of tuples (field_name, enabled_function) defining fields
+    # that should or shouldn't be shown in Advanced Settings based on course-specific settings.
+    # If `enabled_function(course_id)` returns False for a field identified by `field_name`,
+    # the field won't be shown in Advanced Settings for the course identfied by `course_id`.
+    COURSE_SPECIFIC_FILTERED_LIST = [
+        ('adaptive_learning_configuration',
+         AdaptiveLearningEnabledFlag.feature_enabled),
+    ]
+
     @classmethod
     def filtered_list(cls):
         """
@@ -116,9 +125,19 @@ class CourseMetadata(object):
         if not switches.is_enabled(u'instructor_paced_only'):
             filtered_list.append('certificate_available_date')
 
-        # Do not show field for configuring Adaptive Learning if feature is disabled.
-        if not AdaptiveLearningEnabledFlag.is_enabled():
-            filtered_list.append('adaptive_learning_configuration')
+        return filtered_list
+
+    @classmethod
+    def course_specific_filtered_list(cls, course_descriptor):
+        """
+        Return list of fields that shouldn't be shown in the Advanced Settings
+        of a given course.
+        """
+        course_key = course_descriptor.location.course_key
+        filtered_list = [
+            field_name for field_name, enabled_function in cls.COURSE_SPECIFIC_FILTERED_LIST
+            if not enabled_function(course_key)
+        ]
 
         return filtered_list
 
@@ -131,7 +150,7 @@ class CourseMetadata(object):
         result = {}
         metadata = cls.fetch_all(descriptor)
         for key, value in metadata.iteritems():
-            if key in cls.filtered_list():
+            if key in cls.filtered_list() + cls.course_specific_filtered_list(descriptor):
                 continue
             result[key] = value
         return result

--- a/common/djangoapps/adaptive_learning/admin.py
+++ b/common/djangoapps/adaptive_learning/admin.py
@@ -3,8 +3,31 @@ Admin for Adaptive Learning
 """
 from django.contrib import admin
 
-from config_models.admin import ConfigurationModelAdmin
+from config_models.admin import (
+    ConfigurationModelAdmin,
+    KeyedConfigurationModelAdmin
+)
 
-from adaptive_learning.config.models import AdaptiveLearningEnabledFlag
+from adaptive_learning.config.forms import CourseAdaptiveLearningFlagForm
+from adaptive_learning.config.models import (
+    AdaptiveLearningEnabledFlag,
+    CourseAdaptiveLearningFlag
+)
+
+
+class CourseAdaptiveLearningFlagAdmin(KeyedConfigurationModelAdmin):
+    """
+    Admin for enabling Adaptive Learning feature for a course.
+    Allows searching by course id.
+    """
+    form = CourseAdaptiveLearningFlagForm
+    search_fields = ['course_id']
+    fieldsets = (
+        (None, {
+            'fields': ('course_id', 'enabled'),
+            'description': 'Enter a valid course id. If it is invalid, an error message will display.'
+        }),
+    )
 
 admin.site.register(AdaptiveLearningEnabledFlag, ConfigurationModelAdmin)
+admin.site.register(CourseAdaptiveLearningFlag, CourseAdaptiveLearningFlagAdmin)

--- a/common/djangoapps/adaptive_learning/config/forms.py
+++ b/common/djangoapps/adaptive_learning/config/forms.py
@@ -1,0 +1,40 @@
+"""
+Defines a form for providing validation.
+"""
+import logging
+
+from django import forms
+
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.locator import CourseLocator
+from xmodule.modulestore.django import modulestore
+
+from adaptive_learning.config.models import CourseAdaptiveLearningFlag
+
+log = logging.getLogger(__name__)
+
+
+class CourseAdaptiveLearningFlagForm(forms.ModelForm):
+    """
+    Input form for new AdaptiveLearning per-course enablement,
+    allowing us to verify user input.
+    """
+
+    class Meta(object):
+        model = CourseAdaptiveLearningFlag
+        fields = '__all__'
+
+    def clean_course_id(self):
+        """Validate the course id"""
+        cleaned_id = self.cleaned_data["course_id"]
+        try:
+            course_key = CourseLocator.from_string(cleaned_id)
+        except InvalidKeyError:
+            msg = u'Course id invalid. Entered course id was: "{0}."'.format(cleaned_id)
+            raise forms.ValidationError(msg)
+
+        if not modulestore().has_course(course_key):
+            msg = u'Course not found. Entered course id was: "{0}". '.format(course_key.to_deprecated_string())
+            raise forms.ValidationError(msg)
+
+        return course_key

--- a/common/djangoapps/adaptive_learning/config/models.py
+++ b/common/djangoapps/adaptive_learning/config/models.py
@@ -3,15 +3,72 @@ Provides configuration models for Adaptive Learning
 """
 
 from config_models.models import ConfigurationModel
+from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 
 class AdaptiveLearningEnabledFlag(ConfigurationModel):
     """
-    A flag that enables/disables Adaptive Learning across an entire instance.
+    A flag that enables/disables the Adaptive Learning feature across an entire instance.
+
+    Defaults to False.
     """
+
+    @classmethod
+    def feature_enabled(cls, course_id=None):
+        """
+        Looks at the currently active configuration model to determine
+        whether Adaptive Learning is available (either for an instance
+        or for a course).
+
+        If the course_id parameter is passed, it returns a boolean indicating
+        whether Adaptive Learning is available for the particular course.
+        Note that in order for Adaptive Learning to be available in a given course
+        both flags (an instance-wide flag and a course-specific one)
+        need to exist and be enabled.
+
+        If the course_id parameter is not passed, it returns a boolean
+        specyfing whether Adaptive Learning feature is available instance-wide.
+        """
+
+        if AdaptiveLearningEnabledFlag.current().enabled:
+            if course_id:
+                course_flag = (
+                    CourseAdaptiveLearningFlag.objects.filter(course_id=course_id).order_by('-change_date').first()
+                )
+                return course_flag.enabled if course_flag else False
+            else:
+                return True
+        else:
+            return False
 
     class Meta(object):
         app_label = "adaptive_learning"
 
     def __unicode__(self):
-        return u"AdaptiveLearningEnabledFlag: enabled {}".format(self.enabled)
+        current_model = AdaptiveLearningEnabledFlag.current()
+        return u"AdaptiveLearningEnabledFlag: enabled {}".format(
+            current_model.is_enabled()
+        )
+
+
+class CourseAdaptiveLearningFlag(ConfigurationModel):
+    """
+    A flag that enables Adaptive Learning for a specific course.
+    Only has an effect if the general flag above is set to True.
+    If the flag does not exist for a course, it defaults to Adaptive Learning
+    not being available for this course.
+    """
+    KEY_FIELDS = ('course_id',)
+
+    class Meta(object):
+        app_label = "adaptive_learning"
+
+    # The course that these features are attached to.
+    course_id = CourseKeyField(max_length=255, db_index=True)
+
+    def __unicode__(self):
+        not_en = "Not "
+        if self.enabled:
+            not_en = ""
+        # pylint: disable=no-member
+        return u"Course '{}': Adaptive Learning {}Enabled".format(self.course_id.to_deprecated_string(), not_en)

--- a/common/djangoapps/adaptive_learning/config/tests/test_models.py
+++ b/common/djangoapps/adaptive_learning/config/tests/test_models.py
@@ -1,0 +1,40 @@
+"""
+Tests for configuration models of Adaptive Learning
+"""
+
+import ddt
+
+from django.test import TestCase
+from opaque_keys.edx.locator import CourseLocator
+
+from adaptive_learning.config.models import AdaptiveLearningEnabledFlag
+from adaptive_learning.config.tests.utils import adaptive_learning_enabled_feature_flags
+
+
+@ddt.ddt
+class AdaptiveLearningEnabledFlagTest(TestCase):
+    """
+    Tests the behaviour of the feature flags for Adaptive Learning
+    which are set in Django Admin settings.
+    """
+
+    def setUp(self):
+        super(AdaptiveLearningEnabledFlagTest, self).setUp()
+        self.course_id = CourseLocator(org="edx", course="course", run="run")
+
+    @ddt.data(
+        (False, False, False),
+        (True, False, False),
+        (False, True, False),
+        (True, True, True)
+    )
+    @ddt.unpack
+    def test_feature_enabled(
+        self, global_enabled_flag, course_enabled_flag, feature_enabled_for_course
+    ):
+        with adaptive_learning_enabled_feature_flags(
+            global_enabled_flag, self.course_id, course_enabled_flag
+        ):
+            self.assertEqual(
+                AdaptiveLearningEnabledFlag.feature_enabled(self.course_id), feature_enabled_for_course
+            )

--- a/common/djangoapps/adaptive_learning/config/tests/utils.py
+++ b/common/djangoapps/adaptive_learning/config/tests/utils.py
@@ -1,0 +1,30 @@
+"""
+Provides helper functions for tests which need
+to configure flags related to Adaptive Learning.
+"""
+from contextlib import contextmanager
+
+from adaptive_learning.config.models import (
+    AdaptiveLearningEnabledFlag,
+    CourseAdaptiveLearningFlag
+)
+from request_cache.middleware import RequestCache
+
+
+@contextmanager
+def adaptive_learning_enabled_feature_flags(
+    global_flag,
+    course_id=None,
+    enabled_for_course=False
+):
+    """
+    Sets the global setting and the course-specific
+    setting (if the course_id is given) for Adaptive Learning.
+    """
+    RequestCache.clear_request_cache()
+    AdaptiveLearningEnabledFlag.objects.create(enabled=global_flag)
+    if course_id:
+        CourseAdaptiveLearningFlag.objects.create(
+            course_id=course_id, enabled=enabled_for_course
+        )
+    yield

--- a/common/djangoapps/adaptive_learning/migrations/0002_courseadaptivelearningflag.py
+++ b/common/djangoapps/adaptive_learning/migrations/0002_courseadaptivelearningflag.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations, models
+from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('adaptive_learning', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CourseAdaptiveLearningFlag',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
+                ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
+                ('course_id', CourseKeyField(max_length=255, db_index=True)),
+                ('changed_by', models.ForeignKey(on_delete=models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
+            ],
+        ),
+    ]

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -17,7 +17,7 @@ from adaptive_learning.config.models import AdaptiveLearningEnabledFlag
 <%
   cert_name_short = settings.CERT_NAME_SHORT
   cert_name_long = settings.CERT_NAME_LONG
-  adaptive_learning_enabled = AdaptiveLearningEnabledFlag.current().enabled
+  adaptive_learning_enabled = AdaptiveLearningEnabledFlag.current().feature_enabled()
 %>
 
 


### PR DESCRIPTION
This PR adds course-level option to enable/disable Adaptive Learning feature through Django Admin panel. Adaptive Learning can be enabled by setting a global and an individual (per-course) flag.

**JIRA tickets**: Implements OC-3299.

**Dependencies:** None

**Author notes and concerns:** Database change has occurred. Added a new model `CourseAdaptiveLearningFlag`.

**Testing instructions**:

1. Run tests.
2. Go to Django Admin panel and play with values of adaptive learning flags. After changing the values, go to Course Advanced Settings in Studio (e.g. [localhost:18010/settings/advanced/course-v1:edX+DemoX+Demo_Course]()) and see whether Adaptive Learning section is present. It should be present only if both global and individual (per-course) flags are set to True.

**Reviewers**:
- [ ] @itsjeyd 


Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>