### PR TITLE
SE-985 Backport mobile auth completion fix to Hawthorn

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -68,9 +68,9 @@ edx-ace==0.1.8
 edx-analytics-data-api-client
 edx-ccx-keys
 edx-celeryutils
-edx-completion
+edx-completion==1.0.3               # Compatible with edx-drf-extensions
 edx-django-release-util             # Release utils for the edx release pipeline
-edx-drf-extensions
+edx-drf-extensions==1.11.0          # Updates JWT Authentication and adds support for inactive user sessions
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.1
 edx-enterprise

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -237,5 +237,5 @@ web-fragments==0.2.2
 webob==1.8.2              # via xblock
 wrapt==1.10.5
 xblock-review==1.1.5
-xblock==1.2.1
+xblock==1.2.2
 zendesk==1.1.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -111,11 +111,11 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.7
+edx-completion==1.0.3
 edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
-edx-drf-extensions==1.5.2
+edx-drf-extensions==1.11.0
 edx-enterprise==0.70.3
 edx-i18n-tools==0.4.5
 edx-milestones==0.1.13

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -345,7 +345,7 @@ webob==1.8.2
 werkzeug==0.14.1
 wrapt==1.10.5
 xblock-review==1.1.5
-xblock==1.2.1
+xblock==1.2.2
 xmltodict==0.11.0
 zendesk==1.1.1
 zope.interface==4.5.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -131,11 +131,11 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.7
+edx-completion==1.0.3
 edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
-edx-drf-extensions==1.5.2
+edx-drf-extensions==1.11.0
 edx-enterprise==0.70.3
 edx-i18n-tools==0.4.5
 edx-lint==0.5.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -326,7 +326,7 @@ webob==1.8.2
 werkzeug==0.14.1          # via flask
 wrapt==1.10.5
 xblock-review==1.1.5
-xblock==1.2.1
+xblock==1.2.2
 xmltodict==0.11.0         # via moto
 zendesk==1.1.1
 zope.interface==4.5.0     # via twisted

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -126,11 +126,11 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.7
+edx-completion==1.0.3
 edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
-edx-drf-extensions==1.5.2
+edx-drf-extensions==1.11.0
 edx-enterprise==0.70.3
 edx-i18n-tools==0.4.5
 edx-lint==0.5.5


### PR DESCRIPTION
Bumps version of edx-completion to 1.0.3.
* Addresses JWT and inactive user auth issues between completion API and iOS app
* Bumps `edx-drf-extensions` and `XBlock` dependencies to remain compatible with completion, Ginkgo + Hawthorn

**JIRA tickets**: SE-985

**Discussions**: See https://github.com/edx-solutions/edx-platform/pull/1421

**Sandbox URL**: sandbox is being provisioned.
* LMS: https://pr165.sandbox.opencraft.hosting/
* Studio: https://studio.pr165.sandbox.opencraft.hosting/

**Testing instructions**:

Set up edxapp server:
1. Enable mobile REST API (see `FEATURES` below).
1. Enable completion waffle switch: [completion.enable_completion_tracking](https://pr165.sandbox.opencraft.hosting/admin/waffle/switch/2/change/)
1. Create a public, mobile [OAuth2 client](https://pr165.sandbox.opencraft.hosting/admin/oauth2/client/), and duplicate those credentials in a public, Resource owner password-based [OAuth Application](https://pr165.sandbox.opencraft.hosting/admin/oauth2_provider/application/3/change/).
1. Ocim only -- Create a [basic auth OAuth Application](https://pr165.sandbox.opencraft.hosting/admin/oauth2_provider/application/2/change/) with credentials to match the basic auth used by the load balancer.
1. Create a mobile-enabled course (used edX Demo).

Set up iOS app:
1. In `private.yml`, set using the OAuth client key:
   ```yaml
   API_HOST_URL: 'https://pr165.sandbox.opencraft.hosting'
   OAUTH_CLIENT_ID: '****'
   ```
Run the tests:
1. Register a new user (ok to leave inactive).
1. Watch a video and complete a problem on the edX Demo course.
1. Login to the sandbox server as the user, and ensure that these units show up as complete.
    ![completion](https://user-images.githubusercontent.com/7556571/57002514-1d110d00-6bff-11e9-8ee2-e78551bb5191.png)

**Reviewers**
- [ ] @symbolist 

**Settings**
```yaml
EDXAPP_FEATURES:
    ENABLE_MOBILE_REST_API: true
```