### PR TITLE
SE-1017 Disable all registration fields except username

### DIFF
--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -165,6 +165,21 @@ def _apply_third_party_auth_overrides(request, form_desc):
                     }
                 )
 
+            if current_provider.provider_slug == 'cloudera-employees':
+                # disable all default fields other than username.
+                form_desc.override_field_properties(
+                    "email",
+                    restrictions={"readonly": "readonly"}
+                )
+                form_desc.override_field_properties(
+                    "name",
+                    restrictions={"readonly": "readonly"}
+                )
+                form_desc.override_field_properties(
+                    "password",
+                    restrictions={"readonly": "readonly"}
+                )
+
 
 class RegistrationFormFactory(object):
     """HTTP end-points for creating a new user. """

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -1,5 +1,6 @@
 import copy
 import crum
+import json
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -165,20 +166,13 @@ def _apply_third_party_auth_overrides(request, form_desc):
                     }
                 )
 
-            if current_provider.provider_slug == 'cloudera-employees':
-                # disable all default fields other than username.
-                form_desc.override_field_properties(
-                    "email",
-                    restrictions={"readonly": "readonly"}
-                )
-                form_desc.override_field_properties(
-                    "name",
-                    restrictions={"readonly": "readonly"}
-                )
-                form_desc.override_field_properties(
-                    "password",
-                    restrictions={"readonly": "readonly"}
-                )
+            other_settings = json.loads(current_provider.other_settings)
+            if 'PROVIDER_READ_ONLY_FIELDS' in other_settings:
+                for field in other_settings['PROVIDER_READ_ONLY_FIELDS']:
+                    form_desc.override_field_properties(
+                        field,
+                        restrictions={"readonly": "readonly"}
+                    )
 
 
 class RegistrationFormFactory(object):

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -126,8 +126,9 @@ class FormDescription(object):
     ALLOWED_RESTRICTIONS = {
         "text": ["min_length", "max_length"],
         "password": ["min_length", "max_length", "upper", "lower", "digits", "punctuation", "non_ascii", "words",
-                     "numeric", "alphabetic"],
+                     "numeric", "alphabetic", "readonly"],
         "email": ["min_length", "max_length", "readonly"],
+        "name": ["readonly"],
     }
 
     FIELD_TYPE_MAP = {


### PR DESCRIPTION
This PR makes all the registration fields except the username, uneditable for user when using cloudera's SSO.

**JIRA**: SE-1017

**Testing Instructions**:
1. Check the cloudera SSO provider config in the django admin page and ensure the option `send to registration form` flag is enabled.
2. Add the registration field names that you'd like to make read-only under the advanced settings like:
```
{"PROVIDER_READ_ONLY_FIELDS": ["email", "name", "password"]}
```
2. Go to the dashboard page and login with SSO credentials.
3. Verify that all the fields except username, is not editable by the user.
