### PR TITLE
Add CourseFields.other_course_settings to store custom fields

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -859,6 +859,12 @@ class CourseFields(object):
         ),
         scope=Scope.settings, default=False
     )
+    other_course_settings = Dict(
+        display_name=_("Other Course Settings"),
+        help=_("Used to store any additional details about the course needed by this instance of Open edX or for "
+               "integration with external systems such as CRM software."),
+        scope=Scope.settings
+    )
 
 
 class CourseModule(CourseFields, SequenceModule):  # pylint: disable=abstract-method

--- a/common/test/acceptance/pages/studio/settings_advanced.py
+++ b/common/test/acceptance/pages/studio/settings_advanced.py
@@ -228,4 +228,5 @@ class AdvancedSettingsPage(CoursePage):
             'create_zendesk_tickets',
             'ccx_connector',
             'enable_ccx',
+            'other_course_settings',
         ]


### PR DESCRIPTION
This adds a CourseFields field to store arbitrary fields.

Upstream PR: https://github.com/edx/edx-platform/pull/17699

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: see the theme PR
**Merge deadline**: None

**Testing instructions**:

1. Test it in conjunction with the Pearson theme settings PR („program code, institution hidden“): https://github.com/open-craft/edx-theme/pull/38/

**Reviewers**
- [ ] @bradenmacdonald 

**Author concerns**: None
**Settings**: None