### PR TITLE
Add AWS_LOCATION setting for django-storages

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -275,6 +275,7 @@ if FEATURES.get('AUTH_USE_CAS'):
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = ENV_TOKENS.get('FILE_UPLOAD_STORAGE_BUCKET_NAME', FILE_UPLOAD_STORAGE_BUCKET_NAME)
 FILE_UPLOAD_STORAGE_PREFIX = ENV_TOKENS.get('FILE_UPLOAD_STORAGE_PREFIX', FILE_UPLOAD_STORAGE_PREFIX)
+AWS_LOCATION = ENV_TOKENS.get('AWS_LOCATION', FILE_UPLOAD_STORAGE_PREFIX)
 
 ################ SECURE AUTH ITEMS ###############################
 # Secret things: passwords, access keys, etc.

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -538,6 +538,7 @@ else:
 # Specific setting for the File Upload Service to store media in a bucket.
 FILE_UPLOAD_STORAGE_BUCKET_NAME = ENV_TOKENS.get('FILE_UPLOAD_STORAGE_BUCKET_NAME', FILE_UPLOAD_STORAGE_BUCKET_NAME)
 FILE_UPLOAD_STORAGE_PREFIX = ENV_TOKENS.get('FILE_UPLOAD_STORAGE_PREFIX', FILE_UPLOAD_STORAGE_PREFIX)
+AWS_LOCATION = ENV_TOKENS.get('AWS_LOCATION', FILE_UPLOAD_STORAGE_PREFIX)
 
 # If there is a database called 'read_replica', you can use the use_read_replica_if_available
 # function in util/query.py, which is useful for very large database reads


### PR DESCRIPTION
This pull request adds the AWS_LOCATION setting for used by ``django-storages`` to set a prefix for uploading files. It defaults to ``FILE_UPLOAD_STORAGE_PREFIX``.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. Deploy instance with ``AWS_LOCATION`` set.
2. Uploads should go the the prefix specified in ``AWS_LOCATION``.

**Reviewers**
- [ ] TBD