### PR TITLE
Upgrade pymongo and fix issues

### DIFF
--- a/common/lib/xmodule/xmodule/course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/course_metadata_utils.py
@@ -145,7 +145,7 @@ def sorting_dates(start, advertised_start, announcement):
         start = dateutil.parser.parse(advertised_start)
         if start.tzinfo is None:
             start = start.replace(tzinfo=utc)
-    except (ValueError, AttributeError):
+    except (TypeError, ValueError, AttributeError):
         start = start
 
     now = datetime.now(utc)

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1883,7 +1883,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         """
         source_assets = self._find_course_assets(source_course_key)
         dest_assets = {'assets': source_assets.asset_md.copy(), 'course_id': unicode(dest_course_key)}
-        self.asset_collection.delete_many({'course_id': six.text_type(dest_course_key)})
+        self.asset_collection.delete_many({'course_id': unicode(dest_course_key)})
         # Update the document.
         self.asset_collection.insert(dest_assets)
 

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -600,14 +600,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         """
         Closes any open connections to the underlying database
         """
-        self.collection.database.connection.close()
-
-    def mongo_wire_version(self):
-        """
-        Returns the wire version for mongo. Only used to unit tests which instrument the connection.
-        """
-        self.database.connection._ensure_connected()
-        return self.database.connection.max_wire_version
+        self.collection.database.client.close()
 
     def _drop_database(self, database=True, collections=True, connections=True):
         """
@@ -624,14 +617,14 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         # drop the assets
         super(MongoModuleStore, self)._drop_database(database, collections, connections)
 
-        connection = self.collection.database.connection
+        connection = self.collection.database.client
 
         if database:
             connection.drop_database(self.collection.database.proxied_object)
         elif collections:
             self.collection.drop()
         else:
-            self.collection.remove({})
+            self.collection.delete_many({})
 
         if connections:
             connection.close()
@@ -1890,7 +1883,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         """
         source_assets = self._find_course_assets(source_course_key)
         dest_assets = {'assets': source_assets.asset_md.copy(), 'course_id': unicode(dest_course_key)}
-        self.asset_collection.remove({'course_id': unicode(dest_course_key)})
+        self.asset_collection.delete_many({'course_id': six.text_type(dest_course_key)})
         # Update the document.
         self.asset_collection.insert(dest_assets)
 
@@ -1962,7 +1955,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         # A single document exists per course to store the course asset metadata.
         try:
             course_assets = self._find_course_assets(course_key)
-            self.asset_collection.remove(course_assets.doc_id)
+            self.asset_collection.delete_many({'_id': course_assets.doc_id})
         except ItemNotFoundError:
             # When deleting asset metadata, if a course's asset metadata is not present, no big deal.
             pass
@@ -1971,9 +1964,11 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         """
         Check that the db is reachable.
         """
-        if self.database.connection.alive():
+        try:
+            # The ismaster command is cheap and does not require auth.
+            self.database.client.admin.command('ismaster')
             return {ModuleStoreEnum.Type.mongo: True}
-        else:
+        except pymongo.errors.ConnectionFailure:
             raise HeartbeatFailure("Can't connect to {}".format(self.database.name), 'mongo')
 
     def ensure_indexes(self):

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -164,7 +164,7 @@ class DraftModuleStore(MongoModuleStore):
 
         # delete all of the db records for the course
         course_query = self._course_key_to_son(course_key)
-        self.collection.remove(course_query, multi=True)
+        self.collection.delete_many(course_query)
         self.delete_all_asset_metadata(course_key, user_id)
 
         self._emit_course_deleted_signal(course_key)
@@ -637,7 +637,7 @@ class DraftModuleStore(MongoModuleStore):
         if len(to_be_deleted) > 0:
             bulk_record = self._get_bulk_ops_record(root_usages[0].course_key)
             bulk_record.dirty = True
-            self.collection.remove({'_id': {'$in': to_be_deleted}}, safe=self.collection.safe)
+            self.collection.delete_many({'_id': {'$in': to_be_deleted}})
 
     @memoize_in_request_cache('request_cache')
     def has_changes(self, xblock):
@@ -741,7 +741,7 @@ class DraftModuleStore(MongoModuleStore):
         bulk_record = self._get_bulk_ops_record(course_key)
         if len(to_be_deleted) > 0:
             bulk_record.dirty = True
-            self.collection.remove({'_id': {'$in': to_be_deleted}})
+            self.collection.delete_many({'_id': {'$in': to_be_deleted}})
 
         self._flag_publish_event(course_key)
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -308,9 +308,11 @@ class MongoConnection(object):
         """
         Check that the db is reachable.
         """
-        if self.database.connection.alive():
+        try:
+            # The ismaster command is cheap and does not require auth.
+            self.database.client.admin.command('ismaster')
             return True
-        else:
+        except pymongo.errors.ConnectionFailure:
             raise HeartbeatFailure("Can't connect to {}".format(self.database.name), 'mongo')
 
     def get_structure(self, key, course_context=None):
@@ -569,13 +571,7 @@ class MongoConnection(object):
         """
         Closes any open connections to the underlying databases
         """
-        self.database.connection.close()
-
-    def mongo_wire_version(self):
-        """
-        Returns the wire version for mongo. Only used to unit tests which instrument the connection.
-        """
-        return self.database.connection.max_wire_version
+        self.database.client.close()
 
     def _drop_database(self, database=True, collections=True, connections=True):
         """
