### PR TITLE
[WIP] Downgrade chem to nltk 2.0.5, after 2.0.6 disappeared from PyPi

### DIFF
--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -8,6 +8,6 @@ setup(
         "pyparsing==2.0.7",
         "numpy==1.6.2",
         "scipy==0.14.0",
-        "nltk==2.0.6",
+        "nltk==2.0.5",
     ],
 )

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,7 @@
 
 # Third-party:
 git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.10#egg=django-wiki==0.0.10
+git+https://github.com/open-craft/django-wiki.git@jill/fix-django-install-requires#egg=django-wiki==0.0.10
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
Because nltk==2.0.6 [has disappeared](https://pypi.python.org/pypi/nltk/2.0.6) (compare [2.0.5](https://pypi.python.org/pypi/nltk/2.0.5)), we use a previous difference. This is an experiment to see whether 2.0.5 also would work. 2.0.6 was done [to remove „distribute“](https://github.com/edx/nltk/commit/6e96d805c57ee4ca1deb72bb069bfb0473d493e1) 

Temporarily it includes also a fix from https://github.com/open-craft/edx-platform/pull/83, to be able to deploy.

**JIRA tickets**: None.

**Discussions**: We're trying this to see if the instance spawned by this PR provisions correctly, without errors. See URL below

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: https://stage.console.opencraft.com/instance/1530/edx-appserver/392/

**Partner information**: None

**Deployment targets**: Ocim prod.

**Merge deadline**: ASAP after provision is finished and after approval.

**Testing instructions**:

1. Wait for correct provision
2. Check log
3. Test instance
4. Merge

**Author notes and concerns**:
See in https://tasks.opencraft.com/browse/OC-3446
eCommerce still untested.

**Reviewers**
- [ ] @itsjeyd 

**Settings**
```yaml
```
