### PR TITLE
Applies Patch Ironwood : Prevent reverse tab-nabbing

### DIFF
--- a/cms/static/js/base.js
+++ b/cms/static/js/base.js
@@ -97,7 +97,10 @@ define([
             // general link management - new window/tab
             $('a[rel="external"]:not([title])')
                 .attr('title', gettext('This link will open in a new browser window/tab'));
-            $('a[rel="external"]').attr('target', '_blank');
+            $('a[rel="external"]').attr({
+                rel: 'noopener external',
+                target: '_blank'
+            });
 
             // general link management - lean modal window
             $('a[rel="modal"]').attr('title', gettext('This link will open in a modal window')).leanModal({

--- a/cms/templates/certificates.html
+++ b/cms/templates/certificates.html
@@ -1,9 +1,11 @@
+<%page expression_filter="h"/>
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "certificates" %></%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
 from contentstore import utils
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
@@ -25,8 +27,8 @@ from openedx.core.djangolib.js_utils import (
 window.CMS = window.CMS || {};
 CMS.URL = CMS.URL || {};
 CMS.User = CMS.User || {};
-CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
-CMS.User.isGlobalStaff = '${is_global_staff}'=='True' ? true : false;
+CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}';
+CMS.User.isGlobalStaff = '${is_global_staff | n, js_escaped_string}'=='True' ? true : false;
 </script>
 </%block>
 
@@ -88,13 +90,14 @@ CMS.User.isGlobalStaff = '${is_global_staff}'=='True' ? true : false;
             <h3 class="title-3">${_("Working with Certificates")}</h3>
             <p>${_("Specify a course title to use on the certificate if the course's official title is too long to be displayed well.")}</p>
             <p>${_("For verified certificates, specify between one and four signatories and upload the associated images.")}</p>
-            <p>${_("To edit or delete a certificate before it is activated, hover over the top right corner of the form and select {em_start}Edit{em_end} or the delete icon.").format(em_start="<strong>", em_end="</strong>")}</p>
-            <p>${_("To view a sample certificate, choose a course mode and select {em_start}Preview Certificate{em_end}.").format(em_start='<strong>', em_end="</strong>")}</p>
+            <p>${Text(_("To edit or delete a certificate before it is activated, hover over the top right corner of the form and select {em_start}Edit{em_end} or the delete icon.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
+            <p>${Text(_("To view a sample certificate, choose a course mode and select {em_start}Preview Certificate{em_end}.")).format(em_start=HTML('<strong>'), em_end=HTML("</strong>"))}</p>
 
             <h3 class="title-3">${_("Issuing Certificates to Learners")}</h3>
-            <p>${_("To begin issuing course certificates, a course team member with either the Staff or Admin role selects {em_start}Activate{em_end}. Only course team members with these roles can edit or delete an activated certificate.").format(em_start="<strong>", em_end="</strong>")}</p>
-            <p>${_("{em_start}Do not{em_end} delete certificates after a course has started; learners who have already earned certificates will no longer be able to access them.").format(em_start="<strong>", em_end="</strong>")}</p>
-            <p><a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about certificates")}</a></p>
+            <p>${Text(_("To begin issuing course certificates, a course team member with either the Staff or Admin role selects {em_start}Activate{em_end}. Only course team members with these roles can edit or delete an activated certificate.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
+            <p>${Text(_("{em_start}Do not{em_end} delete certificates after a course has started; learners who have already earned certificates will no longer be able to access them.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
+            <p><a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about certificates")}</a></p>
+
           </div>
         </div>
         <div class="bit">
@@ -108,7 +111,7 @@ CMS.User.isGlobalStaff = '${is_global_staff}'=='True' ? true : false;
         <h2 class="title-3">${_("Other Course Settings")}</h2>
           <nav class="nav-related" aria-label="${_('Other Course Settings')}">
             <ul>
-              <li class="nav-item"><a href="${details_url}">${_("Details &amp; Schedule")}</a></li>
+              <li class="nav-item"><a href="${details_url}">${_("Details & Schedule")}</a></li>
               <li class="nav-item"><a href="${grading_url}">${_("Grading")}</a></li>
               <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
               <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -144,7 +144,7 @@ from openedx.core.djangolib.markup import HTML, Text
                         <p>${_("Confirm that you have properly configured content in each of your experiment groups.")}</p>
                     </div>
                     <div class="bit external-help">
-                        <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about component containers")}</a>
+                        <a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about component containers")}</a>
                     </div>
                 % elif is_unit_page:
                     <div id="publish-unit"></div>
@@ -155,7 +155,8 @@ from openedx.core.djangolib.markup import HTML, Text
                             <h5 class="title">${_("Location ID")}</h5>
                             <p class="unit-id">
                                 <span class="unit-id-value" id="unit-location-id-input">${unit.location.block_id}</span>
-                                <span class="tip"><span class="sr">Tip: </span>${_('To create a link to this unit from an HTML component in this course, enter "/jump_to_id/<location ID>" as the URL value.')}</span>
+                                <span class="tip"><span class="sr">Tip: </span>${Text(_('To create a link to this unit from an HTML component in this course, enter "/jump_to_id/<location ID>" as the URL value.'))}</span>
+
                             </p>
                         </div>
                         <div class="wrapper-unit-tree-location bar-mod-content">

--- a/cms/templates/course-create-rerun.html
+++ b/cms/templates/course-create-rerun.html
@@ -148,7 +148,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
           </div>
 
           <div class="bit external-help">
-            <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about Course Re-runs")}</a>
+            <a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about Course Re-runs")}</a>
           </div>
         </aside>
 

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -164,7 +164,7 @@ from django.core.urlresolvers import reverse
                     <div style="width: 50%" class="status-studio-frontend">
                 % endif
                     <%static:studiofrontend entry="courseOutlineHealthCheck">
-                        <% 
+                        <%
                             course_key = context_course.id
                         %>
                         {
@@ -188,7 +188,7 @@ from django.core.urlresolvers import reverse
                                 "settings": ${reverse('settings_handler', kwargs={'course_key_string': unicode(course_key)})| n, dump_js_escaped_json}
                             }
                         }
-                    </%static:studiofrontend> 
+                    </%static:studiofrontend>
                 </div>
                 <div class="status-highlights-enabled"></div>
             </div>
@@ -218,14 +218,14 @@ from django.core.urlresolvers import reverse
                 <h3 class="title-3">${_("Reorganizing your course")}</h3>
                 <p>${_("Drag sections, subsections, and units to new locations in the outline.")}</p>
                 <div class="external-help">
-                    <a href="${get_online_help_info('outline')['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about the course outline")}</a>
+                    <a href="${get_online_help_info('outline')['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about the course outline")}</a>
                 </div>
             </div>
             <div class="bit">
                 <h3 class="title-3">${_("Setting release dates and grading policies")}</h3>
                 <p>${_("Select the Configure icon for a section or subsection to set its release date. When you configure a subsection, you can also set the grading policy and due date.")}</p>
                 <div class="external-help">
-                    <a href="${get_online_help_info('grading')['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about grading policy settings")}</a>
+                    <a href="${get_online_help_info('grading')['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about grading policy settings")}</a>
                 </div>
             </div>
             <div class="bit">
@@ -234,7 +234,7 @@ from django.core.urlresolvers import reverse
                 <p>${Text(_("To make a section, subsection, or unit unavailable to learners, select the Configure icon for that level, then select the appropriate {em_start}Hide{em_end} option. Grades for hidden sections, subsections, and units are not included in grade calculations.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
                 <p>${Text(_("To hide the content of a subsection from learners after the subsection due date has passed, select the Configure icon for a subsection, then select {em_start}Hide content after due date{em_end}. Grades for the subsection remain included in grade calculations.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
                 <div class="external-help">
-                    <a href="${get_online_help_info('visibility')['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about content visibility settings")}</a>
+                    <a href="${get_online_help_info('visibility')['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about content visibility settings")}</a>
                 </div>
             </div>
 

--- a/cms/templates/export.html
+++ b/cms/templates/export.html
@@ -235,7 +235,7 @@ else:
           <p>${_("Use an archive program to extract the data from the .tar.gz file. Extracted data includes the library.xml file, as well as subfolders that contain library content.")}</p>
       </div>
       <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about exporting a library")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about exporting a library")}</a>
       </div>
     </aside>
   %else:
@@ -269,7 +269,7 @@ else:
         <p>${_("Use an archive program to extract the data from the .tar.gz file. Extracted data includes the course.xml file, as well as subfolders that contain course content.")}</p>
       </div>
       <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about exporting a course")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about exporting a course")}</a>
       </div>
     </aside>
   %endif

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -86,7 +86,7 @@ from openedx.core.djangolib.markup import HTML, Text
             <p>${_("Enrollment track groups allow you to offer different course content to learners in each enrollment track. Learners enrolled in each enrollment track in your course are automatically included in the corresponding enrollment track group.")}</p>
             <p>${_("On unit pages in the course outline, you can restrict access to components to learners based on their enrollment track.")}</p>
             <p>${_("You cannot edit enrollment track groups, but you can expand each group to view details of the course content that is designated for learners in the group.")}</p>
-            <p><a href="${get_online_help_info(enrollment_track_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
+            <p><a href="${get_online_help_info(enrollment_track_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
           </div>
         </div>
       % endif
@@ -96,7 +96,7 @@ from openedx.core.djangolib.markup import HTML, Text
               <p>${_("If you have cohorts enabled in your course, you can use content groups to create cohort-specific courseware. In other words, you can customize the content that particular cohorts see in your course.")}</p>
               <p>${_("Each content group that you create can be associated with one or more cohorts. In addition to making course content available to all learners, you can restrict access to some content to learners in specific content groups. Only learners in the cohorts that are associated with the specified content groups see the additional content.")}</p>
               <p>${Text(_("Click {em_start}New content group{em_end} to add a new content group. To edit the name of a content group, hover over its box and click {em_start}Edit{em_end}. You can delete a content group only if it is not in use by a unit. To delete a content group, hover over its box and click the delete icon.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
-              <p><a href="${get_online_help_info(content_groups_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
+              <p><a href="${get_online_help_info(content_groups_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
           </div>
         </div>
       % if should_show_experiment_groups:
@@ -105,7 +105,7 @@ from openedx.core.djangolib.markup import HTML, Text
             <h3 class="title-3">${_("Experiment Group Configurations")}</h3>
             <p>${_("Use experiment group configurations if you are conducting content experiments, also known as A/B testing, in your course. Experiment group configurations define how many groups of learners are in a content experiment. When you create a content experiment for a course, you select the group configuration to use.")}</p>
             <p>${Text(_("Click {em_start}New Group Configuration{em_end} to add a new configuration. To edit a configuration, hover over its box and click {em_start}Edit{em_end}. You can delete a group configuration only if it is not in use in an experiment. To delete a configuration, hover over its box and click the delete icon.")).format(em_start=HTML("<strong>"), em_end=HTML("</strong>"))}</p>
-            <p><a href="${get_online_help_info(experiment_group_configurations_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
+            <p><a href="${get_online_help_info(experiment_group_configurations_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn More")}</a></p>
           </div>
         </div>
       % endif

--- a/cms/templates/import.html
+++ b/cms/templates/import.html
@@ -213,7 +213,7 @@ else:
           <p>${_("If you change and import a library that is referenced by randomized content blocks in one or more courses, those courses do not automatically use the updated content. You must manually refresh the randomized content blocks to bring them up to date with the latest library content.")}</p>
       </div>
       <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about importing a library")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about importing a library")}</a>
       </div>
     </aside>
   %else:
@@ -245,7 +245,7 @@ else:
         <p>${_("If you perform an import while your course is running, and you change the URL names (or url_name nodes) of any Problem components, the student data associated with those Problem components may be lost. This data includes students' problem scores.")}</p>
       </div>
       <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about importing a course")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about importing a course")}</a>
       </div>
     </aside>
   %endif

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -519,7 +519,7 @@ from openedx.core.djangolib.js_utils import (
         <ol class="list-actions">
           <li class="action-item">
 
-            <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank">${_("Getting Started with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
+            <a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank">${_("Getting Started with {studio_name}").format(studio_name=settings.STUDIO_NAME)}</a>
           </li>
         </ol>
       </div>

--- a/cms/templates/js/add-xblock-component-support-legend.underscore
+++ b/cms/templates/js/add-xblock-component-support-legend.underscore
@@ -1,7 +1,7 @@
 <% if (support_legend.show_legend) { %>
     <span class="support-documentation">
         <a class="support-documentation-link"
-           href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/create_exercises_and_tools.html#levels-of-support-for-tools" target="_blank">
+           href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/create_exercises_and_tools.html#levels-of-support-for-tools" rel="noopener" target="_blank">
             <%- support_legend.documentation_label %>
         </a>
         <span class="support-documentation-level">

--- a/cms/templates/js/certificate-web-preview.underscore
+++ b/cms/templates/js/certificate-web-preview.underscore
@@ -1,17 +1,17 @@
-<label for="course-modes"><%= gettext("Choose mode") %></label>
+<label for="course-modes"><%- gettext("Choose mode") %></label>
 <select id="course-modes">
 <% _.each(course_modes, function(course_mode) { %>
-     <option value= "<%= course_mode %>"><%= course_mode %></option>
+     <option value= "<%- course_mode %>"><%- course_mode %></option>
 <% }); %>
 </select>
-<a href=<%= certificate_web_view_url %> class="button preview-certificate-link" target="_blank">
-    <%= gettext("Preview Certificate") %>
+<a href=<%- certificate_web_view_url %> class="button preview-certificate-link" rel="noopener" target="_blank">
+    <%- gettext("Preview Certificate") %>
 </a>
 <button class="button activate-cert">
     <span>
     <% if(!is_active) { %>
-        <%= gettext("Activate") %></span>
+        <%- gettext("Activate") %></span>
     <% } else { %>
-        <%= gettext("Deactivate") %></span>
+        <%- gettext("Deactivate") %></span>
     <% } %>
 </button>

--- a/cms/templates/js/course-highlights-enable.underscore
+++ b/cms/templates/js/course-highlights-enable.underscore
@@ -8,5 +8,5 @@
 <% } else { %>
   <button class="status-highlights-enabled-value button" aria-labelledby="highlights-enabled-label"><%- gettext('Enable Now') %></button>
 <% } %>
-<a class="status-highlights-enabled-info" href="<%- highlights_doc_url %>" target="_blank">Learn more</a>
+<a class="status-highlights-enabled-info" href="<%- highlights_doc_url %>" rel="noopener" target="_blank">Learn more</a>
 </div>

--- a/cms/templates/js/highlights-enable-editor.underscore
+++ b/cms/templates/js/highlights-enable-editor.underscore
@@ -15,7 +15,7 @@
     ),
     {
         linkStart: edx.HtmlUtils.interpolateHtml(
-            edx.HtmlUtils.HTML('<a href="{highlightsDocUrl}" target="_blank">'),
+            edx.HtmlUtils.HTML('<a href="{highlightsDocUrl}" rel="noopener" target="_blank">'),
             {highlightsDocUrl: xblockInfo.attributes.highlights_doc_url}
         ),
         linkEnd: edx.HtmlUtils.HTML('</a>')

--- a/cms/templates/js/license-selector.underscore
+++ b/cms/templates/js/license-selector.underscore
@@ -1,9 +1,9 @@
 <div class="wrapper-license">
     <h3 class="label setting-label">
-        <%= gettext("License Type") %>
+        <%- gettext("License Type") %>
     </h3>
     <ul class="license-types">
-        <% var link_start_tpl = '<a href="{url}" target="_blank">'; %>
+        <% var link_start_tpl = '<a href="{url}" rel="noopener" target="_blank">'; %>
         <% _.each(licenseInfo, function(license, licenseType) { %>
             <li class="license-type" data-license="<%- licenseType %>">
                 <button name="license-<%- licenseType %>"
@@ -14,8 +14,8 @@
                 </button>
                 <p class="tip">
                     <% if(license.url) { %>
-                        <a href="<%- license.url %>" target="_blank">
-                            <%= gettext("Learn more about {license_name}")
+                        <a href="<%- license.url %>" rel="noopener" target="_blank">
+                            <%- gettext("Learn more about {license_name}")
                                         .replace("{license_name}", license.name)
                             %>
                         </a>
@@ -71,15 +71,15 @@
 <% if (showPreview) { %>
     <div class="wrapper-license-preview">
         <h4 class="label setting-label">
-            <%= gettext("License Display") %>
+            <%- gettext("License Display") %>
         </h4>
         <p class="tip">
-            <%= gettext("The following message will be displayed at the bottom of the courseware pages within your course:") %>
+            <%- gettext("The following message will be displayed at the bottom of the courseware pages within your course:") %>
         </p>
         <div class="license-preview">
         <% // keep this synchronized with the contents of common/templates/license.html %>
         <% if (model.type === "all-rights-reserved") { %>
-            © <span class="license-text"><%= gettext("All Rights Reserved") %></span>
+            © <span class="license-text"><%- gettext("All Rights Reserved") %></span>
         <% } else if (model.type === "creative-commons") {
              var possible = ["by", "nc", "nd", "sa"];
              var enabled = _.filter(possible, function(option) {
@@ -98,16 +98,16 @@
                     />
             <% } else { %>
 	        <% //<span> must come before <i> icon or else spacing gets messed up %>
-                <span class="sr"><%= gettext("Creative Commons licensed content, with terms as follow:") %>&nbsp;</span><span aria-hidden="true" class="icon-cc"></span>
+                <span class="sr"><%- gettext("Creative Commons licensed content, with terms as follow:") %>&nbsp;</span><span aria-hidden="true" class="icon-cc"></span>
                 <% _.each(enabled, function(option) { %>
                         <span class="sr"><%- license.options[option.toUpperCase()].name %>&nbsp;</span><span aria-hidden="true" class="icon-cc-<%- option %>"></span>
                 <% }); %>
-                <span class="license-text"><%= gettext("Some Rights Reserved") %></span>
+                <span class="license-text"><%- gettext("Some Rights Reserved") %></span>
             <% } %>
         <% } else { %>
-            <%= typeof licenseString == "string" ? licenseString : "" %>
+            <%- typeof licenseString == "string" ? licenseString : "" %>
             <% // Default to ARR license %>
-            © <span class="license-text"><%= gettext("All Rights Reserved") %></span>
+            © <span class="license-text"><%- gettext("All Rights Reserved") %></span>
         <% } %>
         </a>
     </div>

--- a/cms/templates/js/metadata-file-uploader-item.underscore
+++ b/cms/templates/js/metadata-file-uploader-item.underscore
@@ -1,3 +1,3 @@
-<a href="#" class="upload-action upload-setting"><%= model.get('value') ? gettext('Replace') : gettext('Upload') %>
-</a><% if (model.get('value')) { %><a href="<%= model.get("value") %>" target="_blank" class="download-action download-setting"><%= gettext("Download") %>
+<a href="#" class="upload-action upload-setting"><%- model.get('value') ? gettext('Replace') : gettext('Upload') %>
+</a><% if (model.get('value')) { %><a href="<%- model.get("value") %>" rel="noopener" target="_blank" class="download-action download-setting"><%- gettext("Download") %>
 </a><% } %>

--- a/cms/templates/library.html
+++ b/cms/templates/library.html
@@ -98,7 +98,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 </div>
                 % endif
                 <div class="bit external-help">
-                    <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about content libraries")}</a>
+                    <a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about content libraries")}</a>
                 </div>
             </div>
         </div>

--- a/cms/templates/textbooks.html
+++ b/cms/templates/textbooks.html
@@ -1,9 +1,10 @@
+<%page expression_filter="h"/>
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "textbooks" %></%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from openedx.core.djangolib.js_utils import dump_js_escaped_json
+from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
 
 <%block name="title">${_("Textbooks")}</%block>
@@ -21,9 +22,9 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json
 <script type="text/javascript">
 window.CMS = window.CMS || {};
 CMS.URL = CMS.URL || {};
-CMS.URL.UPLOAD_ASSET = "${upload_asset_url}"
-CMS.URL.TEXTBOOKS = "${textbook_url}"
-CMS.URL.LMS_BASE = "${settings.LMS_BASE}"
+CMS.URL.UPLOAD_ASSET = "${upload_asset_url | n, js_escaped_string}"
+CMS.URL.TEXTBOOKS = "${textbook_url | n, js_escaped_string}"
+CMS.URL.LMS_BASE = "${settings.LMS_BASE | n, js_escaped_string}"
 </script>
 </%block>
 
@@ -66,7 +67,7 @@ CMS.URL.LMS_BASE = "${settings.LMS_BASE}"
         </div>
 
         <div class="bit external-help">
-          <a href="${get_online_help_info(online_help_token())['doc_url']}" target="_blank" class="button external-help-button">${_("Learn more about textbooks")}</a>
+          <a href="${get_online_help_info(online_help_token())['doc_url']}" rel="noopener" target="_blank" class="button external-help-button">${_("Learn more about textbooks")}</a>
         </div>
       </aside>
     </section>

--- a/cms/templates/ux/reference/fragments/course-settings.html
+++ b/cms/templates/ux/reference/fragments/course-settings.html
@@ -41,7 +41,7 @@
             <h3 class="title">Course Summary Page <span class="tip">(for student enrollment and access)</span></h3>
             <div class="copy">
 
-              <p><a class="link-courseURL" rel="external" href="http://localhost:8000/courses/course-v1:AndyA+AA101+1/about" title="This link will open in a new browser window/tab" target="_blank">http://localhost:8000/courses/course-v1:AndyA+AA101+1/about</a></p>
+              <p><a class="link-courseURL" rel="external noopener" href="http://localhost:8000/courses/course-v1:AndyA+AA101+1/about" title="This link will open in a new browser window/tab" target="_blank">http://localhost:8000/courses/course-v1:AndyA+AA101+1/about</a></p>
             </div>
 
             <ul class="list-actions">
@@ -351,7 +351,7 @@
                   <label class="sr" for="course-overview-cm-textarea">
                     HTML Code Editor
                   </label>
-                  <span class="tip tip-stacked">Introductions, prerequisites, FAQs that are used on <a class="link-courseURL" rel="external" href="http://localhost:8000/courses/course-v1:AndyA+AA101+1/about" title="This link will open in a new browser window/tab" target="_blank">your course summary page</a> (formatted in HTML)</span>
+                  <span class="tip tip-stacked">Introductions, prerequisites, FAQs that are used on <a class="link-courseURL" rel="external noopener" href="http://localhost:8000/courses/course-v1:AndyA+AA101+1/about" title="This link will open in a new browser window/tab" target="_blank">your course summary page</a> (formatted in HTML)</span>
                 </li>
 
                 <li class="field image" id="field-course-image">
@@ -465,7 +465,7 @@
                 </button>
                 <p class="tip">
 
-                        <a href="https://creativecommons.org/about" target="_blank">
+                        <a href="https://creativecommons.org/about" rel="noopener" target="_blank">
                             Learn more about Creative Commons
                         </a>
 

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -220,7 +220,7 @@
         <h2 class="sr-only">${_("Account Navigation")}</h2>
         <ol>
           <li class="nav-item nav-account-help">
-            <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" target="_blank">${_("Help")}</a></span></h3>
+            <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a></span></h3>
           </li>
           <li class="nav-item nav-account-user">
             <%include file="user_dropdown.html" args="online_help_token=online_help_token" />
@@ -236,7 +236,7 @@
         <h2 class="sr-only">${_("Account Navigation")}</h2>
         <ol>
           <li class="nav-item nav-not-signedin-help">
-            <a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" target="_blank">${_("Help")}</a>
+            <a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a>
           </li>
           % if static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION')):
               <li class="nav-item nav-not-signedin-signup">

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -77,13 +77,16 @@ from xmodule.editing_module import MetadataOnlyEditingDescriptor
 from xmodule.lti_2_util import LTI20ModuleMixin, LTIError
 from xmodule.raw_module import EmptyDataRawDescriptor
 from xmodule.x_module import XModule, module_attr
+from openedx.core.djangolib.markup import HTML, Text
+
 
 log = logging.getLogger(__name__)
 
 DOCS_ANCHOR_TAG_OPEN = (
-    "<a target='_blank' "
+    "<a rel='noopener' target='_blank' "
     "href='https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html'>"
 )
+BREAK_TAG = '<br />'
 
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
 #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
@@ -121,39 +124,42 @@ class LTIFields(object):
     )
     lti_id = String(
         display_name=_("LTI ID"),
-        help=_(
+        help=Text(_(
             "Enter the LTI ID for the external LTI provider.  "
             "This value must be the same LTI ID that you entered in the "
             "LTI Passports setting on the Advanced Settings page."
-            "<br />See {docs_anchor_open}the edX LTI documentation{anchor_close} for more details on this setting."
-        ).format(
-            docs_anchor_open=DOCS_ANCHOR_TAG_OPEN,
-            anchor_close="</a>"
+            "{break_tag}See {docs_anchor_open}the edX LTI documentation{anchor_close} for more details on this setting."
+        )).format(
+            break_tag=HTML(BREAK_TAG),
+            docs_anchor_open=HTML(DOCS_ANCHOR_TAG_OPEN),
+            anchor_close=HTML("</a>")
         ),
         default='',
         scope=Scope.settings
     )
     launch_url = String(
         display_name=_("LTI URL"),
-        help=_(
+        help=Text(_(
             "Enter the URL of the external tool that this component launches. "
             "This setting is only used when Hide External Tool is set to False."
-            "<br />See {docs_anchor_open}the edX LTI documentation{anchor_close} for more details on this setting."
-        ).format(
-            docs_anchor_open=DOCS_ANCHOR_TAG_OPEN,
-            anchor_close="</a>"
+            "{break_tag}See {docs_anchor_open}the edX LTI documentation{anchor_close} for more details on this setting."
+        )).format(
+            break_tag=HTML(BREAK_TAG),
+            docs_anchor_open=HTML(DOCS_ANCHOR_TAG_OPEN),
+            anchor_close=HTML("</a>")
         ),
         default='http://www.example.com',
         scope=Scope.settings)
     custom_parameters = List(
         display_name=_("Custom Parameters"),
-        help=_(
+        help=Text(_(
             "Add the key/value pair for any custom parameters, such as the page your e-book should open to or "
             "the background color for this component."
-            "<br />See {docs_anchor_open}the edX LTI documentation{anchor_close} for more details on this setting."
-        ).format(
-            docs_anchor_open=DOCS_ANCHOR_TAG_OPEN,
-            anchor_close="</a>"
+            "{break_tag}See {docs_anchor_open}the edX LTI documentation{anchor_close} for more details on this setting."
+        )).format(
+            break_tag=HTML(BREAK_TAG),
+            docs_anchor_open=HTML(DOCS_ANCHOR_TAG_OPEN),
+            anchor_close=HTML("</a>")
         ),
         scope=Scope.settings)
     open_in_a_new_page = Boolean(

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -89,14 +89,14 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         Returns expected dashboard enrollment message with link to Insights.
         """
         return 'Enrollment data is now available in <a href="http://example.com/courses/{}" ' \
-               'target="_blank">Example</a>.'.format(text_type(self.course.id))
+               'rel="noopener" target="_blank">Example</a>.'.format(text_type(self.course.id))
 
     def get_dashboard_analytics_message(self):
         """
         Returns expected dashboard demographic message with link to Insights.
         """
         return 'For analytics about your course, go to <a href="http://example.com/courses/{}" ' \
-               'target="_blank">Example</a>.'.format(text_type(self.course.id))
+               'rel="noopener" target="_blank">Example</a>.'.format(text_type(self.course.id))
 
     def test_instructor_tab(self):
         """

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -136,7 +136,7 @@ def instructor_dashboard_2(request, course_id):
     if show_analytics_dashboard_message(course_key):
         # Construct a URL to the external analytics dashboard
         analytics_dashboard_url = '{0}/courses/{1}'.format(settings.ANALYTICS_DASHBOARD_URL, unicode(course_key))
-        link_start = HTML("<a href=\"{}\" target=\"_blank\">").format(analytics_dashboard_url)
+        link_start = HTML("<a href=\"{}\" rel=\"noopener\" target=\"_blank\">").format(analytics_dashboard_url)
         analytics_dashboard_message = _(
             "To gain insights into student enrollment and participation {link_start}"
             "visit {analytics_dashboard_name}, our new course analytics product{link_end}."
@@ -711,7 +711,7 @@ def _section_send_email(course, access):
 def _get_dashboard_link(course_key):
     """ Construct a URL to the external analytics dashboard """
     analytics_dashboard_url = '{0}/courses/{1}'.format(settings.ANALYTICS_DASHBOARD_URL, unicode(course_key))
-    link = HTML(u"<a href=\"{0}\" target=\"_blank\">{1}</a>").format(
+    link = HTML(u"<a href=\"{0}\" rel=\"noopener\" target=\"_blank\">{1}</a>").format(
         analytics_dashboard_url, settings.ANALYTICS_DASHBOARD_NAME
     )
     return link

--- a/lms/static/js/instructor_dashboard/util.js
+++ b/lms/static/js/instructor_dashboard/util.js
@@ -488,7 +488,7 @@
                     cssClass: 'file-download-link',
                     formatter: function(row, cell, value, columnDef, dataContext) {
                         return edx.HtmlUtils.joinHtml(edx.HtmlUtils.HTML(
-                            '<a target="_blank" href="'), dataContext.url,
+                            '<a rel="noopener" target="_blank" href="'), dataContext.url,
                             edx.HtmlUtils.HTML('">'), dataContext.name,
                             edx.HtmlUtils.HTML('</a>'));
                     }

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -41,7 +41,7 @@ export class StudentAccountDeletion extends React.Component {
     const loseAccessText = StringUtils.interpolate(
       gettext('You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for {htmlStart}printing or downloading a certificate{htmlEnd}.'),
       {
-        htmlStart: '<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" target="_blank">',
+        htmlStart: '<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" rel="noopener" target="_blank">',
         htmlEnd: '</a>',
       },
     );
@@ -51,7 +51,7 @@ export class StudentAccountDeletion extends React.Component {
     const socialAuthError = StringUtils.interpolate(
       gettext('Before proceeding, please {htmlStart}unlink all social media accounts{htmlEnd}.'),
       {
-        htmlStart: '<a href="https://support.edx.org/hc/en-us/articles/207206067" target="_blank">',
+        htmlStart: '<a href="https://support.edx.org/hc/en-us/articles/207206067" rel="noopener" target="_blank">',
         htmlEnd: '</a>',
       },
     );
@@ -59,7 +59,7 @@ export class StudentAccountDeletion extends React.Component {
     const activationError = StringUtils.interpolate(
       gettext('Before proceeding, please {htmlStart}activate your account{htmlEnd}.'),
       {
-        htmlStart: '<a href="https://support.edx.org/hc/en-us/articles/115000940568-How-do-I-activate-my-account-" target="_blank">',
+        htmlStart: '<a href="https://support.edx.org/hc/en-us/articles/115000940568-How-do-I-activate-my-account-" rel="noopener" target="_blank">',
         htmlEnd: '</a>',
       },
     );
@@ -67,7 +67,7 @@ export class StudentAccountDeletion extends React.Component {
     const changeAcctInfoText = StringUtils.interpolate(
       gettext('{htmlStart}Want to change your email, name, or password instead?{htmlEnd}'),
       {
-        htmlStart: '<a href="https://support.edx.org/hc/en-us/sections/115004139268-Manage-Your-Account-Settings" target="_blank">',
+        htmlStart: '<a href="https://support.edx.org/hc/en-us/sections/115004139268-Manage-Your-Account-Settings" rel="noopener" target="_blank">',
         htmlEnd: '</a>',
       },
     );

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -96,7 +96,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
     const loseAccessText = StringUtils.interpolate(
       gettext('You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for {htmlStart}printing or downloading a certificate{htmlEnd}.'),
       {
-        htmlStart: '<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" target="_blank">',
+        htmlStart: '<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" rel="noopener" target="_blank">',
         htmlEnd: '</a>',
       },
     );

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -133,12 +133,11 @@
 
                 render: function(html) {
                     var fields = html || '',
-                        formErrorsTitle = gettext('An error occurred.');
-
-                    $(this.el).html(_.template(this.tpl)({
-                    /* We pass the context object to the template so that
-                     * we can perform variable interpolation using sprintf
-                     */
+                        formErrorsTitle = gettext('An error occurred.'),
+                        renderHtml = _.template(this.tpl)({
+                          /* We pass the context object to the template so that
+                           * we can perform variable interpolation using sprintf
+                           */
                         context: {
                             fields: fields,
                             currentProvider: this.currentProvider,
@@ -149,7 +148,8 @@
                             autoRegisterWelcomeMessage: this.autoRegisterWelcomeMessage,
                             registerFormSubmitButtonText: this.registerFormSubmitButtonText
                         }
-                    }));
+                        });
+                    HtmlUtils.setHtml($(this.el), HtmlUtils.HTML(renderHtml));
 
                     this.postRender();
 
@@ -261,7 +261,7 @@
                     $('label a').click(function(ev) {
                         ev.stopPropagation();
                         ev.preventDefault();
-                        window.open($(this).attr('href'), $(this).attr('target'));
+                        window.open($(this).attr('href'), $(this).attr('target'), 'noopener');
                     });
                     $('.form-field').each(function() {
                         $(this).find('option:first').html('');

--- a/lms/templates/api_admin/catalogs/edit.html
+++ b/lms/templates/api_admin/catalogs/edit.html
@@ -4,6 +4,7 @@
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 
 <%namespace name='static' file='/static_content.html'/>
@@ -13,8 +14,8 @@ from django.utils.translation import ugettext as _
 <%block name="js_extra">
 <%static:require_module module_name="js/api_admin/catalog_preview_factory" class_name="CatalogPreviewFactory">
   CatalogPreviewFactory({
-    previewUrl: "${preview_url}",
-    catalogApiUrl: "${catalog_api_url}",
+    previewUrl: "${preview_url | n, js_escaped_string}",
+    catalogApiUrl: "${catalog_api_url | n, js_escaped_string}",
   });
 </%static:require_module>
 </%block>
@@ -24,7 +25,7 @@ from django.utils.translation import ugettext as _
   <h1 id="api-header">${catalog.name}</h1>
 
   <p>
-    <a href="${'{root}/{id}/csv/'.format(root=catalog_api_catalog_endpoint, id=catalog.id)}" target="_blank">
+    <a href="${'{root}/{id}/csv/'.format(root=catalog_api_catalog_endpoint, id=catalog.id)}" rel="noopener" target="_blank">
       ${_("Download CSV")}
     </a>
   </p>
@@ -37,7 +38,7 @@ from django.utils.translation import ugettext as _
           <input type="checkbox" id="delete-catalog" name="delete-catalog" />
           <label class="api-checkbox-label" for="delete-catalog">${_("Delete this catalog")}</label>
         </p>
-        ${form.as_p() | n}
+        ${form.as_p() | n, decode.utf8}
         <input id="catalog-create-submit" type="submit" value="${_('Update Catalog')}"/>
       </form>
     </div>

--- a/lms/templates/api_admin/catalogs/list.html
+++ b/lms/templates/api_admin/catalogs/list.html
@@ -4,6 +4,7 @@
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 
 <%namespace name='static' file='/static_content.html'/>
@@ -13,8 +14,8 @@ from django.utils.translation import ugettext as _
 <%block name="js_extra">
 <%static:require_module module_name="js/api_admin/catalog_preview_factory" class_name="CatalogPreviewFactory">
 CatalogPreviewFactory({
-  previewUrl: "${preview_url}",
-  catalogApiUrl: "${catalog_api_url}",
+  previewUrl: "${preview_url | n, js_escaped_string}",
+  catalogApiUrl: "${catalog_api_url | n, js_escaped_string}",
 });
 </%static:require_module>
 </%block>
@@ -28,7 +29,7 @@ CatalogPreviewFactory({
       <a href="${reverse('api_admin:catalog-edit', args=(catalog.id,))}">${catalog.name}</a>&nbsp;
       (<a
           href="${'{root}/{id}/csv/'.format(root=catalog_api_catalog_endpoint, id=catalog.id)}"
-          target="_blank">${_("Download CSV")}</a>)
+          rel="noopener" target="_blank">${_("Download CSV")}</a>)
     </li>
     % endfor
   </ul>
@@ -38,7 +39,7 @@ CatalogPreviewFactory({
     <div class="api-form-container">
       <form class="api-form" id="catalog-create" action="${reverse('api_admin:catalog-list', args={'username': username})}" method="post">
         <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
-        ${form.as_p() | n}
+        ${form.as_p() | n, decode.utf8}
         <input id="catalog-create-submit" type="submit" value="${_('Create Catalog')}"/>
       </form>
     </div>

--- a/lms/templates/certificates/_accomplishment-banner.html
+++ b/lms/templates/certificates/_accomplishment-banner.html
@@ -25,7 +25,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
                   social_network: 'LinkedIn'
               };
               Logger.log('edx.certificate.shared', data);
-              window.open('${linked_in_url | n, js_escaped_string}');
+              window.open('${linked_in_url | n, js_escaped_string}', '', 'noopener');
           });
       });
 
@@ -33,7 +33,9 @@ from openedx.core.djangolib.js_utils import js_escaped_string
           // popup a window at center of the screen.
           var left = (screen.width/2)-(width/2);
           var top = (screen.height/2)-(height/2);
-          return window.open(url, title, 'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width='+width+', height='+height+', top='+top+', left='+left);
+          var popupWindow = window.open(url, title, 'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width='+width+', height='+height+', top='+top+', left='+left);
+          popupWindow.opener = null;
+          return popupWindow;
       }
   </script>
 </%block>

--- a/lms/templates/certificates/_badges-modal.html
+++ b/lms/templates/certificates/_badges-modal.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%namespace name='static' file='../static_content.html'/>
 <script src="${static.url('js/lms-base-vendor.js')}"></script>
 <script src="${static.url('js/certificates/certificates.js')}"></script>
@@ -12,9 +13,9 @@
         <hr class="modal-hr"/>
         <img class="backpack-logo" src="${static.url('certificates/images/backpack-logo.png')}">
         <ol class="badges-steps">
-            <li class="step">Create a <a href="https://backpack.openbadges.org/" target="_blank">Mozilla Backpack</a> account, or log in to your existing account
+            <li class="step">Create a <a href="https://backpack.openbadges.org/" rel="noopener" target="_blank">Mozilla Backpack</a> account, or log in to your existing account
             </li>
-            <li class="step"><a href="${badge.image_url}" target="_blank">Download this image (right-click, save as)</a> and then <a href="https://backpack.openbadges.org/backpack/add" target="_blank">upload</a> it to your backpack.</li>
+            <li class="step"><a href="${badge.image_url}" rel="noopener" target="_blank">Download this image (right-click, save as)</a> and then <a href="https://backpack.openbadges.org/backpack/add" rel="noopener" target="_blank">upload</a> it to your backpack.</li>
         </ol>
         <div class="image-container">
             <img class="badges-backpack-example" src="${static.url('certificates/images/backpack-ui.png')}">

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -79,9 +79,9 @@ username = get_enterprise_learner_generic_name(request) or student.username
                                 </div>
                                 <div class="msg-actions">
                                     %if certificate_data.cert_web_view_url:
-                                    <a class="btn" href="${certificate_data.cert_web_view_url}" target="_blank">${_("View Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
+                                    <a class="btn" href="${certificate_data.cert_web_view_url}" rel="noopener" target="_blank">${_("View Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
                                     %elif certificate_data.cert_status == CertificateStatuses.downloadable and certificate_data.download_url:
-                                    <a class="btn" href="${certificate_data.download_url}" target="_blank">${_("Download Your Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
+                                    <a class="btn" href="${certificate_data.download_url}" rel="noopener" target="_blank">${_("Download Your Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
                                     %elif certificate_data.cert_status == CertificateStatuses.requesting:
                                     <button class="btn generate_certs" data-endpoint="${post_url}" id="btn_generate_cert">${_('Request Certificate')}</button>
                                     %endif

--- a/lms/templates/credit_notifications/credit_eligibility_email.html
+++ b/lms/templates/credit_notifications/credit_eligibility_email.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%!
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.markup import HTML, Text
@@ -18,7 +19,7 @@
       <table>
         <tr>
           <td class="cn-img-wrapper">
-            <a target="_blank" title="" href="#">
+            <a rel="noopener" target="_blank" title="" href="#">
               <img class="cn-img" src="cid:${branded_logo}">
             </a>
           </td>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -291,7 +291,7 @@ from student.models import CourseEnrollment
                 <li class="order-history">
                   <span class="title">${_("Order History")}</span>
                   % for order_history_item in order_history_list:
-                    <span><a href="${order_history_item['receipt_url']}" target="_blank" class="edit-name">${order_history_item['order_date']}</a></span>
+                    <span><a href="${order_history_item['receipt_url']}" rel="noopener" target="_blank" class="edit-name">${order_history_item['order_date']}</a></span>
                   % endfor
                 </li>
                 % endif

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -82,7 +82,7 @@ else:
               </li>
             % elif cert_status['status'] == 'downloadable' and cert_status.get('show_cert_web_view', False):
               <li class="action action-certificate">
-                <a class="btn" href="${cert_status['cert_web_view_url']}" target="_blank"
+                <a class="btn" href="${cert_status['cert_web_view_url']}" rel="noopener" target="_blank"
                    title="${_('This link will open the certificate web view')}">
                   ${_("View {cert_name_short}").format(cert_name_short=cert_name_short,)}
                 </a>
@@ -123,7 +123,7 @@ else:
         % if cert_status['status'] == 'downloadable' and cert_status['linked_in_url']:
           <ul class="actions actions-secondary">
               <li class="action action-share">
-                <a class="action-linkedin-profile" target="_blank" href="${cert_status['linked_in_url']}"
+                <a class="action-linkedin-profile" rel="noopener" target="_blank" href="${cert_status['linked_in_url']}"
                  title="${_('Add Certificate to LinkedIn Profile')}"
                  data-course-id="${course_overview.id}"
                  data-certificate-mode="${cert_status['mode']}"

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -235,10 +235,11 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                           data-trigger="focus hover"
                           class="action action-facebook"
                           href="${facebook_url}"
+                          rel="noopener"
                           target="_blank"
                           title="${_('Share on Facebook')}"
                           data-course-id="${course_overview.id}"
-                          onclick="window.open('${facebook_url}', '${share_window_name}', '${share_window_config}'); return false;">
+                          onclick="var popupWindow = window.open('${facebook_url}', '${share_window_name}', '${share_window_config}'); popupWindow.opener = null; return false;">
                           <span class="sr">${share_msg}</span>
                           <span class="fa fa-facebook" aria-hidden="true"></span>
                         </a>
@@ -256,10 +257,11 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                           data-trigger="focus hover"
                           class="action action-twitter"
                           href="${twitter_url}"
+                          rel="noopener"
                           target="_blank"
                           title="${_('Share on Twitter')}"
                           data-course-id="${course_overview.id}"
-                          onclick="window.open('${twitter_url}', '${share_window_name}', '${share_window_config}'); return false;">
+                          onclick="var popupWindow = window.open('${twitter_url}', '${share_window_name}', '${share_window_config}'); popupWindow.opener = null; return false;">
                           <span class="sr">${share_msg}</span>
                           <span class="fa fa-twitter" aria-hidden="true"></span>
                         </a>

--- a/lms/templates/dashboard/_dashboard_credit_info.html
+++ b/lms/templates/dashboard/_dashboard_credit_info.html
@@ -1,20 +1,25 @@
-<%page args="credit_status" />
+<%page expression_filter="h" args="credit_status" />
 <%!
     from django.utils.translation import ugettext as _
+    from openedx.core.djangolib.markup import HTML, Text
 %>
 <%namespace name='static' file='../static_content.html'/>
 
 
 % if credit_status["eligible"]:
     <%
-        provider_link = '<a href="{href}" target="_blank">{name}</a>'.format(
-            href=credit_status["provider_status_url"],
-            name=credit_status["provider_name"])
-
+        provider_link = Text('{link_start}{name}{link_end}').format(
+            link_start=HTML('<a href="{href}" rel="noopener" target="_blank">').format(href=credit_status["provider_status_url"]),
+            name=credit_status["provider_name"],
+            link_end=HTML('</a>')
+        )
         error = credit_status['error']
 
         # Translators: provider_name is the name of a credit provider or university (e.g. State University)
-        credit_msg = _("You have completed this course and are eligible to purchase course credit. Select <strong>Get Credit</strong> to get started.")
+        credit_msg = Text(_("You have completed this course and are eligible to purchase course credit. Select {strong_start}Get Credit{strong_end} to get started.")).format(
+            strong_start = HTML('<strong>'),
+            strong_end = HTML('</strong>')
+        )
         if credit_status['provider_name']:
             credit_msg = _("You are now eligible for credit from {provider}. Congratulations!").format(provider=credit_status['provider_name'])
 
@@ -32,9 +37,11 @@
                 # Learner must initiate the credit request
 
                 # Translators: link_to_provider_site is a link to an external webpage. The text of the link will be the name of a  credit provider, such as 'State University' or 'Happy Fun Company'.
-                credit_msg = _("Thank you for your payment. To receive course credit, you must now request credit "
-                "at the {link_to_provider_site} website. Select <b>Request Credit</b> to get started.").format(
-                    link_to_provider_site=provider_link,
+                credit_msg = Text(_("Thank you for your payment. To receive course credit, you must now request credit "
+                "at the {link_to_provider_site} website. Select {break_start}Request Credit{break_end} to get started.")).format(
+                    link_to_provider_site=HTML(provider_link),
+                    break_start = HTML('<b>'),
+                    break_end = HTML('</b>')
                 )
                 credit_msg_class = "credit-request-not-started-msg"
                 credit_btn_label = _("Request Credit")
@@ -49,9 +56,11 @@
             elif request_status == 'approved':
                 # Credit granted!
                 # Translators: link_to_provider_site is a link to an external webpage. The text of the link will be the name of a credit provider, such as 'State University' or 'Happy Fun Company'. provider_name is the name of credit provider.
-                credit_msg = _("<b>Congratulations!</b> {provider_name} has approved your request for course credit. To see your course credit, visit the {link_to_provider_site} website.").format(
-                    provider_name=credit_status["provider_name"],
-                    link_to_provider_site=provider_link,
+                credit_msg = Text(_("{break_start}Congratulations!{break_end} {provider_name} has approved your request for course credit. To see your course credit, visit the {link_to_provider_site} website.")).format(
+                    break_start = HTML('<b>'),
+                    break_end = HTML('</b>'),
+                    link_to_provider_site=HTML(provider_link),
+                    provider_name=credit_status["provider_name"]
                 )
                 credit_msg_class = "credit-request-approved-msg"
                 credit_btn_href = credit_status['provider_status_url']
@@ -67,22 +76,24 @@
                 credit_btn_label = None
     %>
 
-    <div class="message message-status is-shown credit-message">
+<div class="message message-status is-shown credit-message">
 
-        <p class="message-copy is-hidden credit-error-msg" data-credit-error="${credit_status['error']}">
-            ${_("An error occurred with this transaction. For help, contact {support_email}.").format(
-            support_email=u'<a href="mailto:{address}">{address}</a>'.format(
-            address=settings.DEFAULT_FEEDBACK_EMAIL
-            )
-            )}
-        </p>
-        <div class="credit-action">
-            % if credit_btn_label:
-                <a class="btn credit-btn ${credit_btn_class}" href="${credit_btn_href | h}" target="_blank" data-course-key="${credit_status['course_key'] | h}" data-user="${user.username | h}" data-provider="${credit_status['provider_id'] | h}">
-                    ${credit_btn_label}
-                </a>
-            % endif
-            <div class="message-copy credit-msg ${credit_msg_class}">${credit_msg}</div>
-        </div>
+    <p class="message-copy is-hidden credit-error-msg" data-credit-error="${credit_status['error']}">
+        ${Text(_("An error occurred with this transaction. For help, contact {support_email}.")).format(
+        support_email=HTML(u'<a href="mailto:{address}">{address}</a>').format(
+        address=settings.DEFAULT_FEEDBACK_EMAIL
+        )
+        )}
+    </p>
+    <div class="credit-action">
+        % if credit_btn_label:
+        <a class="btn credit-btn ${credit_btn_class}" href="${credit_btn_href}" rel="noopener" target="_blank"
+            data-course-key="${credit_status['course_key']}" data-user="${user.username}"
+            data-provider="${credit_status['provider_id']}">
+            ${credit_btn_label}
+        </a>
+        % endif
+        <div class="message-copy credit-msg ${credit_msg_class}">${credit_msg}</div>
     </div>
+</div>
 % endif

--- a/lms/templates/fields/field_order_history.underscore
+++ b/lms/templates/fields/field_order_history.underscore
@@ -4,7 +4,7 @@
     <span class="u-field-order-price"><span class="sr"><%- gettext('Cost') %>: </span><% if (!isNaN(parseFloat(totalPrice))) { %>$<% } %><%- totalPrice %></span>
     <span class="u-field-order-link">
         <% if (receiptUrl) { %>
-            <a class="u-field-link" target="_blank" href="<%- receiptUrl %>"><%- gettext('Order Details') %><span class="sr"> <%- gettext('for') %> <%- orderId %></span></a>
+            <a class="u-field-link" rel="noopener" target="_blank" href="<%- receiptUrl %>"><%- gettext('Order Details') %><span class="sr"> <%- gettext('for') %> <%- orderId %></span></a>
         <% } %>
     </span>
     <% _.each(lines, function(item){ %>

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -81,8 +81,8 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 <div class="ie-banner" aria-hidden="true">${Text(_('{begin_strong}Warning:{end_strong} Your browser is not fully supported. We strongly recommend using {chrome_link} or {ff_link}.')).format(
     begin_strong=HTML('<strong>'),
     end_strong=HTML('</strong>'),
-    chrome_link=HTML('<a href="https://www.google.com/chrome" target="_blank">Chrome</a>'),
-    ff_link=HTML('<a href="http://www.mozilla.org/firefox" target="_blank">Firefox</a>'),
+    chrome_link=HTML('<a href="https://www.google.com/chrome" rel="noopener" target="_blank">Chrome</a>'),
+    ff_link=HTML('<a href="http://www.mozilla.org/firefox" rel="noopener" target="_blank">Firefox</a>'),
 )}</div>
 <![endif]-->
 % endif

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -82,7 +82,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
       </div>
     % endif
     <div class="mobile-nav-item hidden-mobile nav-item">
-      <a class="help-link" href="${help_link}" target="_blank">${_("Help")}</a>
+      <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
     </div>
     <%include file="user_dropdown.html"/>
   </div>

--- a/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
+++ b/lms/templates/instructor/instructor_dashboard_2/cohort-group-header.underscore
@@ -12,10 +12,10 @@
     <div class="setup-value">
         <% if (cohort.get('assignment_type') == "manual") { %>
             <%- gettext("Learners are added to this cohort only when you provide their email addresses or usernames on this page.") %>
-            <a href="/help_token/cohortmanual" class="incontext-help action-secondary action-help" target="_blank"><%- gettext("What does this mean?") %></a>
+            <a href="/help_token/cohortmanual" class="incontext-help action-secondary action-help" rel="noopener" target="_blank"><%- gettext("What does this mean?") %></a>
         <% } else { %>
             <%- gettext("Learners are added to this cohort automatically.") %>
-            <a href="/help_token/cohortautomatic" class="incontext-help action-secondary action-help" target="_blank"><%- gettext("What does this mean?") %></a>
+            <a href="/help_token/cohortautomatic" class="incontext-help action-secondary action-help" rel="noopener" target="_blank"><%- gettext("What does this mean?") %></a>
         <% } %>
     </div>
 </div>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_analytics.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_analytics.html
@@ -11,7 +11,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <p>
         <em>
             ${Text(_("For analytics about your course, go to {link_start}{analytics_dashboard_name}{link_end}.")).format(
-                link_start=HTML('<a href="{dashboard_url}" target="_blank">').format(
+                link_start=HTML('<a href="{dashboard_url}" rel="noopener" target="_blank">').format(
                     dashboard_url=escape_uri_path('{base_url}/courses/{course_id}'.format(
                         base_url=settings.ANALYTICS_DASHBOARD_URL,
                         course_id=section_data['course_id'],

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 
@@ -6,6 +7,8 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 import third_party_auth
 from third_party_auth import provider, pipeline
+from openedx.core.djangolib.markup import HTML, Text
+from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
 %>
 
 <%block name="pagetitle">${_("Log into your {platform_name} Account").format(platform_name=platform_name)}</%block>
@@ -27,7 +30,7 @@ from third_party_auth import provider, pipeline
       // new window/tab opening
       $('a[rel="external"], a[class="new-vp"]')
       .click( function() {
-        window.open( $(this).attr('href') );
+        window.open( $(this).attr('href'), '', 'noopener' );
         return false;
       });
 
@@ -54,24 +57,24 @@ from third_party_auth import provider, pipeline
         if (request.status === 403) {
           $('.message.submission-error').removeClass('is-shown');
           $('.third-party-signin.message').addClass('is-shown').focus();
-          $('.third-party-signin.message .instructions').html(request.responseText);
+          $('.third-party-signin.message .instructions').text(request.responseText);
         } else {
           $('.third-party-signin.message').removeClass('is-shown');
           $('.message.submission-error').addClass('is-shown').focus();
-          $('.message.submission-error').html(gettext("Your request could not be completed.  Please try again."));
+          $('.message.submission-error').text(gettext("Your request could not be completed.  Please try again."));
         }
       });
 
-      $('#login-form').on('ajax:success', function(event, json, xhr) {
-        if(json.success) {
-          var nextUrl = "${login_redirect_url}";
+      $('#login-form').on('ajax:success', function (event, json, xhr) {
+        if (json.success) {
+          var nextUrl = "${login_redirect_url | n, js_escaped_string}";
           if (json.redirect_url) {
             nextUrl = json.redirect_url; // Most likely third party auth completion. This trumps 'nextUrl' above.
           }
           if (!isExternal(nextUrl)) {
             location.href=nextUrl;
           } else {
-            location.href="${reverse('dashboard')}";
+            location.href="${reverse('dashboard') | n, js_escaped_string}";
           }
         } else if(json.hasOwnProperty('redirect')) {
           // Shibboleth authentication redirect requested by the server:
@@ -83,7 +86,7 @@ from third_party_auth import provider, pipeline
         } else {
           toggleSubmitButton(true);
           $('.message.submission-error').addClass('is-shown').focus();
-          $('.message.submission-error .message-copy').html(json.value);
+          $('.message.submission-error .message-copy').text(json.value);
         }
       });
       $("#forgot-password-link").click(function() {
@@ -97,17 +100,27 @@ from third_party_auth import provider, pipeline
       var $submitButton = $('form .form-actions #submit');
 
       if(enable) {
-        $submitButton.
-          removeClass('is-disabled').
-          attr('aria-disabled', false).
-          prop('disabled', false).
-          html("${_('Log into My {platform_name} Account').format(platform_name=platform_name)} <span class='orn-plus'>+</span> ${_('Access My Courses')}");
+
+        var platform = "${_('Log into My {platform_name} Account').format(platform_name=platform_name) | n, js_escaped_string}";
+        var msg = "${_('Access My Courses') | n, js_escaped_string}";
+        var content  = edx.HtmlUtils.interpolateHtml(
+          edx.HtmlUtils.HTML("{platform}<span class='orn-plus'>+</span>{msg}"),
+          {
+            platform:platform,
+            msg:msg
+          }
+        );
+          $submitButton.
+            removeClass('is-disabled').
+            attr('aria-disabled', false).
+            prop('disabled', false).
+            html(HtmlUtils.ensureHtml(content).toString());
       }
       else {
         $submitButton.
           addClass('is-disabled').
           prop('disabled', true).
-          text("${_(u'Processing your account information')}");
+          text("${_(u'Processing your account information') | n, js_escaped_string}");
       }
     }
 
@@ -117,15 +130,15 @@ from third_party_auth import provider, pipeline
     }
 
     (function post_form_if_pipeline_running(pipeline_running) {
-       // If the pipeline is running, the user has already authenticated via a
-       // third-party provider. We want to invoke /login_ajax to loop in the
-       // code that does logging and sets cookies on the request. It is most
-       // consistent to do that by using the same mechanism that is used when
-       // the use does first-party sign-in: POSTing the sign-in form.
-       if (pipeline_running) {
-         $('#login-form').submit();
-       }
-    })(${pipeline_running})
+      // If the pipeline is running, the user has already authenticated via a
+      // third-party provider. We want to invoke /login_ajax to loop in the
+      // code that does logging and sets cookies on the request. It is most
+      // consistent to do that by using the same mechanism that is used when
+      // the use does first-party sign-in: POSTing the sign-in form.
+      if (pipeline_running) {
+        $('#login-form').submit();
+      }
+    })(${pipeline_running | n, dump_js_escaped_json})
   </script>
 </%block>
 
@@ -170,7 +183,11 @@ from third_party_auth import provider, pipeline
       % endif
 
       <p class="instructions sr">
-        ${_('Please provide the following information to log into your {platform_name} account. Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.').format(platform_name=platform_name)}
+        ${Text(_('Please provide the following information to log into your {platform_name} account. Required fields are noted by {strong_start}bold text and an asterisk (*){strong_end}.')).format(
+          platform_name=platform_name,
+          strong_start = HTML('<strong class="indicator">'),
+          strong_end=HTML('</strong>')
+        )}
       </p>
 
       <div class="group group-form group-form-requiredinformation">
@@ -220,7 +237,7 @@ from third_party_auth import provider, pipeline
 
     % for enabled in provider.Registry.displayed_for_login():
       ## Translators: provider_name is the name of an external, third-party user authentication provider (like Google or LinkedIn).
-      <button type="submit" class="button button-primary button-${enabled.provider_id} login-${enabled.provider_id}" onclick="thirdPartySignin(event, '${pipeline_url[enabled.provider_id]}');">
+      <button type="submit" class="button button-primary button-${enabled.provider_id} login-${enabled.provider_id}" onclick="thirdPartySignin(event, '${pipeline_url[enabled.provider_id]| n, decode.utf8}');">
         % if enabled.icon_class:
         <span class="icon fa ${enabled.icon_class}" aria-hidden="true"></span>
         % else:

--- a/lms/templates/lti.html
+++ b/lms/templates/lti.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%!
 import json
 from django.utils.translation import ugettext as _
@@ -33,7 +34,7 @@ from django.utils.translation import ugettext as _
             % if description:
                 <div class="lti-description">${description}</div>
             % endif
-            <p class="lti-link external"><a target="_blank" class="link_lti_new_window" href="${form_url}">
+            <p class="lti-link external"><a rel="noopener" target="_blank" class="link_lti_new_window" href="${form_url}">
                 ${button_text or _('View resource in a new window')}
                  <span class="icon fa fa-external-link" aria-hidden="true"></span>
             </a></p>

--- a/lms/templates/navigation/bootstrap/navbar-authenticated.html
+++ b/lms/templates/navigation/bootstrap/navbar-authenticated.html
@@ -81,6 +81,7 @@ from django.utils.translation import ugettext as _
 
     <li class="nav-item mt-2 nav-item-open-collapsed">
       <a href="${get_online_help_info(online_help_token)['doc_url']}"
+       rel="noopener"
        target="_blank"
        class="nav-link">${_("Help")}</a>
     </li>

--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -58,6 +58,7 @@ from django.utils.translation import ugettext as _
 <%include file="../user_dropdown.html"/>
 
 <a href="${get_online_help_info(online_help_token)['doc_url']}"
+         rel="noopener"
          target="_blank"
          class="doc-link">${_("Help")}</a>
 

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -93,8 +93,8 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
 <div class="ie-banner" aria-hidden="true">${Text(_('{begin_strong}Warning:{end_strong} Your browser is not fully supported. We strongly recommend using {chrome_link} or {ff_link}.')).format(
     begin_strong=HTML('<strong>'),
     end_strong=HTML('</strong>'),
-    chrome_link=HTML('<a href="https://www.google.com/chrome" target="_blank">Chrome</a>'),
-    ff_link=HTML('<a href="http://www.mozilla.org/firefox" target="_blank">Firefox</a>'),
+    chrome_link=HTML('<a href="https://www.google.com/chrome" rel="noopener" target="_blank">Chrome</a>'),
+    ff_link=HTML('<a href="http://www.mozilla.org/firefox" rel="noopener" target="_blank">Firefox</a>'),
 )}</div>
 <![endif]-->
 % endif

--- a/lms/templates/register-shib.html
+++ b/lms/templates/register-shib.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 <%namespace file='main.html' import="login_query"/>
@@ -9,6 +10,8 @@ from django_countries import countries
 from student.models import UserProfile
 from datetime import date
 import calendar
+from openedx.core.djangolib.js_utils import js_escaped_string
+from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%block name="pagetitle">${_("Preferences for {platform_name}").format(platform_name=settings.PLATFORM_NAME)}</%block>
@@ -25,7 +28,7 @@ import calendar
       // new window/tab opening
       $('a[rel="external"], a[class="new-vp"]')
       .click( function() {
-      window.open( $(this).attr('href') );
+      window.open( $(this).attr('href'), '', 'noopener' );
       return false;
       });
 
@@ -50,7 +53,7 @@ import calendar
       });
 
       $('#register-form').on('ajax:success', function(event, json, xhr) {
-        var url = json.redirect_url || "${reverse('dashboard')}";
+        var url = json.redirect_url || "${reverse('dashboard') | n, js_escaped_string}";
         location.href = url;
       });
 
@@ -58,7 +61,7 @@ import calendar
         toggleSubmitButton(true);
         json = $.parseJSON(jqXHR.responseText);
         $('.status.message.submission-error').addClass('is-shown').focus();
-        $('.status.message.submission-error .message-copy').html(json.value).stop().css("display", "block");
+        $('.status.message.submission-error .message-copy').text(json.value).stop().css("display", "block");
         $(".field-error").removeClass('field-error');
         $("[data-field='"+json.field+"']").addClass('field-error')
       });
@@ -72,14 +75,14 @@ import calendar
           removeClass('is-disabled').
           attr('aria-disabled', false).
           removeProp('disabled').
-          text("${_('Update my {platform_name} Account').format(platform_name=settings.PLATFORM_NAME)}");
+          text("${_('Update my {platform_name} Account').format(platform_name=settings.PLATFORM_NAME) | n, js_escaped_string}");
       }
       else {
         $submitButton.
           addClass('is-disabled').
           attr('aria-disabled', true).
           prop('disabled', true).
-          text("${_('Processing your account information')}");
+          text("${_('Processing your account information') | n, js_escaped_string}");
       }
     }
   </script>
@@ -108,7 +111,10 @@ import calendar
       </div>
 
       <p class="instructions">
-        ${_('Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}
+        ${Text(_('Required fields are noted by {strong_start}bold text and an asterisk (*){strong_end}.')).format(
+          strong_start=HTML('<strong class="indicator">'),
+          strong_end=HTML('</strong>')
+        )}
       </p>
 
       <fieldset class="group group-form group-form-requiredinformation">
@@ -159,9 +165,9 @@ import calendar
 
             <div class="field required checkbox" id="field-tos">
               <input id="tos-yes" type="checkbox" name="terms_of_service" value="true" required aria-required="true" />
-              <label for="tos-yes">${_('I agree to the {link_start}Terms of Service{link_end}').format(
-                link_start='<a href="{url}" class="new-vp">'.format(url=marketing_link('TOS')),
-                link_end='</a>')}</label>
+              <label for="tos-yes">${Text(_('I agree to the {link_start}Terms of Service{link_end}')).format(
+                link_start=HTML('<a href="{url}" class="new-vp">').format(url=marketing_link('TOS')),
+                link_end=HTML('</a>'))}</label>
             </div>
 
             % endif
@@ -171,17 +177,17 @@ import calendar
               <%
                 honor_code_path = marketing_link('HONOR')
               %>
-              <label for="honorcode-yes">${_('I agree to the {link_start}Honor Code{link_end}').format(
-                link_start='<a href="{url}" class="new-vp">'.format(url=honor_code_path),
-                link_end='</a>')}</label>
+              <label for="honorcode-yes">${Text(_('I agree to the {link_start}Honor Code{link_end}')).format(
+                link_start=HTML('<a href="{url}" class="new-vp">').format(url=honor_code_path),
+                link_end=HTML('</a>'))}</label>
             </div>
           </li>
         </ol>
       </fieldset>
 
 % if course_id and enrollment_action:
-      <input type="hidden" name="enrollment_action" value="${enrollment_action | h}" />
-      <input type="hidden" name="course_id" value="${course_id | h}" />
+      <input type="hidden" name="enrollment_action" value="${enrollment_action}" />
+      <input type="hidden" name="course_id" value="${course_id}" />
 % endif
 
       <div class="form-actions">

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -1,8 +1,10 @@
+<%page expression_filter="h"/>
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 <%namespace file='main.html' import="login_query"/>
 <%!
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.js_utils import js_escaped_string
 from django.urls import reverse
 from django.utils import html
 from django_countries import countries
@@ -27,7 +29,7 @@ import calendar
       // new window/tab opening
       $('a[rel="external"], a[class="new-vp"]')
       .click( function() {
-      window.open( $(this).attr('href') );
+      window.open( $(this).attr('href'), '', 'noopener' );
       return false;
       });
 
@@ -52,14 +54,14 @@ import calendar
       });
 
       $('#register-form').on('ajax:success', function(event, json, xhr) {
-        var nextUrl = "${login_redirect_url}";
+        var nextUrl = "${login_redirect_url | n, js_escaped_string}";
         if (json.redirect_url) {
           nextUrl = json.redirect_url; // Most likely third party auth completion. This trumps 'nextUrl' above.
         }
         if (!isExternal(nextUrl)) {
           location.href=nextUrl;
         } else {
-          location.href="${reverse('dashboard')}";
+          location.href="${reverse('dashboard') | n, js_escaped_string}";
         }
       });
 
@@ -67,7 +69,7 @@ import calendar
         toggleSubmitButton(true);
         json = $.parseJSON(jqXHR.responseText);
         $('.status.message.submission-error').addClass('is-shown').focus();
-        $('.status.message.submission-error .message-copy').html(json.value).stop().css("display", "block");
+        $('.status.message.submission-error .message-copy').text(json.value).stop().css("display", "block");
         $(".field-error").removeClass('field-error');
         $("[data-field='"+json.field+"']").addClass('field-error')
       });
@@ -86,13 +88,13 @@ import calendar
           removeClass('is-disabled').
           attr('aria-disabled', false).
           prop('disabled', false).
-          html("${_('Create My {platform_name} Account').format(platform_name=platform_name)}");
+          text("${_('Create My {platform_name} Account').format(platform_name=platform_name) | n, js_escaped_string}");
       }
       else {
         $submitButton.
           addClass('is-disabled').
           prop('disabled', true).
-          text("${_('Processing your account information')}");
+          text("${_('Processing your account information') | n, js_escaped_string}");
       }
     }
   </script>

--- a/lms/templates/signup_modal.html
+++ b/lms/templates/signup_modal.html
@@ -1,3 +1,4 @@
+<%page expression_filter="h"/>
 <%namespace name='static' file='static_content.html'/>
 <%!
 from django.conf import settings
@@ -6,7 +7,10 @@ from django_countries import countries
 from student.models import UserProfile
 from datetime import date
 import calendar
+from openedx.core.djangolib.markup import HTML, Text
+from openedx.core.djangolib.js_utils import js_escaped_string
 %>
+
 
 <section id="signup-modal" class="modal signup-modal">
   <div class="inner-wrapper">
@@ -21,8 +25,8 @@ import calendar
     <div id="register">
       <header>
         <h2>
-	  ${_('Sign Up for {platform_name}').format(
-	      platform_name=u'<span class="edx">{}</span>'.format(settings.PLATFORM_NAME)
+	  ${Text(_('Sign Up for {platform_name}')).format(
+	      platform_name=HTML(u'<span class="edx">{}</span>').format(settings.PLATFORM_NAME)
 	  )}
 	</h2>
         <hr>
@@ -47,7 +51,11 @@ import calendar
           <label data-field="name" for="signup_fullname">${_('Full Name')} + ' *'</label>
 	    <input id="signup_fullname" type="text" name="name" placeholder="${_('e.g. Your Name (for certificates)')}" required />
 	  % else:
-	  <p>${_('<i>Welcome</i> {name}').format(name=extauth_id)}</p><br/>
+	  <p>${Text(_('{italic_start}Welcome{italic_end} {name}')).format(
+      italic_start=HTML('<i>'),
+      italic_end=HTML('</i>'),
+      name=extauth_id
+      )}</p><br/>
 	  <p><i>${_('Enter a public username:')}</i></p>
 
           <label data-field="username" for="signup_username">${_('Public Username')} + ' *'</label>
@@ -127,17 +135,17 @@ import calendar
         <div class="input-group">
           <label data-field="terms_of_service" class="terms-of-service" for="signup_tos">
             <input id="signup_tos" name="terms_of_service" type="checkbox" value="true">
-            ${_('I agree to the {link_start}Terms of Service{link_end}').format(
-              link_start='<a href="{url}" target="_blank">'.format(url=reverse('tos')),
-              link_end='</a>') + ' *'}
+              ${Text(_('I agree to the {link_start}Terms of Service{link_end}')).format(
+                link_start=HTML('<a href="{url}" rel="noopener" target="_blank">').format(url=reverse('tos')),
+                link_end=HTML('</a>'))} *
           </label>
 
           % if settings.REGISTRATION_EXTRA_FIELDS['honor_code'] != 'hidden':
           <label data-field="honor_code" class="honor-code" for="signup_honor">
             <input id="signup_honor" name="honor_code" type="checkbox" value="true">
-            ${_('I agree to the {link_start}Honor Code{link_end}').format(
-              link_start='<a href="{url}" target="_blank">'.format(url=reverse('honor')),
-              link_end='</a>') + ' *'}
+            ${Text(_('I agree to the {link_start}Honor Code{link_end}')).format(
+              link_start=HTML('<a href="{url}" rel="noopener" target="_blank">').format(url=reverse('honor')),
+              link_end=HTML('</a>'))} *
           </label>
           % endif
         </div>
@@ -162,12 +170,12 @@ import calendar
 <script type="text/javascript">
   (function() {
    $(document).delegate('#register_form', 'ajax:success', function(data, json, xhr) {
-     location.href="${reverse('dashboard')}";
+     location.href="${reverse('dashboard') | n, js_escaped_string}";
     });
    $(document).delegate('#register_form', 'ajax:error', function(event, jqXHR, textStatus) {
      json = $.parseJSON(jqXHR.responseText);
      $(".field-error").removeClass('field-error');
-     $('#register_error').html(json.value).stop().css("display", "block");
+     $('#register_error').text(json.value).stop().css("display", "block");
      $("[data-field='"+json.field+"']").addClass('field-error')
     });
 

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -15,7 +15,7 @@
         </label>
         <% if (supplementalLink && supplementalText) { %>
             <div class="supplemental-link">
-                <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
+                <a href="<%- supplementalLink %>" rel="noopener" target="_blank"><%- supplementalText %></a>
             </div>
         <% } %>
     <% } %>
@@ -45,7 +45,7 @@
         <% if ( instructions ) { %> <span class="tip tip-input" id="<%- form %>-<%- name %>-desc"><%- instructions %></span><% } %>
         <% if (supplementalLink && supplementalText) { %>
             <div class="supplemental-link">
-                <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
+                <a href="<%- supplementalLink %>" rel="noopener" target="_blank"><%- supplementalText %></a>
             </div>
         <% } %>
     <% } else if ( type === 'textarea' ) { %>
@@ -71,7 +71,7 @@
         <% if ( instructions ) { %> <span class="tip tip-input" id="<%- form %>-<%- name %>-desc"><%- instructions %></span><% } %>
         <% if (supplementalLink && supplementalText) { %>
             <div class="supplemental-link">
-                <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
+                <a href="<%- supplementalLink %>" rel="noopener" target="_blank"><%- supplementalText %></a>
             </div>
         <% } %>
     <% } else if (type === 'plaintext' ) { %>
@@ -86,7 +86,7 @@
         <% if ( type === 'checkbox' ) { %>
             <% if (supplementalLink && supplementalText) { %>
                 <div class="supplemental-link">
-                    <a href="<%- supplementalLink %>" target="_blank"><%- supplementalText %></a>
+                    <a href="<%- supplementalLink %>" rel="noopener" target="_blank"><%- supplementalText %></a>
                 </div>
             <% } %>
         <% } %>

--- a/lms/templates/wiki/delete.html
+++ b/lms/templates/wiki/delete.html
@@ -26,7 +26,7 @@
 
       <ul>
         {% for child in delete_children %}
-        <li><a href="{% url 'wiki:get' article_id=child.article.id %}" target="_blank">{{ child.article }}</a></li>
+        <li><a href="{% url 'wiki:get' article_id=child.article.id %}" rel="noopener" target="_blank">{{ child.article }}</a></li>
         {% if delete_children_more %}
         <li><em>{% trans "...and more!" %}</em></li>
         {% endif %}

--- a/lms/templates/wiki/includes/cheatsheet.html
+++ b/lms/templates/wiki/includes/cheatsheet.html
@@ -13,9 +13,9 @@
           <h2>{% trans "Wiki Syntax Help" %}</h2>
           <p>{% trans "This wiki uses <strong>Markdown</strong> for styling. There are several useful guides online. See any of the links below for in-depth details:" %}</p>
           <ul>
-              <li><a href="http://daringfireball.net/projects/markdown/basics" target="_blank">{% trans 'Markdown: Basics' %}</a></li>
-              <li><a href="http://greg.vario.us/doc/markdown.txt" target="_blank">{% trans 'Quick Markdown Syntax Guide' %}</a></li>
-              <li><a href="http://www.lowendtalk.com/discussion/6/miniature-markdown-guide" target="_blank">{% trans 'Miniature Markdown Guide' %}</a></li>
+              <li><a href="http://daringfireball.net/projects/markdown/basics" rel="noopener" target="_blank">{% trans 'Markdown: Basics' %}</a></li>
+              <li><a href="http://greg.vario.us/doc/markdown.txt" rel="noopener" target="_blank">{% trans 'Quick Markdown Syntax Guide' %}</a></li>
+              <li><a href="http://www.lowendtalk.com/discussion/6/miniature-markdown-guide" rel="noopener" target="_blank">{% trans 'Miniature Markdown Guide' %}</a></li>
           </ul>
           <p>{% trans "To create a new wiki article, create a link to it. Clicking the link gives you the creation page." %}</p>
           <pre>{% trans "[Article Name](wiki:ArticleName)" %}</pre>

--- a/openedx/core/djangoapps/api_admin/widgets.py
+++ b/openedx/core/djangoapps/api_admin/widgets.py
@@ -9,6 +9,7 @@ from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangolib.markup import HTML, Text
 
 
 class TermsOfServiceCheckboxInput(CheckboxInput):
@@ -27,15 +28,15 @@ class TermsOfServiceCheckboxInput(CheckboxInput):
 
         # Translators: link_start and link_end are HTML tags for a link to the terms of service.
         # platform_name is the name of this Open edX installation.
-        label = _(
+        label = Text(_(
             'I, and my organization, accept the {link_start}{platform_name} API Terms of Service{link_end}.'
-        ).format(
+        )).format(
             platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
-            link_start='<a href="{url}" target="_blank">'.format(url=reverse('api_admin:api-tos')),
-            link_end='</a>',
+            link_start=HTML('<a href="{url}" rel="noopener" target="_blank">').format(url=reverse('api_admin:api-tos')),
+            link_end=HTML("</a>"),
         )
 
-        html = u'<input{{}} /> <label class="tos-checkbox-label" for="{id}">{label}</label>'.format(
+        html = HTML(u'<input{{}} /> <label class="tos-checkbox-label" for="{id}">{label}</label>').format(
             id=final_attrs['id'],
             label=label
         )

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -855,7 +855,9 @@ class RegistrationFormFactory(object):
         )).format(
             platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
             terms_of_service=terms_label,
-            terms_of_service_link_start=HTML("<a href='{terms_link}' target='_blank'>").format(terms_link=terms_link),
+            terms_of_service_link_start=HTML("<a href='{terms_link}' rel='noopener' target='_blank'>").format(
+                terms_link=terms_link
+            ),
             terms_of_service_link_end=HTML("</a>"),
         )
 
@@ -881,9 +883,13 @@ class RegistrationFormFactory(object):
             )).format(
                 platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
                 terms_of_service=terms_label,
-                terms_of_service_link_start=HTML("<a href='{terms_url}' target='_blank'>").format(terms_url=terms_link),
+                terms_of_service_link_start=HTML("<a href='{terms_url}' rel='noopener' target='_blank'>").format(
+                    terms_url=terms_link
+                ),
                 terms_of_service_link_end=HTML("</a>"),
-                privacy_policy_link_start=HTML("<a href='{pp_url}' target='_blank'>").format(pp_url=pp_link),
+                privacy_policy_link_start=HTML("<a href='{pp_url}' rel='noopener' target='_blank'>").format(
+                    pp_url=pp_link
+                ),
                 privacy_policy_link_end=HTML("</a>"),
             )
 
@@ -915,7 +921,7 @@ class RegistrationFormFactory(object):
         label = Text(_(u"I agree to the {platform_name} {tos_link_start}{terms_of_service}{tos_link_end}")).format(
             platform_name=configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME),
             terms_of_service=terms_label,
-            tos_link_start=HTML("<a href='{terms_link}' target='_blank'>").format(terms_link=terms_link),
+            tos_link_start=HTML("<a href='{terms_link}' rel='noopener' target='_blank'>").format(terms_link=terms_link),
             tos_link_end=HTML("</a>"),
         )
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1096,7 +1096,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             "default": False
         }
     ]
-    link_template = "<a href='/honor' target='_blank'>{link_label}</a>"
+    link_template = "<a href='/honor' rel='noopener' target='_blank'>{link_label}</a>"
 
     def setUp(self):
         super(RegistrationViewTest, self).setUp()
@@ -1706,8 +1706,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
     )
     @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": True})
     def test_registration_honor_code_mktg_site_enabled(self):
-        link_template = "<a href='https://www.test.com/honor' target='_blank'>{link_label}</a>"
-        link_template2 = "<a href='#' target='_blank'>{link_label}</a>"
+        link_template = "<a href='https://www.test.com/honor' rel='noopener' target='_blank'>{link_label}</a>"
+        link_template2 = "<a href='#' rel='noopener' target='_blank'>{link_label}</a>"
         link_label = "Terms of Service and Honor Code"
         link_label2 = "Privacy Policy"
         self._assert_reg_field(
@@ -1738,7 +1738,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
     @override_settings(MKTG_URLS_LINK_MAP={"HONOR": "honor"})
     @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": False})
     def test_registration_honor_code_mktg_site_disabled(self):
-        link_template = "<a href='/privacy' target='_blank'>{link_label}</a>"
+        link_template = "<a href='/privacy' rel='noopener' target='_blank'>{link_label}</a>"
         link_label = "Terms of Service and Honor Code"
         link_label2 = "Privacy Policy"
         self._assert_reg_field(
@@ -1776,7 +1776,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
         # Honor code field should say ONLY honor code,
         # not "terms of service and honor code"
         link_label = 'Honor Code'
-        link_template = "<a href='https://www.test.com/honor' target='_blank'>{link_label}</a>"
+        link_template = "<a href='https://www.test.com/honor' rel='noopener' target='_blank'>{link_label}</a>"
         self._assert_reg_field(
             {"honor_code": "required", "terms_of_service": "required"},
             {
@@ -1799,7 +1799,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
 
         # Terms of service field should also be present
         link_label = "Terms of Service"
-        link_template = "<a href='https://www.test.com/tos' target='_blank'>{link_label}</a>"
+        link_template = "<a href='https://www.test.com/tos' rel='noopener' target='_blank'>{link_label}</a>"
         self._assert_reg_field(
             {"honor_code": "required", "terms_of_service": "required"},
             {
@@ -1847,7 +1847,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
 
         link_label = 'Terms of Service'
         # Terms of service field should also be present
-        link_template = "<a href='/tos' target='_blank'>{link_label}</a>"
+        link_template = "<a href='/tos' rel='noopener' target='_blank'>{link_label}</a>"
         self._assert_reg_field(
             {"honor_code": "required", "terms_of_service": "required"},
             {

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login_registration_forms.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login_registration_forms.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.urls import reverse
 from mock import patch
 
+from openedx.core.djangolib.js_utils import js_escaped_string
 from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
 from util.testing import UrlResetMixin
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -144,7 +145,7 @@ class LoginFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStoreTes
 
         # Verify that the parameters are sent on to the next page correctly
         post_login_handler = _finish_auth_url(params)
-        js_success_var = 'var nextUrl = "{}";'.format(post_login_handler)
+        js_success_var = 'var nextUrl = "{}";'.format(js_escaped_string(post_login_handler))
         self.assertContains(response, js_success_var)
 
         # Verify that the login link preserves the querystring params
@@ -220,7 +221,7 @@ class RegisterFormTest(ThirdPartyAuthTestMixin, UrlResetMixin, SharedModuleStore
 
         # Verify that the parameters are sent on to the next page correctly
         post_login_handler = _finish_auth_url(params)
-        js_success_var = 'var nextUrl = "{}";'.format(post_login_handler)
+        js_success_var = 'var nextUrl = "{}";'.format(js_escaped_string(post_login_handler))
         self.assertContains(response, js_success_var)
 
         # Verify that the login link preserves the querystring params

--- a/openedx/core/djangoapps/user_authn/views/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_views.py
@@ -791,7 +791,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
                 line_break=HTML('<br/>'),
                 enterprise_name=ec_name,
                 platform_name=settings.PLATFORM_NAME,
-                privacy_policy_link_start=HTML("<a href='{pp_url}' target='_blank'>").format(
+                privacy_policy_link_start=HTML("<a href='{pp_url}' rel='noopener' target='_blank'>").format(
                     pp_url=settings.MKTG_URLS.get('PRIVACY', 'https://www.edx.org/edx-privacy-policy')
                 ),
                 privacy_policy_link_end=HTML("</a>"),

--- a/openedx/core/lib/license/templates/license.html
+++ b/openedx/core/lib/license/templates/license.html
@@ -1,4 +1,4 @@
-<%page args="license, button=False, button_size='88x31'"/>
+<%page args="license, button=False, button_size='88x31'" expression_filter="h"/>
 ## keep this synchronized with the contents of cms/templates/js/license-selector.underscore
 <%!
 from django.utils.translation import ugettext as _
@@ -40,7 +40,7 @@ def parse_license(lic):
         enabled = ["zero"]
         version = license_options.get("ver", "1.0")
     %>
-    <a rel="license" href="https://creativecommons.org/licenses/${'-'.join(enabled)}/${version}/" target="_blank">
+    <a rel="license noopener" href="https://creativecommons.org/licenses/${'-'.join(enabled)}/${version}/" target="_blank">
     % if button:
         <img src="https://licensebuttons.net/l/${'-'.join(enabled)}/${version}/${button_size}.png"
              alt="${license}"

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -98,7 +98,7 @@ def get_enterprise_sidebar_context(enterprise_customer):
         line_break=HTML('<br/>'),
         enterprise_name=enterprise_customer['name'],
         platform_name=platform_name,
-        privacy_policy_link_start=HTML("<a href='{pp_url}' target='_blank'>").format(
+        privacy_policy_link_start=HTML("<a href='{pp_url}' rel='noopener' target='_blank'>").format(
             pp_url=settings.MKTG_URLS.get('PRIVACY', 'https://www.edx.org/edx-privacy-policy')
         ),
         privacy_policy_link_end=HTML("</a>"),

--- a/openedx/features/learner_profile/static/learner_profile/templates/share_modal.underscore
+++ b/openedx/features/learner_profile/static/learner_profile/templates/share_modal.underscore
@@ -7,21 +7,31 @@
     <hr class="modal-hr"/>
     <img class="backpack-logo" src="<%- badgeMeta.badges_logo %>" alt="">
     <ol class="badges-steps">
-        <li class="step"><%=
-        interpolate(
-          gettext("Create a %(link_start)sMozilla Backpack%(link_end)s account, or log in to your existing account"),
-          {link_start: '<a href="https://backpack.openbadges.org/" target="_blank">', link_end: '</a>'},
-          true
-        )%>
+        <li class="step">
+        <%- edx.HtmlUtils.interpolateHtml(
+            gettext("Create a {link_start}Mozilla Backpack{link_end} account, or log in to your existing account"),
+            {
+              link_start: edx.HtmlUtils.HTML('<a href="https://backpack.openbadges.org/" rel="noopener" target="_blank">'),
+              link_end: edx.HtmlUtils.HTML('</a>')
+            }
+          )
+        %>
         </li>
-        <li class="step"><%=
-        interpolate(
-          gettext("%(download_link_start)sDownload this image (right-click or option-click, save as)%(link_end)s and then %(upload_link_start)supload%(link_end)s it to your backpack.</li>"), {
-            download_link_start: '<a class="badge-link" href="' + image_url + '" target="_blank">',
-            link_end: '</a>', upload_link_start: '<a href="https://backpack.openbadges.org/backpack/add" target="_blank">'
-          },
-          true
-        )%>
+        <li class="step">
+        <%- edx.HtmlUtils.interpolateHtml(
+            gettext("{download_link_start}Download this image (right-click or option-click, save as){link_end} and then {upload_link_start}upload{link_end} it to your backpack."),
+            {
+              download_link_start: edx.HtmlUtils.joinHtml(
+                edx.HtmlUtils.HTML('<a class="badge-link" href="'),
+                image_url,
+                edx.HtmlUtils.HTML('" rel="noopener" target="_blank">'),
+              ),
+              link_end: edx.HtmlUtils.HTML('</a>'),
+              upload_link_start: edx.HtmlUtils.HTML('<a href="https://backpack.openbadges.org/backpack/add" rel="noopener" target="_blank">')
+            }
+        )
+        %>
+        </li>
     </ol>
     <div class="image-container">
         <img class="badges-backpack-example" src="<%- badgeMeta.backpack_ui_img %>" alt="">

--- a/openedx/features/learner_profile/static/learner_profile/templates/social_icons.underscore
+++ b/openedx/features/learner_profile/static/learner_profile/templates/social_icons.underscore
@@ -1,7 +1,7 @@
 <div class="social-links">
     <% for (var platform in socialLinks) { %>
         <% if (socialLinks[platform]) { %>
-            <a target="_blank" href= <%-socialLinks[platform]%>>
+            <a rel="noopener" target="_blank" href= <%-socialLinks[platform]%>>
                 <span class="icon fa fa-<%-platform%>-square" data-platform=<%-platform%> aria-hidden="true"></span>
             </a>
         <% } %>

--- a/openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
+++ b/openedx/features/learner_profile/templates/learner_profile/learner-achievements-fragment.html
@@ -35,7 +35,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 )
                 %>
                 % if certificate_url:
-                    <a href="${certificate_url}" target="_blank">
+                    <a href="${certificate_url}" rel="noopener" target="_blank">
                         <div class="card certificate-card mode-${certificate['type']}">
                             <div class="card-logo">
                                 <h4 class="sr-only">

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -305,7 +305,7 @@ from student.models import CourseEnrollment
           <li class="order-history">
             <span class="title">${_("Order History")}</span>
             % for order_history_item in order_history_list:
-              <span><a href="${order_history_item['receipt_url']}" target="_blank" class="edit-name">${order_history_item['order_date']}</a></span>
+              <span><a href="${order_history_item['receipt_url']}" rel="noopener" target="_blank" class="edit-name">${order_history_item['order_date']}</a></span>
             % endfor
           </li>
           % endif

--- a/themes/edx.org/lms/templates/header/navbar-authenticated.html
+++ b/themes/edx.org/lms/templates/header/navbar-authenticated.html
@@ -74,9 +74,9 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     % endif
     <div class="mobile-nav-item hidden-mobile nav-item">
       % if online_help_token == "instructor":
-        <a class="help-link" href="${get_online_help_info(online_help_token)['doc_url']}" target="_blank">${_("Help")}</a>
+        <a class="help-link" href="${get_online_help_info(online_help_token)['doc_url']}" rel="noopener" target="_blank">${_("Help")}</a>
       % else:
-        <a class="help-link" href="${configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)}" target="_blank">${_("Help")}</a>
+        <a class="help-link" href="${configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)}" rel="noopener" target="_blank">${_("Help")}</a>
       % endif
     </div>
     <%include file="user_dropdown.html"/>

--- a/themes/stanford-style/lms/templates/register-shib.html
+++ b/themes/stanford-style/lms/templates/register-shib.html
@@ -1,8 +1,11 @@
+<%page expression_filter="h" />
 <%inherit file="main.html" />
 <%!
 from django.utils.translation import ugettext as _
 from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string
+from openedx.core.djangolib.markup import HTML, Text
+
 %>
 
 <%block name="pagetitle">${_("Preferences for {platform_name}").format(platform_name=settings.PLATFORM_NAME)}</%block>
@@ -19,7 +22,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
       // new window/tab opening
       $('a[rel="external"], a[class="new-vp"]')
       .click( function() {
-      window.open( $(this).attr('href') );
+      window.open( $(this).attr('href'), '', 'noopener' );
       return false;
       });
 
@@ -51,8 +54,10 @@ from openedx.core.djangolib.js_utils import js_escaped_string
       $('#register-form').on('ajax:error', function(event, jqXHR, textStatus) {
         toggleSubmitButton(true);
         json = $.parseJSON(jqXHR.responseText);
+        var submission_message = $('.status.message.submission-error .message-copy');
         $('.status.message.submission-error').addClass('is-shown').focus();
-        $('.status.message.submission-error .message-copy').html(json.value).stop().css("display", "block");
+        edx.HtmlUtils.setHtml(submission_message, edx.HtmlUtils.ensureHtml(json.value));
+        submission_message.stop().css("display", "block");
         $(".field-error").removeClass('field-error');
         $("[data-field='"+json.field+"']").addClass('field-error')
       });
@@ -102,7 +107,10 @@ from openedx.core.djangolib.js_utils import js_escaped_string
       </div>
 
       <p class="instructions">
-        ${_('Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.')}
+        ${Text(_('Required fields are noted by {strong_indicator}bold text and an asterisk (*).{strong_close}')).format(
+          strong_indicator=HTML('<strong class="indicator">'),
+          strong_close=HTML('</strong>')
+        )}
       </p>
 
       <fieldset class="group group-form group-form-requiredinformation">
@@ -153,9 +161,9 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
             <div class="field required checkbox" id="field-tos">
               <input id="tos-yes" type="checkbox" name="terms_of_service" value="true" required aria-required="true" />
-              <label for="tos-yes">${_('I agree to the {link_start}Terms of Service{link_end}').format(
-                link_start='<a href="{url}" class="new-vp">'.format(url=marketing_link('TOS')),
-                link_end='</a>')}</label>
+            <label for="tos-yes">${Text(_('I agree to the {link_start}Terms of Service{link_end}')).format(
+              link_start=HTML('<a href="{url}" class="new-vp">').format(url=marketing_link('TOS')),
+              link_end=HTML('</a>'))}</label>
             </div>
 
             % endif
@@ -165,17 +173,17 @@ from openedx.core.djangolib.js_utils import js_escaped_string
               <%
                 honor_code_path = marketing_link('TOS') + "#honor"
               %>
-              <label for="honorcode-yes">${_('I agree to the {link_start}Honor Code{link_end}').format(
-                link_start='<a href="{url}" class="new-vp">'.format(url=honor_code_path),
-                link_end='</a>')}</label>
+              <label for="honorcode-yes">${Text(_('I agree to the {link_start}Honor Code{link_end}')).format(
+                link_start=HTML('<a href="{url}" class="new-vp">').format(url=honor_code_path),
+                link_end=HTML('</a>'))}</label>
             </div>
           </li>
         </ol>
       </fieldset>
 
 % if course_id and enrollment_action:
-      <input type="hidden" name="enrollment_action" value="${enrollment_action | h}" />
-      <input type="hidden" name="course_id" value="${course_id | h}" />
+      <input type="hidden" name="enrollment_action" value="${enrollment_action}" />
+      <input type="hidden" name="course_id" value="${course_id}" />
 % endif
 
       <div class="form-actions">


### PR DESCRIPTION
Patch Ironwood : Prevent reverse tab-nabbing

(cherry picked from commit 54a65f7744897329c0debf270ed3ca643d7147d1)

**JIRA tickets**: [SE-1733](https://tasks.opencraft.com/browse/SE-1733) and all its related issues.

**Discussions**: https://github.com/edx/edx-platform/pull/21635

**Sandbox URL**: TBD - sandbox is being provisioned.

* LMS: https://pr194.sandbox.stage.opencraft.hosting/
* Studio: https://studio.pr194.sandbox.stage.opencraft.hosting/

**Merge deadline**: ASAP

**Testing instructions**:

1. Using the sandbox, run through our [manual instance checklist](https://gitlab.com/opencraft/documentation/private/blob/master/checklists/manual_instance_test.md) to ensure that pages display ok, and that links and tabs work as expected.

**Author notes and concerns**:

1. Am not suggesting that we test to see that the security issue itself is fixed -- edX have provided this patch, so they have tested this.

**Reviewers**
- [ ] @toxinu 