### PR TITLE
(CAM-11 & CAM-12) Downloaded data is sensitive

### DIFF
--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -21514,3 +21514,13 @@ msgid ""
 "A new revision was created: Merge between Revision #%(r1)d and Revision "
 "#%(r2)d"
 msgstr ""
+
+#: lms/templates/instructor/instructor_dashboard_2/data_download.html
+msgid "OK"
+msgstr ""
+
+#: lms/templates/instructor/instructor_dashboard_2/sensitive_data_download_msg.txt
+msgid ""
+"Contains information protected under the Protection of Privacy Law - the "
+"wrongful transgressor commits an offense"
+msgstr ""

--- a/conf/locale/he/LC_MESSAGES/django.po
+++ b/conf/locale/he/LC_MESSAGES/django.po
@@ -23442,3 +23442,13 @@ msgid ""
 "A new revision was created: Merge between Revision #%(r1)d and Revision "
 "#%(r2)d"
 msgstr "גרסה חדשה נוצרה: מיזוג בין גרסה #%(r1)d וגרסה #%(r2)d"
+
+#: lms/templates/instructor/instructor_dashboard_2/data_download.html
+msgid "OK"
+msgstr "בסדר"
+
+#: lms/templates/instructor/instructor_dashboard_2/sensitive_data_download_msg.txt
+msgid ""
+"Contains information protected under the Protection of Privacy Law - the "
+"wrongful transgressor commits an offense"
+msgstr "מכיל מידע מוגן לפי חוק הגנת הפרטיות - המוסר שלא כדין עובר עבירה"

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -61,6 +61,7 @@ from lms.djangoapps.instructor.views import INVOICE_KEY
 from lms.djangoapps.instructor.views.instructor_task_helpers import extract_email_features, extract_task_features
 from lms.djangoapps.instructor_task.api_helper import AlreadyRunningError
 from lms.djangoapps.instructor_task.models import ReportStore
+from lms.djangoapps.instructor_task.tasks_helper.utils import SensitiveMessageOnReports
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_groups.cohorts import is_course_cohorted
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -1868,6 +1869,8 @@ def get_anon_ids(request, course_id):  # pylint: disable=unused-argument
         # In practice, there should not be non-ascii data in this query,
         # but trying to do the right thing anyway.
         encoded = [unicode(s).encode('utf-8') for s in header]
+        disclaimer = SensitiveMessageOnReports()
+        disclaimer.csv_direct(writer)
         writer.writerow(encoded)
         for row in rows:
             encoded = [unicode(s).encode('utf-8') for s in row]

--- a/lms/djangoapps/instructor_analytics/csvs.py
+++ b/lms/djangoapps/instructor_analytics/csvs.py
@@ -8,6 +8,8 @@ import csv
 
 from django.http import HttpResponse
 
+from lms.djangoapps.instructor_task.tasks_helper.utils import SensitiveMessageOnReports
+
 
 def create_csv_response(filename, header, datarows):
     """
@@ -27,6 +29,9 @@ def create_csv_response(filename, header, datarows):
         dialect='excel',
         quotechar='"',
         quoting=csv.QUOTE_ALL)
+
+    disclaimer = SensitiveMessageOnReports()
+    disclaimer.csv_direct(csvwriter)
 
     encoded_header = [unicode(s).encode('utf-8') for s in header]
     csvwriter.writerow(encoded_header)

--- a/lms/djangoapps/instructor_task/tasks_helper/utils.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/utils.py
@@ -1,6 +1,10 @@
 from eventtracking import tracker
 from lms.djangoapps.instructor_task.models import ReportStore
 from util.file import course_filename_prefix_generator
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from edxmako.shortcuts import render_to_string
+
+from django.conf import settings
 
 REPORT_REQUESTED_EVENT_NAME = u'edx.instructor.report.requested'
 
@@ -16,7 +20,6 @@ UPDATE_STATUS_SKIPPED = 'skipped'
 def upload_csv_to_report_store(rows, csv_name, course_id, timestamp, config_name='GRADES_DOWNLOAD'):
     """
     Upload data as a CSV using ReportStore.
-
     Arguments:
         rows: CSV data in the following format (first column may be a
             header):
