### PR TITLE
Add template block to allow redefining the details section in themes

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -203,6 +203,8 @@ from openedx.core.lib.courses import course_image_url
   </%block>
 
   <div class="container">
+
+    <%block name="course_about_details">
     <div class="details">
       % if staff_access and studio_url is not None:
         <div class="wrap-instructor-info studio-view">
@@ -213,7 +215,8 @@ from openedx.core.lib.courses import course_image_url
       <div class="inner-wrapper">
         ${get_course_about_section(request, course, "overview")}
       </div>
-  </div>
+    </div>
+    </%block>
 
     <div class="course-sidebar">
       <div class="course-summary">


### PR DESCRIPTION
(cherry picked from commit b8e384e5e8d0c87eb3f600cec12975543e64d28b)

See PR upstream. https://github.com/edx/edx-platform/pull/17543

Required to add an extra „Enquire now“ button. (https://github.com/open-craft/edx-theme/pull/33)