@@ -589,7 +585,7 @@ class MongoConnection(object):
 
         If connections is True, then close the connection to the database as well.
         """
-        connection = self.database.connection
+        connection = self.database.client
 
         if database:
             connection.drop_database(self.database.name)

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -698,12 +698,6 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         """
         self.db_connection.close_connections()
 
-    def mongo_wire_version(self):
-        """
-        Returns the wire version for mongo. Only used to unit tests which instrument the connection.
-        """
-        return self.db_connection.mongo_wire_version
-
     def _drop_database(self, database=True, collections=True, connections=True):
         """
         A destructive operation to drop the underlying database and close all connections.

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -606,8 +606,6 @@ def mongo_uses_error_check(store):
     """
     Does mongo use the error check as a separate message?
     """
-    if hasattr(store, 'mongo_wire_version'):
-        return store.mongo_wire_version() <= 1
     if hasattr(store, 'modulestores'):
         return any([mongo_uses_error_check(substore) for substore in store.modulestores])
     return False
@@ -626,16 +624,16 @@ def check_mongo_calls_range(max_finds=float("inf"), min_finds=0, max_sends=None,
     :param min_sends: If non-none, make sure number of send calls are >=min_sends
     """
     with check_sum_of_calls(
-        pymongo.message,
-        ['query', 'get_more'],
+        pymongo.collection.Collection,
+        ['find'],
         max_finds,
         min_finds,
     ):
         if max_sends is not None or min_sends is not None:
             with check_sum_of_calls(
-                pymongo.message,
+                pymongo.collection.Collection,
                 # mongo < 2.6 uses insert, update, delete and _do_batched_insert. >= 2.6 _do_batched_write
-                ['insert', 'update', 'delete', '_do_batched_write_command', '_do_batched_insert', ],
+                ['insert', 'update', 'bulk_write', '_delete'],
                 max_sends if max_sends is not None else float("inf"),
                 min_sends if min_sends is not None else 0,
             ):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo_call_count.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo_call_count.py
@@ -148,14 +148,14 @@ class CountMongoCallsCourseTraversal(TestCase):
         (MIXED_OLD_MONGO_MODULESTORE_BUILDER, 0, True, False, 359),
         # The line below shows the way this traversal *should* be done
         # (if you'll eventually access all the fields and load all the definitions anyway).
-        (MIXED_SPLIT_MODULESTORE_BUILDER, None, False, True, 4),
+        (MIXED_SPLIT_MODULESTORE_BUILDER, None, False, True, 3),
         (MIXED_SPLIT_MODULESTORE_BUILDER, None, True, True, 38),
         (MIXED_SPLIT_MODULESTORE_BUILDER, 0, False, True, 38),
         (MIXED_SPLIT_MODULESTORE_BUILDER, 0, True, True, 38),
-        (MIXED_SPLIT_MODULESTORE_BUILDER, None, False, False, 4),
-        (MIXED_SPLIT_MODULESTORE_BUILDER, None, True, False, 4),
-        (MIXED_SPLIT_MODULESTORE_BUILDER, 0, False, False, 4),
-        (MIXED_SPLIT_MODULESTORE_BUILDER, 0, True, False, 4)
+        (MIXED_SPLIT_MODULESTORE_BUILDER, None, False, False, 3),
+        (MIXED_SPLIT_MODULESTORE_BUILDER, None, True, False, 3),
+        (MIXED_SPLIT_MODULESTORE_BUILDER, 0, False, False, 3),
+        (MIXED_SPLIT_MODULESTORE_BUILDER, 0, True, False, 3)
     )
     @ddt.unpack
     def test_number_mongo_calls(self, store_builder, depth, lazy, access_all_block_fields, num_mongo_calls):
