### PR TITLE
Cherry pick certificate authorization checks to Ironwood

### DIFF
--- a/lms/djangoapps/certificates/admin.py
+++ b/lms/djangoapps/certificates/admin.py
@@ -66,7 +66,7 @@ class GeneratedCertificateAdmin(admin.ModelAdmin):
     raw_id_fields = ('user',)
     show_full_result_count = False
     search_fields = ('course_id', 'user__username')
-    list_display = ('id', 'course_id', 'mode', 'user')
+    list_display = ('id', 'course_id', 'mode', 'user', 'status')
 
 
 class CertificateGenerationCourseSettingAdmin(admin.ModelAdmin):

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -43,7 +43,7 @@ from edxmako.template import Template
 from openedx.core.djangoapps.catalog.utils import get_course_run_details
 from openedx.core.djangoapps.lang_pref.api import get_closest_released_language
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace
 from openedx.core.lib.courses import course_image_url
 from openedx.core.djangoapps.certificates.api import display_date_for_certificate, certificates_viewable_for_course
 from student.models import LinkedInAddToProfileConfiguration
@@ -57,6 +57,8 @@ _ = translation.ugettext
 
 
 INVALID_CERTIFICATE_TEMPLATE_PATH = 'certificates/invalid.html'
+WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='certificates')
+LOGIN_REQUIRED_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'require_login')
 
 
 def certs_login_required(view):
@@ -65,7 +67,7 @@ def certs_login_required(view):
     """
     def wrap(request, user_id, course_id, *args, **kwargs):
         course_key = CourseKey.from_string(course_id)
-        if CourseWaffleFlag('certificates', 'require_login').is_enabled(course_key):
+        if LOGIN_REQUIRED_FLAG.is_enabled(course_key):
             return login_required(view)(request, user_id, course_id, *args, **kwargs)
         else:
             return view(request, user_id, course_id, *args, **kwargs)


### PR DESCRIPTION
This cherry picks an upstreamed WaffleFlag to require logins for certificate views.

This also adds the certificate status to the GeneratedCertificates admin page view.

**JIRA tickets**: Implements BB-1388.

**Dependencies**: None

**Sandbox URL**: https://pr20957.sandbox.opencraft.hosting/

**Testing instructions**:

1. Generate a certificate to test with.
    ```
    /edx/bin/{python,manage}.edxapp lms --settings=devstack_docker create_fake_cert verified course-v1:edX+DemoX+Demo_Course
    ```
2. Check the certificate renders normally with no login required in an logged-out browser: http://localhost:18000/certificates/user/8/course/course-v1:edX+DemoX+Demo_Course
3. Enable the waffle switch
    ```
    /edx/bin/{python,manage}.edxapp lms --settings=devstack_docker waffle_switch certificates.require_login on
    ```
4. Check the certificate page again and ensure it requires login now.

**Author notes and concerns**:

1. Should we create a waffle configuration in a new file for the certificates application?

**Reviewers**
- [ ] (@giovannicimolin )
- [ ] edX reviewer[s] TBD