### PR TITLE
[WIP] Use new template inheritance system and add new blocks

### DIFF
--- a/common/djangoapps/edxmako/paths.py
+++ b/common/djangoapps/edxmako/paths.py
@@ -65,17 +65,18 @@ class DynamicTemplateLookup(TemplateLookup):
         template. The method adjusts the `uri` to make it relative to the calling template's location.
 
         This method is overridden to detect when a template from a theme tries to override the same template from a
-        standard location, for example when the dasboard.html template is overridden in the theme while at the same
+        standard location, for example when the dashboard.html template is overridden in the theme while at the same
         time inheriting from the standard LMS dashboard.html template.
 
-        When self-inheritance is detected, the uri is wrapped in the TopLevelTemplateURI marker class to ensure that
-        template lookup skips the current theme and looks up the built-in template in standard locations.
+        When this self-inheritance is detected, the uri is wrapped in the TopLevelTemplateURI marker class to ensure
+        that template lookup skips the current theme and looks up the built-in template in standard locations.
         """
         # Make requested uri relative to the calling uri.
         relative_uri = super(DynamicTemplateLookup, self).adjust_uri(uri, calling_uri)
-        # Is the template (calling_uri) which is importing current template (uri) part of a theme?
+        # Is the calling template (calling_uri) which is including or inheriting current template (uri)
+        # located inside a theme?
         if calling_uri != strip_site_theme_templates_path(calling_uri):
-            # Is the calling template trying to call itself?
+            # Is the calling template trying to include/inherit itself?
             if calling_uri == get_template_path_with_theme(relative_uri):
                 return TopLevelTemplateURI(relative_uri)
         return relative_uri
@@ -98,16 +99,22 @@ class DynamicTemplateLookup(TemplateLookup):
         # let mako find and serve a template
         if not template:
             if isinstance(uri, TopLevelTemplateURI):
-                template = super(DynamicTemplateLookup, self).get_template(strip_site_theme_templates_path(uri))
+                template = self._get_toplevel_template(uri)
             else:
                 try:
                     # Try to find themed template, i.e. see if current theme overrides the template
                     template = super(DynamicTemplateLookup, self).get_template(get_template_path_with_theme(uri))
                 except TopLevelLookupException:
-                    # strip off the prefix path to theme and look in default template dirs
-                    template = super(DynamicTemplateLookup, self).get_template(strip_site_theme_templates_path(uri))
+                    template = self._get_toplevel_template(uri)
 
         return template
+
+    def _get_toplevel_template(self, uri):
+        """
+        Lookup a default/toplevel template, ignoring current theme.
+        """
+        # Strip off the prefix path to theme and look in default template dirs.
+        return super(DynamicTemplateLookup, self).get_template(strip_site_theme_templates_path(uri))
 
 
 def clear_lookups(namespace):

--- a/common/test/test-theme/lms/templates/courseware/courses.html
+++ b/common/test/test-theme/lms/templates/courseware/courses.html
@@ -1,0 +1,8 @@
+<%page expression_filter="h"/>
+
+# Include template which does not exist in the theme.
+<%include file="/courseware/error-message.html" />
+# Include template which is overriden in the theme.
+<%include file="/courseware/info.html" />
+# Include custom template which only exists in the theme.
+<%include file="/courseware/test-theme-custom.html" />

--- a/common/test/test-theme/lms/templates/courseware/info.html
+++ b/common/test/test-theme/lms/templates/courseware/info.html
@@ -1,0 +1,2 @@
+<%page expression_filter="h"/>
+<p>This overrides the courseware/info.html template.</p>

--- a/common/test/test-theme/lms/templates/courseware/test-theme-custom.html
+++ b/common/test/test-theme/lms/templates/courseware/test-theme-custom.html
@@ -1,0 +1,2 @@
+<%page expression_filter="h"/>
+<p>This is a custom template.</p>

--- a/common/test/test-theme/lms/templates/dashboard.html
+++ b/common/test/test-theme/lms/templates/dashboard.html
@@ -1,0 +1,9 @@
+<%page expression_filter="h"/>
+<%!
+    from openedx.core.djangolib.markup import HTML
+%>
+
+<%inherit file="dashboard.html" />
+<%block name="pagetitle">Overridden Title!</%block>
+${HTML(parent.body())}
+<%block name="bodyextra">Overriden Body Extra!</%block>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -217,6 +217,8 @@ from openedx.core.lib.courses import course_image_url
 
         <%include file="course_about_sidebar_header.html" />
 
+        ## FIXME add more blocks to simplify the template
+        <%block name="important_dates">
         <ol class="important-dates">
           <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
           % if not course.start_date_is_still_default:
@@ -287,10 +289,15 @@ from openedx.core.lib.courses import course_image_url
             </p>
           </li>
           % endif
+
+          ## FIXME add more blocks like this, one per li
+      <%block name="prerequisites">
           % if get_course_about_section(request, course, "prerequisites"):
             <li class="important-dates-item"><span class="icon fa fa-book" aria-hidden="true"></span><p class="important-dates-item-title">${_("Requirements")}</p><span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span></li>
           % endif
+          </%block>
         </ol>
+        </%block>
     </div>
 
       ## Course reviews tool

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -105,6 +105,8 @@ from openedx.core.lib.courses import course_image_url
 <%block name="pagetitle">${course.display_name_with_default_escaped}</%block>
 
 <section class="course-info">
+  <%block name="course_info_before_header"></%block>
+  <%block name="header">
   <header class="course-profile">
     <div class="intro-inner-wrapper">
       <div class="table">
@@ -116,6 +118,7 @@ from openedx.core.lib.courses import course_image_url
           </h1>
         </div>
 
+        <%block name="main_cta">
         <div class="main-cta">
         %if user.is_authenticated() and registered:
           %if show_courseware_link:
@@ -179,6 +182,7 @@ from openedx.core.lib.courses import course_image_url
           <div id="register_error"></div>
         %endif
         </div>
+        </%block>
 
       </section>
       % if get_course_about_section(request, course, "video"):
@@ -198,6 +202,7 @@ from openedx.core.lib.courses import course_image_url
     </div>
       </div>
   </header>
+  </%block>
 
   <div class="container">
     <div class="details">
@@ -217,7 +222,6 @@ from openedx.core.lib.courses import course_image_url
 
         <%include file="course_about_sidebar_header.html" />
 
-        ## FIXME add more blocks to simplify the template
         <%block name="important_dates">
         <ol class="important-dates">
           <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
@@ -290,20 +294,19 @@ from openedx.core.lib.courses import course_image_url
           </li>
           % endif
 
-          ## FIXME add more blocks like this, one per li
-      <%block name="prerequisites">
           % if get_course_about_section(request, course, "prerequisites"):
             <li class="important-dates-item"><span class="icon fa fa-book" aria-hidden="true"></span><p class="important-dates-item-title">${_("Requirements")}</p><span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span></li>
           % endif
-          </%block>
         </ol>
         </%block>
     </div>
 
+      <%block name="course_reviews_tool">
       ## Course reviews tool
       % if reviews_fragment_view:
        ${HTML(reviews_fragment_view.body_html())}
       % endif
+      </%block>
 
       ## For now, ocw links are the only thing that goes in additional resources
       % if get_course_about_section(request, course, "ocw_links"):

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -33,6 +33,8 @@
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="find-courses">
       <section class="courses-container">
+
+        <%block name="course_discovery_search">
         % if course_discovery_enabled:
         <div id="discovery-form" role="search" aria-label="course" class="wrapper-search-context">
           <div id="discovery-message" class="search-status-label"></div>
@@ -54,6 +56,7 @@
         <div id="filter-bar" class="filters hide-phone is-collapsed">
         </div>
         % endif
+        </%block>
 
         <div class="courses${'' if course_discovery_enabled else ' no-course-discovery'}" role="region" aria-label="${_('List of Courses')}">
           <ul class="courses-listing">
@@ -66,6 +69,7 @@
         </div>
 
 
+        <%block name="course_discovery_refine_search">
         % if course_discovery_enabled:
         <aside aria-label="${_('Refine Your Search')}" class="search-facets phone-menu">
           <h2 class="header-search-facets">${_('Refine Your Search')}</h2>
@@ -73,6 +77,8 @@
           </section>
         </aside>
         % endif
+        </%block>
+
 
       </section>
     </section>

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -10,7 +10,12 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="home">
+      <%block name="top_banner"></%block>
+
       <header>
+        <%block name="before_main_header_text"></%block>
+
+        <%block name="welcome_overlay">
         <div class="outer-wrapper">
           <div class="title">
             <div class="heading-group">
@@ -46,10 +51,14 @@ from openedx.core.djangolib.markup import HTML, Text
             </a>
           % endif
         </div>
+      </%block>
 
       </header>
+      <%block name="courses_list">
       <%include file="${courses_list}" />
+      </%block>
 
+    <%block name="after_main_header_text"></%block>
     </section>
 </main>
 

--- a/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
+++ b/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
@@ -64,6 +64,69 @@ class TestComprehensiveThemeLMS(TestCase):
         result = staticfiles.finders.find('test-theme/images/logo.png')
         self.assertEqual(result, settings.TEST_THEME / 'lms/static/images/logo.png')
 
+    @with_comprehensive_theme("test-theme")
+    def test_override_block_in_parent(self):
+        """
+        Test that theme title is used instead of parent title.
+        """
+        self._login()
+        dashboard_url = reverse('dashboard')
+        resp = self.client.get(dashboard_url)
+        self.assertEqual(resp.status_code, 200)
+        # This string comes from the 'pagetitle' block of the overriding theme.
+        self.assertContains(resp, "Overridden Title!")
+
+    @with_comprehensive_theme("test-theme")
+    def test_override_block_in_grandparent(self):
+        """
+        Test that theme title is used instead of parent's parent's title.
+        """
+        self._login()
+        dashboard_url = reverse('dashboard')
+        resp = self.client.get(dashboard_url)
+        self.assertEqual(resp.status_code, 200)
+        # This string comes from the 'bodyextra' block of the overriding theme.
+        self.assertContains(resp, "Overriden Body Extra!")
+
+    @with_comprehensive_theme("test-theme")
+    def test_include_default_template(self):
+        """
+        Test that theme template can include template which is not part of the theme.
+        """
+        self._login()
+        courses_url = reverse('courses')
+        resp = self.client.get(courses_url)
+        self.assertEqual(resp.status_code, 200)
+        # The courses.html template includes the error-message.html template.
+        # Verify that the error message is included in the output.
+        self.assertContains(resp, "this module is temporarily unavailable")
+
+    @with_comprehensive_theme("test-theme")
+    def test_include_overridden_template(self):
+        """
+        Test that theme template can include template which is overridden in the active theme.
+        """
+        self._login()
+        courses_url = reverse('courses')
+        resp = self.client.get(courses_url)
+        self.assertEqual(resp.status_code, 200)
+        # The courses.html template includes the info.html file, which is overriden in the theme.
+        self.assertContains(resp, "This overrides the courseware/info.html template.")
+
+    @with_comprehensive_theme("test-theme")
+    def test_include_custom_template(self):
+        """
+        Test that theme template can include template which is only present in the theme, but has no standard LMS
+        equivalent.
+        """
+        self._login()
+        courses_url = reverse('courses')
+        resp = self.client.get(courses_url)
+        self.assertEqual(resp.status_code, 200)
+        # The courses.html template includes the test-theme.custom.html file.
+        # Verify its contents are present in the output.
+        self.assertContains(resp, "This is a custom template.")
+
 
 @skip_unless_cms
 class TestComprehensiveThemeCMS(TestCase):

--- a/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
+++ b/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
@@ -89,6 +89,18 @@ class TestComprehensiveThemeLMS(TestCase):
         self.assertContains(resp, "Overriden Body Extra!")
 
     @with_comprehensive_theme("test-theme")
+    def test_parent_content_in_self_inherited_template(self):
+        """
+        Test that parent's body is present in self inherited template.
+        """
+        self._login()
+        dashboard_url = reverse('dashboard')
+        resp = self.client.get(dashboard_url)
+        self.assertEqual(resp.status_code, 200)
+        # This string comes from the default dashboard.html template.
+        self.assertContains(resp, "Explore courses")
+
+    @with_comprehensive_theme("test-theme")
     def test_include_default_template(self):
         """
         Test that theme template can include template which is not part of the theme.


### PR DESCRIPTION
This cherry-picks https://github.com/edx/edx-platform/pull/16856/commits to implement a new feature: a template can override only some blocks and use the rest of the content from the parent template (instead of being forced to copy/paste all the parent's content).
And in addition the PRs adds some named blocks that will later be used by the Pearson theme.

WIP because more blocks will come, and because https://github.com/edx/edx-platform/pull/16856/commits will be merged.

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: None
**Merge deadline**: None

**Testing instructions**:

1. Run this server with the Pearson theme
2. Notice that the theme works
3. Check that the blocks themselves are neutral when not using Pearson's theme

**Reviewers**
- [ ] @mtyaka 

**Author concerns**: None
**Settings**: None
