### PR TITLE
Implement XBlock Handlers in Blockstore Prototype Runtime

### DIFF
--- a/cms/djangoapps/bundles/urls.py
+++ b/cms/djangoapps/bundles/urls.py
@@ -15,6 +15,12 @@ urlpatterns = [
         ])),
         url(r'^block/(?P<usage_key_str>gblock-v1:[^/]+)/', include([
             url(r'^$', views.bundle_block),
+            url(r'^handler_url/(?P<handler_name>[\w\-]+)/$', views.bundle_xblock_handler_url),
+            url(
+                r'^handler/(?P<user_id>\d+)-(?P<secure_token>\w+)/(?P<handler_name>[\w\-]+)/(?P<suffix>.+)?$',
+                    views.bundle_xblock_handler,
+                    name='bundle_xblock_handler',
+                ),
         ])),
     ])),
 ]

--- a/cms/djangoapps/bundles/views.py
+++ b/cms/djangoapps/bundles/views.py
@@ -4,17 +4,29 @@ Views for dealing with XBlocks that are in a Blockstore bundle.
 from __future__ import absolute_import, division, print_function, unicode_literals
 from uuid import UUID
 
+from django.conf import settings
 from django.http import Http404, JsonResponse, HttpResponseBadRequest
 from django.urls import reverse
+from rest_framework import permissions
+from rest_framework.decorators import api_view, permission_classes, authentication_classes
+from rest_framework.exceptions import PermissionDenied, AuthenticationFailed
+from rest_framework.response import Response
+from rest_framework.reverse import reverse as drf_reverse
 import six
+from xblock.django.request import DjangoWebobRequest, webob_to_django_response
 from xblock.exceptions import NoSuchViewError
 from xblock.runtime import DictKeyValueStore
 
 from opaque_keys.edx.keys import UsageKey
+from openedx.core.lib.api.view_utils import view_auth_classes
 from openedx.core.lib.blockstore_api import get_bundle, list_olx_definitions
-from openedx.core.lib.xblock_runtime.blockstore_kvs import BlockstoreKVS, blockstore_transaction
+from openedx.core.lib.xblock_runtime.blockstore_kvs import BlockstoreKVS, blockstore_transaction, collect_changes
 from openedx.core.lib.xblock_runtime.blockstore_runtime import BlockstoreXBlockRuntime
 from openedx.core.lib.xblock_runtime.runtime import XBlockRuntimeSystem
+from openedx.core.lib.xblock_runtime.utils import (
+    get_secure_token_for_xblock_handler,
+    validate_secure_token_for_xblock_handler,
+)
 from openedx.core.lib.xblock_keys import global_context, BundleDefinitionLocator
 
 
@@ -45,6 +57,31 @@ def get_user_state_kvs():
     return get_user_state_kvs._kvs
 
 
