### PR TITLE
Adds "all_sources" to Mobile API and Course Blocks API video data

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -239,6 +239,11 @@ FEATURES = {
     # Show the language selector in the header
     'SHOW_HEADER_LANGUAGE_SELECTOR': False,
 
+    # At edX it's safe to assume that English transcripts are always available
+    # This is not the case for all installations.
+    # The default value in {lms,cms}/envs/common.py and xmodule/tests/test_video.py should be consistent.
+    'FALLBACK_TO_ENGLISH_TRANSCRIPTS': True,
+
     # Set this to False to facilitate cleaning up invalid xml from your modulestore.
     'ENABLE_XBLOCK_XML_VALIDATION': True,
 

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -790,67 +790,44 @@ class VideoExportTestCase(VideoDescriptorTestBase):
 
 
 @ddt.ddt
+@patch.object(settings, 'YOUTUBE', create=True, new={
+    # YouTube JavaScript API
+    'API': 'www.youtube.com/iframe_api',
+
+    # URL to get YouTube metadata
+    'METADATA_URL': 'www.googleapis.com/youtube/v3/videos/',
+
+    # Current youtube api for requesting transcripts.
+    # For example: http://video.google.com/timedtext?lang=en&v=j_jEn79vS3g.
+    'TEXT_API': {
+        'url': 'video.google.com/timedtext',
+        'params': {
+            'lang': 'en',
+            'v': 'set_youtube_id_of_11_symbols_here',
+        },
+    },
+})
+@patch.object(settings, 'CONTENTSTORE', create=True, new={
+    'ENGINE': 'xmodule.contentstore.mongo.MongoContentStore',
+    'DOC_STORE_CONFIG': {
+        'host': 'edx.devstack.mongo' if 'BOK_CHOY_HOSTNAME' in os.environ else 'localhost',
+        'db': 'test_xcontent_%s' % uuid4().hex,
+    },
+    # allow for additional options that can be keyed on a name, e.g. 'trashcan'
+    'ADDITIONAL_OPTIONS': {
+        'trashcan': {
+            'bucket': 'trash_fs'
+        }
+    }
+})
+@patch.object(settings, 'FEATURES', create=True, new={
+    # The default value in {lms,cms}/envs/common.py and xmodule/tests/test_video.py should be consistent.
+    'FALLBACK_TO_ENGLISH_TRANSCRIPTS': True,
+})
 class VideoDescriptorIndexingTestCase(unittest.TestCase):
     """
     Make sure that VideoDescriptor can format data for indexing as expected.
     """
-    def setUp(self):
-        """
-        Overrides YOUTUBE and CONTENTSTORE settings
-        """
-        super(VideoDescriptorIndexingTestCase, self).setUp()
-        self.youtube_setting = getattr(settings, "YOUTUBE", None)
-        self.contentstore_setting = getattr(settings, "CONTENTSTORE", None)
-        settings.YOUTUBE = {
-            # YouTube JavaScript API
-            'API': 'www.youtube.com/iframe_api',
-
-            # URL to get YouTube metadata
-            'METADATA_URL': 'www.googleapis.com/youtube/v3/videos/',
-
-            # Current youtube api for requesting transcripts.
-            # For example: http://video.google.com/timedtext?lang=en&v=j_jEn79vS3g.
-            'TEXT_API': {
-                'url': 'video.google.com/timedtext',
-                'params': {
-                    'lang': 'en',
-                    'v': 'set_youtube_id_of_11_symbols_here',
-                },
-            },
-        }
-
-        settings.CONTENTSTORE = {
-            'ENGINE': 'xmodule.contentstore.mongo.MongoContentStore',
-            'DOC_STORE_CONFIG': {
-                'host': 'edx.devstack.mongo' if 'BOK_CHOY_HOSTNAME' in os.environ else 'localhost',
-                'db': 'test_xcontent_%s' % uuid4().hex,
-            },
-            # allow for additional options that can be keyed on a name, e.g. 'trashcan'
-            'ADDITIONAL_OPTIONS': {
-                'trashcan': {
-                    'bucket': 'trash_fs'
-                }
-            }
-        }
-
-        self.addCleanup(self.cleanup)
-
-    def cleanup(self):
-        """
-        Returns YOUTUBE and CONTENTSTORE settings to a default value
-        """
-        if self.youtube_setting:
-            settings.YOUTUBE = self.youtube_setting
-            self.youtube_setting = None
-        else:
-            del settings.YOUTUBE
-
-        if self.contentstore_setting:
-            settings.CONTENTSTORE = self.contentstore_setting
-            self.contentstore_setting = None
-        else:
-            del settings.CONTENTSTORE
-
     def test_video_with_no_subs_index_dictionary(self):
         """
         Test index dictionary of a video module without subtitles.
@@ -991,7 +968,7 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
         '''
 
         descriptor = instantiate_descriptor(data=xml_data_transcripts)
-        translations = descriptor.available_translations(descriptor.get_transcripts_info(), verify_assets=False)
+        translations = descriptor.available_translations(descriptor.get_transcripts_info())
         self.assertEqual(translations, ['hr', 'ge'])
 
     def test_video_with_no_transcripts_translation_retrieval(self):
@@ -1001,8 +978,14 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
         does not throw an exception.
         """
         descriptor = instantiate_descriptor(data=None)
-        translations = descriptor.available_translations(descriptor.get_transcripts_info(), verify_assets=False)
-        self.assertEqual(translations, ['en'])
+        translations_with_fallback = descriptor.available_translations(descriptor.get_transcripts_info())
+        self.assertEqual(translations_with_fallback, ['en'])
+
+        with patch.dict(settings.FEATURES, FALLBACK_TO_ENGLISH_TRANSCRIPTS=False):
+            # Some organizations don't have English transcripts for all videos
+            # This feature makes it configurable
+            translations_no_fallback = descriptor.available_translations(descriptor.get_transcripts_info())
+            self.assertEqual(translations_no_fallback, [])
 
     @override_settings(ALL_LANGUAGES=ALL_LANGUAGES)
     def test_video_with_language_do_not_have_transcripts_translation(self):

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -790,6 +790,58 @@ class VideoExportTestCase(VideoDescriptorTestBase):
 
 
 @ddt.ddt
+@patch.object(settings, 'FEATURES', create=True, new={
+    'FALLBACK_TO_ENGLISH_TRANSCRIPTS': False,
+})
+class VideoDescriptorStudentViewDataTestCase(unittest.TestCase):
+    """
+    Make sure that VideoDescriptor returns the expected student_view_data.
+    """
+
+    VIDEO_URL_1 = 'http://www.example.com/source_low.mp4'
+    VIDEO_URL_2 = 'http://www.example.com/source_med.mp4'
+    VIDEO_URL_3 = 'http://www.example.com/source_high.mp4'
+
+    @ddt.data(
+        # Ensure no extra data is returned if video module configured only for web display.
+        (dict(only_on_web=True), dict(only_on_web=True)),
+        # Ensure that the deprecated `source` attribute is included in the `all_sources` list.
+        (
+            dict(only_on_web=False, youtube_id_1_0=None, source=VIDEO_URL_1),
+            dict(only_on_web=False, duration=None, transcripts={},
+                 encoded_videos=dict(fallback=dict(url=VIDEO_URL_1, file_size=0)),
+                 all_sources=[VIDEO_URL_1]),
+        ),
+        # Ensure that `html5_sources` take precendence over deprecated `source` url
+        (
+            dict(only_on_web=False, youtube_id_1_0=None, source=VIDEO_URL_1, html5_sources=[VIDEO_URL_2, VIDEO_URL_3]),
+            dict(only_on_web=False, duration=None, transcripts={},
+                 encoded_videos=dict(fallback=dict(url=VIDEO_URL_2, file_size=0)),
+                 all_sources=[VIDEO_URL_2, VIDEO_URL_3, VIDEO_URL_1]),
+        ),
+        # Ensure that YouTube URLs are included in `encoded_videos`, but not `all_sources`.
+        (
+            dict(only_on_web=False, youtube_id_1_0='abc', html5_sources=[VIDEO_URL_2, VIDEO_URL_3]),
+            dict(only_on_web=False, duration=None, transcripts={},
+                 encoded_videos=dict(fallback=dict(url=VIDEO_URL_2, file_size=0),
+                                     youtube=dict(url='https://www.youtube.com/watch?v=abc', file_size=0)),
+                 all_sources=[VIDEO_URL_2, VIDEO_URL_3]),
+        ),
+    )
+    @ddt.unpack
+    @patch('xmodule.video_module.video_module.is_val_transcript_feature_enabled_for_course')
+    def test_student_view_data(self, field_data, expected_student_view_data, mock_transcript_feature):
+        """
+        Ensure that student_view_data returns the expected results for video modules.
+        """
+        mock_transcript_feature.return_value = False
+        descriptor = instantiate_descriptor(**field_data)
+        descriptor.runtime.course_id = MagicMock()
+        student_view_data = descriptor.student_view_data()
+        self.assertEquals(student_view_data, expected_student_view_data)
+
+
+@ddt.ddt
 @patch.object(settings, 'YOUTUBE', create=True, new={
     # YouTube JavaScript API
     'API': 'www.youtube.com/iframe_api',

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -18,7 +18,7 @@ import datetime
 from uuid import uuid4
 
 from lxml import etree
-from mock import ANY, Mock, patch
+from mock import ANY, Mock, patch, MagicMock
 import ddt
 
 from django.conf import settings
@@ -829,14 +829,11 @@ class VideoDescriptorStudentViewDataTestCase(unittest.TestCase):
         ),
     )
     @ddt.unpack
-    @patch('xmodule.video_module.video_module.is_val_transcript_feature_enabled_for_course')
-    def test_student_view_data(self, field_data, expected_student_view_data, mock_transcript_feature):
+    def test_student_view_data(self, field_data, expected_student_view_data):
         """
         Ensure that student_view_data returns the expected results for video modules.
         """
-        mock_transcript_feature.return_value = False
         descriptor = instantiate_descriptor(**field_data)
-        descriptor.runtime.course_id = MagicMock()
         student_view_data = descriptor.student_view_data()
         self.assertEquals(student_view_data, expected_student_view_data)
 

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -2,6 +2,7 @@
 Utility functions for transcripts.
 ++++++++++++++++++++++++++++++++++
 """
+from django.conf import settings
 import os
 import copy
 import json
@@ -556,7 +557,7 @@ class VideoTranscriptsMixin(object):
     This is necessary for both VideoModule and VideoDescriptor.
     """
 
-    def available_translations(self, transcripts, verify_assets=True):
+    def available_translations(self, transcripts, verify_assets=None):
         """Return a list of language codes for which we have transcripts.
 
         Args:
@@ -566,13 +567,16 @@ class VideoTranscriptsMixin(object):
                 we might do this is to avoid slamming contentstore() with queries
                 when trying to make a listing of videos and their languages.
 
-                Defaults to True.
+                Defaults to `not FALLBACK_TO_ENGLISH_TRANSCRIPTS`.
 
             transcripts (dict): A dict with all transcripts and a sub.
 
                 Defaults to False
         """
         translations = []
+        if verify_assets is None:
+            verify_assets = not settings.FEATURES.get('FALLBACK_TO_ENGLISH_TRANSCRIPTS')
+
         sub, other_langs = transcripts["sub"], transcripts["transcripts"]
 
         # If we're not verifying the assets, we just trust our field values

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -276,7 +276,7 @@ class VideoStudentViewHandlers(object):
 
         elif dispatch.startswith('available_translations'):
 
-            available_translations = self.available_translations(transcripts)
+            available_translations = self.available_translations(transcripts, verify_assets=True)
             if available_translations:
                 response = Response(json.dumps(available_translations))
                 response.content_type = 'application/json'

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -932,6 +932,11 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
 
         encoded_videos = {}
         val_video_data = {}
+        all_sources = self.html5_sources or []
+
+        # `source` is a deprecated field, but we include it for backwards compatibility.
+        if self.source:
+            all_sources.append(self.source)
 
         # Check in VAL data first if edx_video_id exists
         if self.edx_video_id:
@@ -963,10 +968,9 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
 
         # Fall back to other video URLs in the video module if not found in VAL
         if not encoded_videos:
-            video_url = self.html5_sources[0] if self.html5_sources else self.source
-            if video_url:
+            if all_sources:
                 encoded_videos["fallback"] = {
-                    "url": video_url,
+                    "url": all_sources[0],
                     "file_size": 0,  # File size is unknown for fallback URLs
                 }
 
@@ -989,4 +993,5 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
             "duration": val_video_data.get('duration', None),
             "transcripts": transcripts,
             "encoded_videos": encoded_videos,
+            "all_sources": all_sources,
         }

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -981,7 +981,7 @@ class VideoDescriptor(VideoFields, VideoTranscriptsMixin, VideoStudioViewHandler
         transcripts_info = self.get_transcripts_info()
         transcripts = {
             lang: self.runtime.handler_url(self, 'transcript', 'download', query="lang=" + lang, thirdparty=True)
-            for lang in self.available_translations(transcripts_info, verify_assets=False)
+            for lang in self.available_translations(transcripts_info)
         }
 
         return {

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1291,6 +1291,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
                     "fallback": {"url": self.TEST_SOURCE_URL, "file_size": 0},
                     "youtube": {"url": self.TEST_YOUTUBE_EXPECTED_URL, "file_size": 0}
                 },
+                "all_sources": [self.TEST_SOURCE_URL],
             }
         )
 
