### PR TITLE
Add some blocks to course_about.html

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -105,6 +105,8 @@ from openedx.core.lib.courses import course_image_url
 <%block name="pagetitle">${course.display_name_with_default_escaped}</%block>
 
 <section class="course-info">
+
+  <%block name="course_about_header">
   <header class="course-profile">
     <div class="intro-inner-wrapper">
       <div class="table">
@@ -198,6 +200,7 @@ from openedx.core.lib.courses import course_image_url
     </div>
       </div>
   </header>
+  </%block>
 
   <div class="container">
     <div class="details">
@@ -217,6 +220,7 @@ from openedx.core.lib.courses import course_image_url
 
         <%include file="course_about_sidebar_header.html" />
 
+        <%block name="course_about_important_dates">
         <ol class="important-dates">
           <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
           % if not course.start_date_is_still_default:
@@ -287,16 +291,20 @@ from openedx.core.lib.courses import course_image_url
             </p>
           </li>
           % endif
+
           % if get_course_about_section(request, course, "prerequisites"):
             <li class="important-dates-item"><span class="icon fa fa-book" aria-hidden="true"></span><p class="important-dates-item-title">${_("Requirements")}</p><span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span></li>
           % endif
         </ol>
+        </%block>
     </div>
 
+      <%block name="course_about_reviews_tool">
       ## Course reviews tool
       % if reviews_fragment_view:
        ${HTML(reviews_fragment_view.body_html())}
       % endif
+      </%block>
 
       ## For now, ocw links are the only thing that goes in additional resources
       % if get_course_about_section(request, course, "ocw_links"):


### PR DESCRIPTION
Now that the new template inheritance was merged (https://github.com/edx/edx-platform/pull/16856) we can redefine specific blocks.
This adds some block names to existing code so that themes can redefine this blocks easily (without having to redefine the rest of the page).
This handles just course_about.html

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: None
**Merge deadline**: None

**Testing instructions**:

1. Without this change (i.e. with your normal devstack server), go to http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/about and save the HTML in a file
2. Start a server which includes this change: https://github.com/edx/edx-platform/pull/16856, cherry-pick the commit as needed.
3. Apply the patch in this PR, go to the same URL and save to another file
4. Compare files, the HTML should be the same (ignoring whitespace and django-debug-toolbar)
5. Check that no blocks are defined inside other blocks
6. Check that these blocks are like the rest of the other blocks. Or if you're not sure and want to test it, create a theme with a file `lms/templates/course_about.html` which redefines one of the blocks, e.g. `<%block name="course_about_header">`
7. Check that block names don't conflict with other block names used in templates
8. Check that names make sense

**Reviewers**
- [x] @mtyaka 

**Author concerns**: None
**Settings**: None
