### PR TITLE
SE-752 Adds duration argument to send_course_update management command.

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/__init__.py
+++ b/openedx/core/djangoapps/schedules/management/commands/__init__.py
@@ -9,7 +9,7 @@ from openedx.core.djangoapps.schedules.utils import PrefixedDebugLoggerMixin
 
 class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):
     async_send_task = None  # define in subclass
-    offsets = ()  # define in subclass
+    offsets = xrange(-7, -77, -7)
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -22,9 +22,17 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):
             help='Send all emails to this address instead of the actual recipient'
         )
         parser.add_argument('site_domain_name')
+        parser.add_argument(
+            '--duration',
+            type=int,
+            help='The duration for which weekly emails are sent (days).',
+        )
 
     def handle(self, *args, **options):
         self.log_debug('Args = %r', options)
+
+        if 'duration' in options.keys():
+            self.offsets = xrange(-7, -options['duration'], -7)
 
         current_date = datetime.datetime(
             *[int(x) for x in options['date'].split('-')],

--- a/openedx/core/djangoapps/schedules/management/commands/send_course_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/send_course_update.py
@@ -3,6 +3,6 @@ from openedx.core.djangoapps.schedules.tasks import ScheduleCourseUpdate
 
 
 class Command(SendEmailBaseCommand):
+
     async_send_task = ScheduleCourseUpdate
     log_prefix = 'Course Update'
-    offsets = xrange(-7, -77, -7)

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
@@ -32,6 +32,11 @@ class TestSendEmailBaseCommand(CacheIsolationTestCase):
                 None
             )
 
+    def test_duration_option(self):
+        with patch.object(self.command, 'enqueue') as enqueue:
+            self.command.handle(site_domain_name=self.site.domain, date='2017-09-29', duration=63)
+            self.assertEquals(enqueue.call_count, 8)
+
     def test_send_emails(self):
         with patch.multiple(
             self.command,


### PR DESCRIPTION
Cherry-picks the change from https://github.com/edx/edx-platform/pull/19906 into our ironwood release branch.

**Sandbox URL**: sandbox is being provisioned.

* LMS: https://pr169.sandbox.stage.opencraft.hosting/
* Studio: https://studio.pr169.sandbox.stage.opencraft.hosting/

**Merge deadline**: ASAP

**Testing instructions**:

Sandbox `staff` user has superuser privileges.

1. [Enable the creation](https://pr169.sandbox.stage.opencraft.hosting/admin/waffle/) and [scheduling](https://pr169.sandbox.stage.opencraft.hosting/admin/schedules/scheduleconfig/) of course highlights in Django Admin.
1. [Create a self-paced course with weekly course highlights added](https://studio.pr169.sandbox.stage.opencraft.hosting/course/course-v1:OpenCraft+CH+2019_1) to at least section 11 .
1. Register, activate, and enroll a user in the course.
1. Manually modify the automatically created Schedule entry in Django Admin to back-date the enrollment to 11 weeks ago.
1. Run the management command with the following arguments, and ensure that the course highlights from section 11 are sent to the user:
   ```bash
   ./manage.py lms send_course_update --duration 210  --settings=openstack {{ EDXAPP_SITE_NAME }} 
   ```
   Alternately, if you don't have shell access to the server, backdate your Schedule entry to 11 weeks ago yesterday, and wait 24h for the cron to run.

**Reviewers**
- [ ] @pkulkark 

**Settings**
```yaml
# Weekly Course Highlight messages
EDXAPP_ACE_CHANNEL_SAILTHRU_DEBUG: false
EDXAPP_ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME: "template"
EDXAPP_ADDITIONAL_CRON_JOBS:
- name: "Send weekly course highlight emails, daily."
  user: "{{ edxapp_user }}"
  job: "VM1=$(dig vm1.{{ COMMON_DEPLOYMENT }} +short -4  @a.dns.gandi.net); /sbin/ifconfig | grep \"inet addr:${VM1} \" && . {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms send_course_update --duration 210  --settings={{ edxapp_settings }} {{ EDXAPP_SITE_NAME }} >/dev/null 2>&1"
  hour: "0"
  minute: "0"
  day: "*"
```