### PR TITLE
Correct password reset email template

### DIFF
--- a/lms/templates/registration/password_reset_email.html
+++ b/lms/templates/registration/password_reset_email.html
@@ -1,5 +1,5 @@
 {% load i18n %}{% autoescape off %}
-{% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+{% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ platform_name }}.{% endblocktrans %}
 
 {% if failed %}
 {% blocktrans %}However, there is currently no user account associated with your email address: {{ email_address }}.{% endblocktrans %}


### PR DESCRIPTION
When backporting the invalid user handling, I missed a change from
site_name to platform_name in the upstream template, causing a blank
spot in the first sentence of the email.