### PR TITLE
SE-332 Cloudera: Course page with course handouts viewable by anyone, no login

### DIFF
--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -122,6 +122,8 @@ class CourseHomeFragmentView(EdxFragmentView):
         }
         if user_access['is_enrolled'] or user_access['is_staff']:
             outline_fragment = CourseOutlineFragmentView().render_to_fragment(request, course_id=course_id, **kwargs)
+            # Get the handouts
+            handouts_html = self._get_course_handouts(request, course)
             if LATEST_UPDATE_FLAG.is_enabled(course_key):
                 update_message_fragment = LatestUpdateFragmentView().render_to_fragment(
                     request, course_id=course_id, **kwargs
@@ -144,9 +146,7 @@ class CourseHomeFragmentView(EdxFragmentView):
             course_sock_fragment = None
             has_visited_course = None
             resume_course_url = None
-
-        # Get the handouts
-        handouts_html = self._get_course_handouts(request, course)
+            handouts_html = None
 
         # Get the course tools enabled for this user and course
         course_tools = CourseToolsPluginManager.get_enabled_course_tools(request, course_key)


### PR DESCRIPTION
Fixed access to course handouts by `anonymous` user.

**JIRA tickets**: https://tasks.opencraft.com/browse/SE-332
**Screenshots**: 

`---------------------- Before ----------------------`
![image](https://user-images.githubusercontent.com/13070119/46540584-72cc4380-c8c2-11e8-9b92-c7d18347f13c.png)



`---------------------- After ----------------------`
![image](https://user-images.githubusercontent.com/13070119/46540294-8dea8380-c8c1-11e8-9bba-baa52c20b7ec.png)

**Sandbox URL**: http://145.239.12.102/

**Merge deadline**: ASAP
**Testing instructions**:
1. Logout
2. [Visit course url](http://145.239.12.102/courses/course-v1:edX+DemoX+Demo_Course/course/)
3. You should not be able to view/download course handouts

**Author notes and concerns**: do i need also to hide `Important Course Dates` ? In that way it will be consistent, because we aren't showing `Course Tools` and `Course Handouts` but showing `Important Course Dates` 
**Reviewers**: @pomegranited 
