### PR TITLE
Fix the progress graph y-axis - window resize formatting problem in Ironwood

### DIFF
--- a/lms/templates/courseware/progress_graph.js
+++ b/lms/templates/courseware/progress_graph.js
@@ -273,6 +273,7 @@ $(function () {
   };
   
   var $grade_detail_graph = $("#${graph_div_id | n, js_escaped_string}");
+  $grade_detail_graph.width($grade_detail_graph.parent().width());
   if ($grade_detail_graph.length > 0) {
     var plot = $.plot($grade_detail_graph, series, options);
     


### PR DESCRIPTION
Description
---------------
There's an issue that when the screen size is changed after the progress bar is rendered the y-axis values move and overlap the graph or end up off the screen.

The issue here is that the graph is drawn using d3 and d3 fixes nodes to a specific x and y value. The y-axis values are fixed using the `left` css attribute. When the screen changes the `left` value keeps the same and it ends up being somewhere different.

The fix is to make the parent div to have a fixed width which is going to be the width of the screen (or really wherever it's rendered, could be another div) and that width will not change if the screen size is changed.