@@ -1305,6 +1306,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
                 "duration": None,
                 "transcripts": {self.TEST_LANGUAGE: self.transcript_url},
                 "encoded_videos": {"youtube": {"url": self.TEST_YOUTUBE_EXPECTED_URL, "file_size": 0}},
+                "all_sources": [],
             }
         )
 
@@ -1322,6 +1324,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
                 "only_on_web": False,
                 "duration": self.TEST_DURATION,
                 "transcripts": {self.TEST_LANGUAGE: self.transcript_url},
+                'all_sources': [self.TEST_SOURCE_URL],
             }
         )
 

--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -209,7 +209,7 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
 
     # Transcripts...
     transcripts_info = video_descriptor.get_transcripts_info()
-    transcript_langs = video_descriptor.available_translations(transcripts_info, verify_assets=False)
+    transcript_langs = video_descriptor.available_translations(transcripts_info)
 
     transcripts = {
         lang: reverse(

--- a/lms/djangoapps/mobile_api/video_outlines/serializers.py
+++ b/lms/djangoapps/mobile_api/video_outlines/serializers.py
@@ -171,6 +171,8 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
         "only_on_web": video_descriptor.only_on_web,
     }
 
+    all_sources = []
+
     if video_descriptor.only_on_web:
         ret = {
             "video_url": None,
@@ -179,6 +181,7 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
             "size": 0,
             "transcripts": {},
             "language": None,
+            "all_sources": all_sources,
         }
         ret.update(always_available_data)
         return ret
@@ -195,13 +198,18 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
             if default_encoded_video:
                 break
 
+    video_url = None
     if default_encoded_video:
         video_url = default_encoded_video['url']
     # Then fall back to VideoDescriptor fields for video URLs
     elif video_descriptor.html5_sources:
         video_url = video_descriptor.html5_sources[0]
+        all_sources = video_descriptor.html5_sources
     else:
         video_url = video_descriptor.source
+
+    if video_descriptor.source:
+        all_sources.append(video_descriptor.source)
 
     # Get duration/size, else default
     duration = video_data.get('duration', None)
@@ -231,7 +239,8 @@ def video_summary(video_profiles, course_id, video_descriptor, request, local_ca
         "size": size,
         "transcripts": transcripts,
         "language": video_descriptor.get_default_transcript_language(transcripts_info),
-        "encoded_videos": video_data.get('profiles')
+        "encoded_videos": video_data.get('profiles'),
+        "all_sources": all_sources,
     }
     ret.update(always_available_data)
     return ret

--- a/lms/djangoapps/mobile_api/video_outlines/tests.py
+++ b/lms/djangoapps/mobile_api/video_outlines/tests.py
@@ -64,6 +64,7 @@ class TestVideoAPITestCase(MobileAPITestCase):
         self.edx_video_id = 'testing-123'
         self.video_url = 'http://val.edx.org/val/video.mp4'
         self.video_url_high = 'http://val.edx.org/val/video_high.mp4'
+        self.video_url_low = 'http://val.edx.org/val/video_low.mp4'
         self.youtube_url = 'http://val.edx.org/val/youtube.mp4'
         self.html5_video_url = 'http://video.edx.org/html5/video.mp4'
 
@@ -459,7 +460,7 @@ class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCour
         self.assertEqual(course_outline[0]["summary"]["category"], "video")
         self.assertTrue(course_outline[0]["summary"]["only_on_web"])
 
-    def test_mobile_api_config(self):
+    def test_mobile_api_video_profiles(self):
         """
         Tests VideoSummaryList with different MobileApiConfig video_profiles
         """
@@ -494,6 +495,7 @@ class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCour
         )
 
         expected_output = {
+            'all_sources': [],
             'category': u'video',
             'video_thumbnail_url': None,
             'language': u'en',
@@ -555,6 +557,39 @@ class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCour
         }
 
         course_outline[0]['summary'].pop("id")
