### PR TITLE
(CAM-13) Add context to enroll

### DIFF
--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -10551,9 +10551,14 @@ msgstr ""
 msgid "You should Register before trying to access the Unit"
 msgstr ""
 
-#: lms/templates/ccx/enrollment.html
-#: lms/templates/courseware/course_about.html lms/templates/enroll_staff.html
+#: lms/templates/courseware/course_about.html
+msgctxt "self"
+msgid "Enroll"
+msgstr ""
+
+#: lms/templates/enroll_staff.html lms/templates/ccx/enrollment.html
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
+msgctxt "someone"
 msgid "Enroll"
 msgstr ""
 

--- a/conf/locale/he/LC_MESSAGES/django.po
+++ b/conf/locale/he/LC_MESSAGES/django.po
@@ -10605,9 +10605,14 @@ msgstr ""
 msgid "You should Register before trying to access the Unit"
 msgstr ""
 
-#: lms/templates/enroll_staff.html lms/templates/ccx/enrollment.html
 #: lms/templates/courseware/course_about.html
+msgctxt "self"
+msgid "Enroll"
+msgstr ""
+
+#: lms/templates/enroll_staff.html lms/templates/ccx/enrollment.html
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
+msgctxt "someone"
 msgid "Enroll"
 msgstr ""
 

--- a/lms/templates/ccx/enrollment.html
+++ b/lms/templates/ccx/enrollment.html
@@ -1,6 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
+from django.utils.translation import pgettext
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
@@ -53,7 +54,7 @@ from openedx.core.djangolib.markup import HTML, Text
   </div>
 
   <div>
-    <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Enroll")}">
+    <input type="submit" name="enrollment-button" class="enrollment-button" value="${pgettext('someone','Enroll')}">
     <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}">
   </div>
   <div class="request-response"></div>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -1,6 +1,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
+from django.utils.translation import pgettext
 from django.core.urlresolvers import reverse
 from courseware.courses import get_course_about_section
 from django.conf import settings
@@ -325,12 +326,12 @@ from openedx.core.lib.courses import course_image_url
   <div style="display: none;">
     <form id="class_enroll_form" method="post" data-remote="true" action="${reverse('change_enrollment')}">
       <fieldset class="enroll_fieldset">
-        <legend class="sr">${_("Enroll")}</legend>
+        <legend class="sr">${pgettext("self","Enroll")}</legend>
         <input name="course_id" type="hidden" value="${course.id | h}">
         <input name="enrollment_action" type="hidden" value="enroll">
       </fieldset>
       <div class="submit">
-        <input name="submit" type="submit" value="${_('enroll')}">
+        <input name="submit" type="submit" value="${pgettext('self','enroll')}">
       </div>
     </form>
   </div>

--- a/lms/templates/enroll_staff.html
+++ b/lms/templates/enroll_staff.html
@@ -3,6 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
     from django.utils.translation import ugettext as _
+    from django.utils.translation import pgettext
     from courseware.courses import get_course_about_section
 %>
 
@@ -30,7 +31,7 @@
                             <input type="hidden" name="csrfmiddlewaretoken" value="${ csrftoken }"/>
                             <div class="main-cta">
                                 <button class="register" name="enroll" type="submit"
-                                        value="${_('Enroll')}">${_('Enroll')}<span
+                                        value="${pgettext('self','Enroll')}">${pgettext('self', 'Enroll')}<span
                                         class="sr">${course.display_name_with_default}</span></button>
                                 <button class="register" name="dont_enroll" type="submit"
                                         value="${_('Don\'t enroll')}">${_('Don\'t enroll')}<span

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -2,6 +2,7 @@
 <%page args="section_data"/>
 <%!
 from django.utils.translation import ugettext as _
+from django.utils.translation import pgettext
 %>
 <script type="text/template" id="member-list-widget-template">
   <div class="member-list-widget">
@@ -76,7 +77,7 @@ from django.utils.translation import ugettext as _
         </label>
     </div>
     <div>
-        <input type="button" name="enrollment-button" class="enrollment-button" value="${_("Enroll")}" data-endpoint="${ section_data['enroll_button_url'] }" data-action="enroll" >
+        <input type="button" name="enrollment-button" class="enrollment-button" value="${pgettext('someone','Enroll')}" data-endpoint="${ section_data['enroll_button_url'] }" data-action="enroll" >
         <input type="button" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}" data-endpoint="${ section_data['unenroll_button_url'] }" data-action="unenroll" >
     </div>
     <div class="request-response"></div>


### PR DESCRIPTION
# CAM-13

## Description
This PR adds a context to `enroll` string in Hebrew using `pgettext`.

## Background
In Hebrew there are different words for enroll depending on the context. Enroll as in enroll yourself is different as in enroll someone else.

## Reviewers
- [ ] @tomaszgy 