### PR TITLE
Add "course code" and "institution (hidden)" course fields

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -860,6 +860,18 @@ class CourseFields(object):
         scope=Scope.settings, default=False
     )
 
+    program_code = String(
+        display_name=_("Program Code"),
+        help=_("To be used in the 'Enquire now' form."),
+        scope=Scope.settings
+    )
+    institution_hidden = String(
+        display_name=_("Institution (Hidden)"),
+        help=_("To be used in the 'Enquire now' form."),
+        default='TNE-edX',
+        scope=Scope.settings
+    )
+
 
 class CourseModule(CourseFields, SequenceModule):  # pylint: disable=abstract-method
     """


### PR DESCRIPTION
This adds 2 course fields.

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: https://pr117.sandbox.stage.opencraft.hosting/ (still provisioning)
**Merge deadline**: None

**Testing instructions**:

1. Open Studio, and some course
2. Check the „Advanced settings“ tab and see the 2 new fields, save them and check that they persist
3. Check that the default for „institution“ is `TNE-edX` same as it was in the theme
4. Continue checking the theme changes PR (https://github.com/open-craft/edx-theme/pull/37) to check that the values are used

**Reviewers**
- [ ] @bradenmacdonald 

**Author concerns**: None
**Settings**:
```yaml
EDXAPP_ENABLE_COMPREHENSIVE_THEMING: true
EDXAPP_COMPREHENSIVE_THEME_DIRS:
  - '/edx/app/edxapp/themes'
EDXAPP_DEFAULT_SITE_THEME: 'pearsonx'
edxapp_theme_name: 'pearsonx'
edxapp_theme_source_repo: 'https://github.com/open-craft/edx-theme.git'
edxapp_theme_version: 'clemente/pearson-add-program-code-and-institution'
```