### PR TITLE
SE-1069 Reverts addition of third_party_auth.ENABLE_OKTA_AUTH_FIX

### DIFF
--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -1,16 +1,9 @@
 """Third party authentication. """
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace, WaffleSwitch
 
 
 default_app_config = 'third_party_auth.apps.ThirdPartyAuthConfig'
-
-# Namespace for Third party authentication app waffle switches
-THIRD_PARTY_AUTH_WAFFLE_SWITCHES = WaffleSwitchNamespace(name='third_party_auth')
-
-# Waffle flag to enable Okta IdP started authentication
-ENABLE_OKTA_AUTH_FIX = WaffleSwitch(THIRD_PARTY_AUTH_WAFFLE_SWITCHES, 'enable_okta_auth_fix')
 
 
 def is_enabled():

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -82,7 +82,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.user_authn import cookies as user_authn_cookies
 from lms.djangoapps.verify_student.models import SSOVerification
 from lms.djangoapps.verify_student.utils import earliest_allowed_verification_date
-from third_party_auth import ENABLE_OKTA_AUTH_FIX
 from third_party_auth.utils import user_exists
 from track import segment
 
@@ -445,15 +444,7 @@ def parse_query_params(strategy, response, *args, **kwargs):
     # We simply assume 'login' in that case.
     auth_entry = strategy.request.session.get(AUTH_ENTRY_KEY, AUTH_ENTRY_LOGIN)
     if auth_entry not in _AUTH_ENTRY_CHOICES:
-        if not auth_entry and ENABLE_OKTA_AUTH_FIX.is_enabled():
-            # This change is for get okta working with the pipeline.
-            # In some clients, the pipeline starts in okta, so we don't have
-            # this in the field in the session, because there there is no
-            # session yet. So we return login, but the standard workflow still
-            # works.
-            return {'auth_entry': 'login'}
         raise AuthEntryError(strategy.request.backend, 'auth_entry invalid')
-
     return {'auth_entry': auth_entry}
 
 


### PR DESCRIPTION
Upstream code has made this patch obsolete, so we are reverting this change to remove the code drift in our branch.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. Verify that the testing process described in [SE-1069](https://tasks.opencraft.com/browse/SE-1069) was sufficient to justify removing this code change.
1. Check that the two files modified here now match upstream [`open-release/ironwood.2`](https://github.com/edx/edx-platform/tree/open-release/ironwood.2).

**Reviewers**
- [x] @swalladge 