+        self.assertEqual(course_outline[0]['summary'], expected_output)
+
+    def test_mobile_api_html5_sources(self):
+        """
+        Tests VideoSummaryList without the video pipeline, using fallback HTML5 video URLs
+        """
+        self.login_and_enroll()
+        descriptor = ItemFactory.create(
+            parent=self.other_unit,
+            category="video",
+            display_name=u"testing html5 sources",
+            edx_video_id=None,
+            source=self.video_url_high,
+            html5_sources=[self.video_url_low],
+        )
+        expected_output = {
+            'all_sources': [self.video_url_low, self.video_url_high],
+            'category': u'video',
+            'video_thumbnail_url': None,
+            'language': u'en',
+            'id': unicode(descriptor.scope_ids.usage_id),
+            'name': u'testing html5 sources',
+            'video_url': self.video_url_low,
+            'duration': None,
+            'transcripts': {
+                'en': 'http://testserver/api/mobile/v0.5/video_outlines/transcripts/{}/testing_html5_sources/en'.format(self.course.id)  # pylint: disable=line-too-long
+            },
+            'only_on_web': False,
+            'encoded_videos': None,
+            'size': 0,
+        }
+
+        course_outline = self.api_response().data
         self.assertEqual(course_outline[0]['summary'], expected_output)
 
     def test_video_not_in_val(self):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -346,6 +346,11 @@ FEATURES = {
     # Show the language selector in the header
     'SHOW_HEADER_LANGUAGE_SELECTOR': False,
 
+    # At edX it's safe to assume that English transcripts are always available
+    # This is not the case for all installations.
+    # The default value in {lms,cms}/envs/common.py and xmodule/tests/test_video.py should be consistent.
+    'FALLBACK_TO_ENGLISH_TRANSCRIPTS': True,
+
     # Show the language selector in the footer
     'SHOW_FOOTER_LANGUAGE_SELECTOR': False,
 


### PR DESCRIPTION
Cherry-picks changes from https://github.com/edx/edx-platform/pull/16590 into Cloudera's release branch.

Also includes https://github.com/edx/edx-platform/pull/15475, because it fixes a bug with mobile videos that don't have transcripts, and removes merge conflicts with the `all_sources` change above.

25680f1 fixes tests broken because of differences between `master` and `ginkgo.1`.

**Settings**
```yaml
edx_ansible_source_repo: https://github.com/open-craft/configuration
configuration_version: opencraft-release/ginkgo.1-cloudera
openedx_release: open-release/ginkgo.1
EDXAPP_FEATURES:
  ENABLE_MOBILE_REST_API: true
```