@@ -174,7 +174,7 @@ class CountMongoCallsCourseTraversal(TestCase):
 
     @ddt.data(
         (MIXED_OLD_MONGO_MODULESTORE_BUILDER, 176),
-        (MIXED_SPLIT_MODULESTORE_BUILDER, 5),
+        (MIXED_SPLIT_MODULESTORE_BUILDER, 4),
     )
     @ddt.unpack
     def test_lazy_when_course_previously_cached(self, store_builder, num_mongo_calls):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
@@ -1,6 +1,8 @@
 """ Test the behavior of split_mongo/MongoConnection """
 import unittest
 from mock import patch
+from pymongo.errors import ConnectionFailure
+
 from xmodule.modulestore.split_mongo.mongo_connection import MongoConnection
 from xmodule.exceptions import HeartbeatFailure
 
@@ -12,7 +14,7 @@ class TestHeartbeatFailureException(unittest.TestCase):
     def test_heartbeat_raises_exception_when_connection_alive_is_false(self, *calls):
         # pylint: disable=W0613
         with patch('mongodb_proxy.MongoProxy') as mock_proxy:
-            mock_proxy.return_value.alive.return_value = False
+            mock_proxy.return_value.admin.command.side_effect = ConnectionFailure('Test')
             useless_conn = MongoConnection('useless', 'useless', 'useless')
 
             with self.assertRaises(HeartbeatFailure):

--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -6,8 +6,18 @@ import logging
 import pymongo
 from pymongo import ReadPreference
 from mongodb_proxy import MongoProxy
+from pymongo.read_preferences import (
+    ReadPreference,
+    read_pref_mode_from_name,
+    _MONGOS_MODES,
+    _MODES
+)
+
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+# This will yeld a map of all available Mongo modes and their name
+MONGO_READ_PREFERENCE_MAP = dict(zip(_MONGOS_MODES, _MODES))
 
 
 # pylint: disable=bad-continuation
@@ -34,10 +44,16 @@ def connect_to_mongodb(
         # No 'replicaSet' in kwargs - so no secondary reads.
         mongo_client_class = pymongo.MongoClient
 
-    # If read_preference is given as a name of a valid ReadPreference.<NAME> constant
-    # such as "SECONDARY_PREFERRED", convert it. Otherwise pass it through unchanged.
+    # If read_preference is given as a name of a valid ReadPreference.<NAME>
+    # constant such as "SECONDARY_PREFERRED" or a mongo mode such as
+    # "secondaryPreferred", convert it. Otherwise pass it through unchanged.
     if 'read_preference' in kwargs:
-        read_preference = getattr(ReadPreference, kwargs['read_preference'], None)
+        read_preference = MONGO_READ_PREFERENCE_MAP.get(
+            kwargs['read_preference'],
+            kwargs['read_preference']
+        )
+
+        read_preference = getattr(ReadPreference, read_preference, None)
         if read_preference is not None:
             kwargs['read_preference'] = read_preference
 

--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -348,4 +348,4 @@ def add_repo(repo, rdir_in, branch=None):
     cil.save()
 
     log.debug('saved CourseImportLog for %s', cil.course_id)
-    mdb.disconnect()
+    mdb.close()

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -650,7 +650,7 @@ class GitLogs(TemplateView):
             page = min(max(1, given_page), paginator.num_pages)
             logs = paginator.page(page)
 
-        mdb.disconnect()
+        mdb.close()
         context = {
             'logs': logs,
             'course_id': course_id.to_deprecated_string() if course_id else None,

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -88,7 +88,7 @@ pygraphviz==1.1
 pyjwkest==1.3.2
 # TODO Replace PyJWT usage with pyjwkest
 PyJWT==1.4.0
-pymongo==2.9.1
+pymongo==3.9.0
 python-memcached==1.48
 django-memcached-hashring==0.1.2
 python-openid==2.2.5


### PR DESCRIPTION
This commit upgrades the version of pymongo from 2.x to 3.x, removing usages to deprecated functions usage and fixing tests where necessary.

This version of pymongo supports MongoDB 2.x all the way up to 4.2, and this ensures that the platform will be able to run on a supported MongoDB version in the next release.

(cherry picked from commit 9b69d5a62684dc3d9d86b7e71081bebd432bd7d9)