### PR TITLE
Convert DATA_DIR to a Path object when fetching from ENV_TOKENS

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -159,7 +159,7 @@ ALLOWED_HOSTS = [
 ]
 
 LOG_DIR = ENV_TOKENS['LOG_DIR']
-DATA_DIR = ENV_TOKENS.get('DATA_DIR', DATA_DIR)
+DATA_DIR = path(ENV_TOKENS.get('DATA_DIR', DATA_DIR))
 
 CACHES = ENV_TOKENS['CACHES']
 # Cache used for location mapping -- called many times with the same key/value

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -324,7 +324,7 @@ WIKI_ENABLED = ENV_TOKENS.get('WIKI_ENABLED', WIKI_ENABLED)
 
 local_loglevel = ENV_TOKENS.get('LOCAL_LOGLEVEL', 'INFO')
 LOG_DIR = ENV_TOKENS['LOG_DIR']
-DATA_DIR = ENV_TOKENS.get('DATA_DIR', DATA_DIR)
+DATA_DIR = path(ENV_TOKENS.get('DATA_DIR', DATA_DIR))
 
 LOGGING = get_logger_config(LOG_DIR,
                             logging_env=ENV_TOKENS['LOGGING_ENV'],


### PR DESCRIPTION
This fixes the exceptions raised by code that expects it to be a Path
object - for example, the courses page in the sysadmin dashboard throws a 500 error without this fix.

**Steps to reproduce the issue:**
* Ensure that `ENABLE_SYSADMIN_DASHBOARD` is set to `true` in `lms.env.json`. Restart the LMS server if the configuration is changed.
* Login to the LMS site as a superuser user (`is_superuser=True`).
* Click on the Sysadmin link in the top navigation bar or alternatively visit the `/sysadmin/` path.
* Click on 'Courses'.
* The LMS throws a 500 error with the following exception - `TypeError: unsupported operand type(s) for /: 'unicode' and 'unicode' `

**Testing instructions**
* Ensure that `ENABLE_SYSADMIN_DASHBOARD` is set to `true` in `lms.env.json`. Restart the LMS server if the configuration is changed.
* Login to the LMS site as a superuser user (`is_superuser=True`).
* Click on the Sysadmin link in the top navigation bar or alternatively visit the `/sysadmin/` path.
* Click on 'Courses'.
* The courses page should open without any exceptions.

**Reviewers**
- [ ] @viadanna 