+def get_xblock_handler_url(usage_id_str, handler_name, suffix, user_id):
+    """
+    Studio's implementation of a method for getting the URL to any XBlock
+    handler. The URL must be usable without any authentication (no cookie,
+    no OAuth/JWT), and may expire.
+    """
+    scheme = "https" if settings.HTTPS == "on" else "http"
+    site_root_url = scheme + '://' + settings.CMS_BASE
+    # or for the LMS version: configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
+
+    if user_id == XBlockRuntimeSystem.ANONYMOUS_USER:
+        raise NotImplementedError("thirdparty handler links not yet implemented")  # TODO: implement
+    else:
+        # Normal case: generate a token-secured URL for this handler, specific
+        # to this user and this XBlock.
+        secure_token = get_secure_token_for_xblock_handler(user_id, usage_id_str)
+        path = reverse('bundle_xblock_handler', kwargs={
+            'usage_key_str': usage_id_str,
+            'user_id': user_id,
+            'secure_token': secure_token,
+            'handler_name': handler_name,
+        })
+    return site_root_url + path
+
+
 def get_readonly_runtime_system():
     """
     Get the XBlockRuntimeSystem for viewing content in Studio but
@@ -53,8 +90,7 @@ def get_readonly_runtime_system():
     # pylint: disable=protected-access
     if not hasattr(get_readonly_runtime_system, '_system'):
         get_readonly_runtime_system._system = XBlockRuntimeSystem(
-            # TODO: Need an actual method for calling handler_urls with this runtime:
-            handler_url=lambda *args, **kwargs: 'test_url',
+            handler_url=get_xblock_handler_url,
             authored_data_kvs=get_blockstore_kvs(),
             student_data_kvs=get_user_state_kvs(),
             runtime_class=BlockstoreXBlockRuntime,
@@ -123,3 +159,59 @@ def bundle_block(request, usage_key_str, view_name='student_view'):
     data.update(fragment.to_dict())
 
     return JsonResponse(data)
+
+
+@api_view(['GET'])
+@view_auth_classes(is_authenticated=True)
+def bundle_xblock_handler_url(request, usage_key_str, handler_name):
+    """
+    Get an absolute URL which can be used (without any authentication) to call
+    the given XBlock handler.
+    
+    The URL will expire but is guaranteed to be valid for a minimum of 2 days.
+    """
+    handler_url = get_xblock_handler_url(usage_key_str, handler_name, '', request.user.id)
+    return Response({"handler_url": handler_url})
+
+
+@api_view(['GET', 'POST', 'PUT', 'DELETE'])
+@authentication_classes([])  # Disable session authentication; we don't need it and don't want CSRF checks
+@permission_classes((permissions.AllowAny, ))
+def bundle_xblock_handler(request, user_id, secure_token, usage_key_str, handler_name, suffix):
+    """
+    Run an XBlock's handler and return the result
+    """
+    user_id = int(user_id)  # User ID comes from the URL, not session auth
+
+    usage_key = UsageKey.from_string(usage_key_str)
+    if usage_key.context_key != global_context:
+        return HttpResponseBadRequest("This API method only works with usages in the global context.")
+
+    runtime = get_readonly_runtime_system().get_runtime(user_id=user_id)
+
+    # To support sandboxed XBlocks, custom frontends, and other use cases, we
+    # authenticate requests using a secure token in the URL. see
+    # openedx.core.lib.xblock_runtime.runtime.get_secure_hash_for_xblock_handler
+    # for details and rationale.
+    if not validate_secure_token_for_xblock_handler(user_id, usage_key_str, secure_token):
+        raise PermissionDenied("Invalid/expired auth token.")
+    if request.user.is_authenticated:
+        # The user authenticated twice, e.g. with session auth and the token
+        # So just make sure the session auth matches the token
+        if request.user.id != user_id:
+            raise AuthenticationFailed("Authentication conflict.")
+
+    request_webob = DjangoWebobRequest(request)  # Convert from django request to the webob format that XBlocks expect
+
+    with blockstore_transaction():
+        # Load the XBlock:
+        block = runtime.get_block(usage_key)
+        # Run the handler, and save any resulting XBlock field value changes:
+        with collect_changes():
+            response_webob = block.handle(handler_name, request_webob, suffix)
+
+    response = webob_to_django_response(response_webob)
+    # We need to set Access-Control-Allow-Origin: * to allow sandboxed XBlocks
+    # to call these handlers:
+    response['Access-Control-Allow-Origin'] = '*'
+    return response

--- a/openedx/core/lib/xblock_runtime/utils.py
+++ b/openedx/core/lib/xblock_runtime/utils.py
@@ -1,0 +1,63 @@
+"""
+Useful helper methods related to the XBlock runtime
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+import hashlib
+import hmac
+import logging
+import math
+import time
+
+from django.conf import settings
+from six import text_type
+
+
+def get_secure_token_for_xblock_handler(user_id, block_key_str, time_idx = 0):
+    """
+    Get a secure token (one-way hash) used to authenticate XBlock handler
+    requests. This token replaces both the session ID cookie (or OAuth
+    bearer token) and the CSRF token for such requests.
+
+    The token is specific to one user and one XBlock usage ID, though may
+    be used for any handler. It expires and is only valid for 2-4 days.
+
+    We use this token because XBlocks may sometimes be sandboxed (run in a
+    client-side JavaScript environment with no access to cookies) and
+    because the XBlock python and JavaScript handler_url APIs do not provide
+    any way of authenticating the handler requests, other than assuming
+    cookies are present or including this sort of secure token in the
+    handler URL.
+
+    to ensure that only authorized XBlock code in an IFrame we created is
+    calling the secure_xblock_handler endpoint.
+
+    For security, we need these tokens to have an expiration date. So: the
+    hash incorporates the current time, rounded to the lowest TOKEN_PERIOD
+    value. When checking this, you should check both time_idx=0 and
+    time_idx=-1 in case we just recently moved from one time period to
+    another (i.e. at the stroke of midnight UTC or similar). The effect of
+    this is that each token is valid for 2-4 days.
+    """
+    TOKEN_PERIOD = 24 * 60 * 60 * 2  # These URLs are valid for 2-4 days
+    time_token = math.floor(time.time() / TOKEN_PERIOD)
+    time_token += TOKEN_PERIOD * time_idx
+    check_string = text_type(time_token) + ':' + text_type(user_id) + ':' + block_key_str
+    secure_key = hmac.new(settings.SECRET_KEY.encode('utf-8'), check_string.encode('utf-8'), hashlib.sha256).hexdigest()
+    return secure_key[:20]
+
+
+def validate_secure_token_for_xblock_handler(user_id, block_key_str, token):
+    """
+    Returns True if the specified handler authentication token is valid for the
+    given XBlock ID and user ID. Otherwise returns false.
+
+    See get_secure_token_for_xblock_handler
+    """
+    token = token.encode('utf-8')  # This line isn't needed after python 3, nor the .encode('utf-8') below
+    token_expected = get_secure_token_for_xblock_handler(user_id, block_key_str).encode('utf-8')
+    prev_token_expected = get_secure_token_for_xblock_handler(user_id, block_key_str, -1).encode('utf-8')
+    result1 = hmac.compare_digest(token, token_expected)
+    result2 = hmac.compare_digest(token, prev_token_expected)
+    # All computations happen above this line so this function always takes a
+    # constant time to produce its answer (security best practice).
+    return bool(result1 or result2)


