### PR TITLE
SE-1017 Disable all registration fields except username

### DIFF
--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -1017,3 +1017,13 @@ class RegistrationFormFactory(object):
                         default=current_provider.name if current_provider.name else "Third Party",
                         required=False,
                     )
+
+                    # Provider config values are parsed as string. Convert into dictionary.
+                    other_settings = json.loads(current_provider.other_settings)
+
+                    if 'PROVIDER_READ_ONLY_FIELDS' in other_settings:
+                        for field in other_settings['PROVIDER_READ_ONLY_FIELDS']:
+                            form_desc.override_field_properties(
+                                field,
+                                restrictions={"readonly": "readonly"}
+                            )

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -211,17 +211,6 @@ def _apply_third_party_auth_overrides(request, form_desc):
                     }
                 )
 
-            if current_provider.other_settings:
-                # Provider config values are parsed as string. Convert into dictionary.
-                other_settings = json.loads(current_provider.other_settings)
-
-                if 'PROVIDER_READ_ONLY_FIELDS' in other_settings:
-                    for field in other_settings['PROVIDER_READ_ONLY_FIELDS']:
-                        form_desc.override_field_properties(
-                            field,
-                            restrictions={"readonly": "readonly"}
-                    )
-
 
 class RegistrationFormFactory(object):
     """HTTP end-points for creating a new user. """

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -1,5 +1,6 @@
 import copy
 import crum
+import json
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -209,6 +210,16 @@ def _apply_third_party_auth_overrides(request, form_desc):
                         "max_length": accounts.EMAIL_MAX_LENGTH,
                     }
                 )
+
+            # Provider config values are parsed as string. Convert into dictionary.
+            other_settings = json.loads(current_provider.other_settings)
+
+            if 'PROVIDER_READ_ONLY_FIELDS' in other_settings:
+                for field in other_settings['PROVIDER_READ_ONLY_FIELDS']:
+                    form_desc.override_field_properties(
+                        field,
+                        restrictions={"readonly": "readonly"}
+                    )
 
 
 class RegistrationFormFactory(object):

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -211,14 +211,15 @@ def _apply_third_party_auth_overrides(request, form_desc):
                     }
                 )
 
-            # Provider config values are parsed as string. Convert into dictionary.
-            other_settings = json.loads(current_provider.other_settings)
+            if current_provider.other_settings:
+                # Provider config values are parsed as string. Convert into dictionary.
+                other_settings = json.loads(current_provider.other_settings)
 
-            if 'PROVIDER_READ_ONLY_FIELDS' in other_settings:
-                for field in other_settings['PROVIDER_READ_ONLY_FIELDS']:
-                    form_desc.override_field_properties(
-                        field,
-                        restrictions={"readonly": "readonly"}
+                if 'PROVIDER_READ_ONLY_FIELDS' in other_settings:
+                    for field in other_settings['PROVIDER_READ_ONLY_FIELDS']:
+                        form_desc.override_field_properties(
+                            field,
+                            restrictions={"readonly": "readonly"}
                     )
 
 
@@ -1018,12 +1019,13 @@ class RegistrationFormFactory(object):
                         required=False,
                     )
 
-                    # Provider config values are parsed as string. Convert into dictionary.
-                    other_settings = json.loads(current_provider.other_settings)
+                    if current_provider.other_settings:
+                        # Provider config values are parsed as string. Convert into dictionary.
+                        other_settings = json.loads(current_provider.other_settings)
 
