### PR TITLE
Downgrade setuptools to avoid race-condition bug

### DIFF
--- a/requirements/edx/openstack.txt
+++ b/requirements/edx/openstack.txt
@@ -2,5 +2,9 @@
 # Dependencies for OpenStack deployments.
 #
 
+# Fixes bug with installing django-storage required packages
+# https://github.com/pypa/setuptools/issues/951
+setuptools==24.0.3
+
 # OpenStack swift backend for django storage API
 django-storage-swift==1.2.15


### PR DESCRIPTION
Use older version of setuptools to get around bug that prevents install of openstack requirements

RE: https://github.com/pypa/setuptools/issues/951

**Merge deadline**: ASAP

**Testing instructions**
1. Deploy instance with this patch applied
2. It should not fail while installing openstack requirements

**Reviewers**
- [ ] @pomegranited 
