### PR TITLE
Install chem nltk from edX fork, and fix django-wiki dependency. Pearson.

### DIFF
--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -10,4 +10,7 @@ setup(
         "scipy==0.14.0",
         "nltk==2.0.6",
     ],
+    dependency_links=[
+        "git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6",
+    ],
 )


### PR DESCRIPTION
Two changes:
- Because nltk==2.0.6 [has disappeared](https://pypi.python.org/pypi/nltk/2.0.6) (compare [2.0.5](https://pypi.python.org/pypi/nltk/2.0.5)), we use edX's fork for "chem"
- Because django-wiki didn't mention an upper Django version, 2.0 was used and crashed, so we prefer to keep it <2.0

**JIRA tickets**: None.

**Discussions**: See https://github.com/open-craft/edx-platform/pull/79

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD

**Partner information**: None

**Deployment targets**: Ocim prod.

**Merge deadline**: ASAP after provision is finished and after approval.

**Testing instructions**:

Same as https://github.com/open-craft/edx-platform/pull/79

**Author notes and concerns**:
None

**Reviewers**
- [x] @itsjeyd 

**Settings**
```yaml
```