-                    if 'PROVIDER_READ_ONLY_FIELDS' in other_settings:
-                        for field in other_settings['PROVIDER_READ_ONLY_FIELDS']:
-                            form_desc.override_field_properties(
-                                field,
-                                restrictions={"readonly": "readonly"}
-                            )
+                        if 'PROVIDER_READ_ONLY_FIELDS' in other_settings:
+                            for field in other_settings['PROVIDER_READ_ONLY_FIELDS']:
+                                form_desc.override_field_properties(
+                                    field,
+                                    restrictions={"readonly": "readonly"}
+                                )

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -125,8 +125,8 @@ class FormDescription(object):
 
     ALLOWED_RESTRICTIONS = {
         "text": ["min_length", "max_length"],
-        "password": ["min_length", "max_length", "upper", "lower", "digits", "punctuation", "non_ascii", "words",
-                     "numeric", "alphabetic", "readonly"],
+        "password": ["min_length", "max_length", "min_upper", "min_lower",
+                     "min_punctuation", "min_symbol", "min_numeric", "min_alphabetic"],
         "email": ["min_length", "max_length", "readonly"],
         "name": ["readonly"],
     }

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -100,7 +100,7 @@ def require_post_params(required_params):
     """
     def _decorator(func):  # pylint: disable=missing-docstring
         @wraps(func)
-        def _wrapped(*args, **_kwargs):
+        def _wrapped(*args, **_kwargs):  # pylint: disable=missing-docstring
             request = args[0]
             missing_params = set(required_params) - set(request.POST.keys())
             if len(missing_params) > 0:
@@ -125,9 +125,10 @@ class FormDescription(object):
 
     ALLOWED_RESTRICTIONS = {
         "text": ["min_length", "max_length"],
-        "password": ["min_length", "max_length", "min_upper", "min_lower",
-                     "min_punctuation", "min_symbol", "min_numeric", "min_alphabetic"],
+        "password": ["min_length", "max_length", "upper", "lower", "digits", "punctuation", "non_ascii", "words",
+                     "numeric", "alphabetic", "readonly"],
         "email": ["min_length", "max_length", "readonly"],
+        "name": ["readonly"],
     }
 
     FIELD_TYPE_MAP = {

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1380,6 +1380,45 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 }
             )
 
+    def test_third_party_auth_disable_registration_fields(self):
+        no_extra_fields_setting = {}
+        provider = self.configure_google_provider(enabled=True,
+                                                  other_settings='{"PROVIDER_READ_ONLY_FIELDS": ["email", "name"]}')
+        with simulate_running_pipeline(
+            "openedx.core.djangoapps.user_api.api.third_party_auth.pipeline", "google-oauth2",
+            email="bob@example.com",
+            fullname="Bob",
+        ):
+            self._assert_reg_field(
+                no_extra_fields_setting,
+                {
+                    u"name": u"name",
+                    u"defaultValue": u"Bob",
+                    u"type": u"text",
+                    u"required": True,
+                    u"label": u"Full Name",
+                    u"instructions": u"This name will be used on any certificates that you earn.",
+                    u"restrictions": {
+                        "readonly": "readonly",
+                    }
+                }
+            )
+
+            self._assert_reg_field(
+                no_extra_fields_setting,
+                {
+                    u"name": u"email",
+                    u"defaultValue": u"bob@example.com",
+                    u"type": u"email",
+                    u"required": True,
+                    u"label": u"Email",
+                    u"instructions": u"This is what you will use to login.",
+                    u"restrictions": {
+                        "readonly": "readonly",
+                    },
+                }
+            )
+
     def test_register_form_level_of_education(self):
         self._assert_reg_field(
             {"level_of_education": "optional"},


### PR DESCRIPTION
This PR makes all the registration fields except the username, uneditable for user when using cloudera's SSO.

See upstream PR https://github.com/edx/edx-platform/pull/20957

**JIRA**: SE-1017

**Testing Instructions**:

1. Check the cloudera SSO provider config in the django admin page and ensure the option `send to registration form` flag is enabled.
2. Add the registration field names that you'd like to make read-only under the advanced settings like:
```
{"PROVIDER_READ_ONLY_FIELDS": ["email", "name"]}
```
3. Go to the dashboard page and login with SSO credentials.
4. Verify that all the fields except username, is not editable by the user.

**Reviewers:**
@pomegranited 