### PR TITLE
[WIP] Comment out nltk==2.0.6 dependency

### DIFF
--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -8,6 +8,10 @@ setup(
         "pyparsing==2.0.7",
         "numpy==1.6.2",
         "scipy==0.14.0",
-        "nltk==2.0.6",
+        # Temporarily we comment this dependency, because it's not found in PyPi anymore, and we cannot
+        # get it from an external repository.
+        # nltk==2.0.6 is already required by requirements/edx/github.txt, that means that it will still
+        # work as long as we run 'chem' after installing edx requirements.
+        #"nltk==2.0.6",
     ],
 )

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -212,7 +212,6 @@ if ENV_TOKENS.get('SESSION_COOKIE_NAME', None):
     # NOTE, there's a bug in Django (http://bugs.python.org/issue18012) which necessitates this being a str()
     SESSION_COOKIE_NAME = str(ENV_TOKENS.get('SESSION_COOKIE_NAME'))
 
-BOOK_URL = ENV_TOKENS['BOOK_URL']
 LOG_DIR = ENV_TOKENS['LOG_DIR']
 
 CACHES = ENV_TOKENS['CACHES']

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -1,7 +1,6 @@
 {
     "ANALYTICS_SERVER_URL": "",
     "ANALYTICS_DASHBOARD_URL": "",
-    "BOOK_URL": "",
     "BUGS_EMAIL": "bugs@example.com",
     "BULK_EMAIL_DEFAULT_FROM_EMAIL": "no-reply@example.com",
     "CACHES": {

--- a/lms/envs/bok_choy_docker.env.json
+++ b/lms/envs/bok_choy_docker.env.json
@@ -1,7 +1,6 @@
 {
     "ANALYTICS_SERVER_URL": "",
     "ANALYTICS_DASHBOARD_URL": "",
-    "BOOK_URL": "",
     "BUGS_EMAIL": "bugs@example.com",
     "BULK_EMAIL_DEFAULT_FROM_EMAIL": "no-reply@example.com",
     "CACHES": {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -590,11 +590,6 @@ AUTHENTICATION_BACKENDS = (
 STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
-# Dev machines shouldn't need the book
-# BOOK_URL = '/static/book/'
-BOOK_URL = 'https://mitxstatic.s3.amazonaws.com/book_images/'  # For AWS deploys
-RSS_TIMEOUT = 600
-
 # Configuration option for when we want to grab server error pages
 STATIC_GRAB = False
 DEV_CONTENT = True

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,7 @@
 
 # Third-party:
 git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.10#egg=django-wiki==0.0.10
+git+https://github.com/open-craft/django-wiki.git@jill/fix-django-install-requires#egg=django-wiki==0.0.10
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
Because nltk==2.0.6 [has disappeared](https://pypi.python.org/pypi/nltk/2.0.6) (compare [2.0.5](https://pypi.python.org/pypi/nltk/2.0.5)), we try to remove it. This is an experiment to see whether everything will still work. The dependency is already declared at https://github.com/edx/edx-platform/blob/master/requirements/edx/github.txt#L54

Temporarily it includes also a fix from https://github.com/open-craft/edx-platform/pull/83, to be able to deploy.

**JIRA tickets**: None.

**Discussions**: We're trying this to see if the instance spawned by this PR provisions correctly, without errors. See URL below

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: https://stage.console.opencraft.com/instance/1530/edx-appserver/392/

**Partner information**: None

**Deployment targets**: Ocim prod.

**Merge deadline**: ASAP after provision is finished and after approval.

**Testing instructions**:

1. Wait for correct provision
2. Check log
3. Test instance
4. Merge

**Author notes and concerns**:
See in https://tasks.opencraft.com/browse/OC-3446
eCommerce still untested.

**Reviewers**
- [ ] @itsjeyd 

**Settings**
```yaml
```
