### PR TITLE
Install chem nltk from edX fork.

### DIFF
--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -10,4 +10,7 @@ setup(
         "scipy==0.14.0",
         "nltk==2.0.6",
     ],
+    dependency_links=[
+        "git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6",
+    ],
 )


### PR DESCRIPTION
Because nltk==2.0.6 [has disappeared](https://pypi.python.org/pypi/nltk/2.0.6) (compare [2.0.5](https://pypi.python.org/pypi/nltk/2.0.5)), we use edX's fork.

**JIRA tickets**: None.

**Discussions**: None

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD

**Partner information**: None

**Deployment targets**: Ocim prod.

**Merge deadline**: ASAP after provision is finished and after approval.

**Testing instructions**:

1. Wait for correct provision
2. Check log
3. Test instance
4. Merge

**Author notes and concerns**:
See in https://tasks.opencraft.com/browse/OC-3446

**Reviewers**
- [ ] @itsjeyd 

**Settings**
```yaml
```
