### PR TITLE
Use django-storage-swift opencraft-release/ginkgo.1

### DIFF
--- a/requirements/edx/openstack.txt
+++ b/requirements/edx/openstack.txt
@@ -6,5 +6,5 @@
 # https://github.com/pypa/setuptools/issues/951
 setuptools==24.0.3
 
-# OpenStack swift backend for django storage API, with lazy connection loading
-git+https://github.com/open-craft/django-storage-swift.git@jill/lazy_connect#egg=django-storage-swift==1.2.15
+# OpenStack swift backend for django storage API
+django-storage-swift==1.2.18


### PR DESCRIPTION
https://github.com/open-craft/django-storage-swift/pull/1 merged, so this reverts the change that uses that PR's branch.

**Sandbox URLs**

* LMS: https://pr112.sandbox.stage.opencraft.hosting/
* Studio: https://studio-pr112.sandbox.stage.opencraft.hosting/

Provisioning now with 193261e and persistent storage.

**Reviewer**
- [x] @smarnach 