@@ -28,6 +31,11 @@ def upload_csv_to_report_store(rows, csv_name, course_id, timestamp, config_name
         course_id: ID of the course
     """
     report_store = ReportStore.from_config(config_name)
+    disclaimer = SensitiveMessageOnReports()
+    if disclaimer.should_msg_be_displayed:
+        # Append the new row above the headers.
+        send_disclaimer = disclaimer.with_report_store()
+        rows = [send_disclaimer] + rows
     report_store.store_rows(
         course_id,
         u"{course_prefix}_{csv_name}_{timestamp_str}.csv".format(
@@ -45,3 +53,48 @@ def tracker_emit(report_name):
     Emits a 'report.requested' event for the given report.
     """
     tracker.emit(REPORT_REQUESTED_EVENT_NAME, {"report_type": report_name, })
+
+
+class SensitiveMessageOnReports(object):
+    """
+    Adds a sensitive data message to the reports if the flag
+    DISPLAY_SENSITIVE_DATA_MSG_FOR_DOWNLOADS is enabled.
+
+    Due to reports being generated in different ways, each one handles their own way:
+        1. Using the CSV library directly.
+        2. Using upload_csv_to_report_store function which in turn
+           uses store_rows of DjangoStorageReportStore class where is built the CSV.
+    """
+
+    def __init__(self):
+        self.should_msg_be_displayed = configuration_helpers.get_value(
+            'DISPLAY_SENSITIVE_DATA_MSG_FOR_DOWNLOADS',
+            settings.FEATURES.get(
+                'DISPLAY_SENSITIVE_DATA_MSG_FOR_DOWNLOADS',
+                False
+            )
+        )
+
+    def csv_direct(self, writer):
+        """
+        Writes the row immediately in the CSV.
+        """
+        if self.should_msg_be_displayed:
+            msg = self.process_message()
+            encode = unicode(msg).encode('utf-8')
+            return writer.writerow([encode])
+
+    def with_report_store(self):
+        """
+        Return the string parsed in process_message. This string is passed
+        to upload_csv_to_report_store which decides if execute it or not.
+        """
+        return [self.process_message()]
+
+    def process_message(self):
+        """
+        Return the message parsed from template.
+        """
+        template_message = 'instructor/instructor_dashboard_2/sensitive_data_download_msg.txt'
+        message = render_to_string(template_message, None)
+        return message

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -395,6 +395,10 @@ FEATURES = {
 
     # Set to enable Enterprise integration
     'ENABLE_ENTERPRISE_INTEGRATION': False,
+
+    # Show sensitive data msg when downloading reports
+    'ENABLE_SENSITIVE_DATA_MSG_ON_DASHBOARD': False,
+    'DISPLAY_SENSITIVE_DATA_MSG_FOR_DOWNLOADS': False,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -291,6 +291,25 @@
     }
 }
 
+.data-disclaimer-modal {
+  color:#555 !important;
+  background-color: #f5f5f5;
+  padding: 60px !important;
+  line-height: 1.9;
+  line-height: 1.9;
+
+  .inner-wrapper {
+    border: none !important;
+    box-shadow: none !important;
+  }
+}
+ 
+.modal_close {
+  position: absolute;
+  display: block;
+  z-index: 2;
+}
+
 // elements - general
 // --------------------
 .idash-section {

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -1,8 +1,32 @@
+<%namespace name='static' file='/static_content.html'/>
 <%page args="section_data" expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
+
+% if configuration_helpers.get_value('ENABLE_SENSITIVE_DATA_MSG_ON_DASHBOARD', settings.FEATURES.get('ENABLE_SENSITIVE_DATA_MSG_ON_DASHBOARD', False)):
+  
+  <%static:require_module_async module_name="js/vendor/jquery.leanModal" class_name="leanModal">
+  
+    $('[data-section="data_download"]').click(function(){
+        $( 'a[rel*=leanModal]' ).leanModal({ top : 200, closeButton: ".modal_close" });
+        $( "#sensitive-data" ).click();
+    });
+  
+   </%static:require_module_async>
+  
+  <a href="#sensitive-data-modal" id="sensitive-data" style="display:none" rel="leanModal"></a>
+  
+  <div aria-hidden="true" role="dialog" tabindex="-1" class="modal data-disclaimer-modal" id="sensitive-data-modal">
+    <div class="inner-wrapper" style="margin-bottom: 20px;">
+    <%include file="sensitive_data_download_msg.txt"/>
+    </div>
+    <input type="button" class="modal_close" value="${_('OK')}" href="#">
+  </div>
+  
+% endif
 
 <div class="data-download-container action-type-container">
   <div class="request-response-error msg msg-error copy" id="data-request-response-error"></div>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -6,6 +6,7 @@
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from openedx.core.djangolib.markup import HTML
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 <%block name="bodyclass">view-in-course view-instructordash</%block>
 

--- a/lms/templates/instructor/instructor_dashboard_2/sensitive_data_download_msg.txt
+++ b/lms/templates/instructor/instructor_dashboard_2/sensitive_data_download_msg.txt
@@ -1,0 +1,5 @@
+<%!
+from django.utils.translation import ugettext as _
+%>
+
+${_("Contains information protected under the Protection of Privacy Law - the wrongful transgressor commits an offense")}


### PR DESCRIPTION
Set the flag `ENABLE_SENSITIVE_DATA_MSG_ON_DASHBOARD` to `True` in `site_configuration` or in `settings.FEATURES`

<img width="1420" alt="screen shot 2018-02-01 at 4 22 17 pm" src="https://user-images.githubusercontent.com/3858265/35684185-caf8f1d6-076e-11e8-8a53-a95e20096682.png">

cc @pomegranited 