### PR DESCRIPTION
This adds handler support to the prototype Blockstore-based XBlock runtime being developed in the https://github.com/edx/edx-platform/pull/19136 feature branch.

**TODO**:
- [x] Implement handler_url with absolute URLs and non-cookie authentication
- [x] Make the use of csrf_exempt safe
- [ ] Support the `thirdparty` arg for non-user handler calls?
- [ ] The Studio console is warning that "WARNING 4494 [edx_rest_framework_extensions.auth.jwt.middleware] middleware.py:62 - The view bundle_xblock_handler_url allows Jwt Authentication but needs to include the NotJwtRestrictedApplication permission class (adding it for you)" but there [is no useful documentation providing guidance as to what/when/why we should use that](https://github.com/edx/edx-drf-extensions/blob/4569b9bf7e54a917d4acdd545b10c058c960dd1a/edx_rest_framework_extensions/permissions.py#L61), nor do I see other examples of that permissions class being used anywhere in edx-platform?

**Test Instructions**:
* Follow the instructions at https://github.com/edx/edx-platform/pull/19136 to import a Drag and Drop XBlock into Blockstore
* View the XBlock's student_view JSON, e.g. at http://localhost:18010/api/bundles/v0/block/gblock-v1:ec2566b7-e618-429b-8d97-b3ded042b862:drag-and-drop-v2:971aadaaaa5a4886b37fee3ced711b30/ (may need to change the IDs to match your local setup)
* Open the JS console and call the publish_event handler using the code below (change the block ID):
    ```
    blockId = 'gblock-v1:ec2566b7-e618-429b-8d97-b3ded042b862:drag-and-drop-v2:971aadaaaa5a4886b37fee3ced711b30';
    secureUrl = (await (await fetch(`http://localhost:18010/api/bundles/v0/block/${blockId}/handler_url/publish_event/`, {method: 'GET', credentials: 'include'})).json()).handler_url
    data = {event_type: 'test', 'arg': 'hello'};
    await fetch(secureUrl, {method: 'POST', headers: {"Content-Type": "application/json; charset=UTF-8"}, body: JSON.stringify(data)});
    ```
* In your docker devstack's `make studio-attach` output, you should see:
   ```
   INFO 3097 [openedx.core.lib.xblock_runtime.runtime] runtime.py:63 - 
   XBlock gblock-v1:ec2566b7-e618-429b-8d97-b3ded042b862:drag-and-drop-v2:971aadaaaa5a4886b37fee3ced711b30
   has published a 'test' event: {u'arg': u'hello'}
   ```

Note: I am holding off on writing test cases for the prototype runtime until we're more sure of the approach, and have finalized a bit more of the Blockstore storage format and opaque key format.