### PR TITLE
SE-1541 Move block to where ENV_TOKENS is defined

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -57,11 +57,6 @@ BROKER_CONNECTION_TIMEOUT = 1
 # For the Result Store, use the django cache named 'celery'
 CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 
-# When the broker is behind an ELB, use a heartbeat to refresh the
-# connection and to detect if it has been dropped.
-BROKER_HEARTBEAT = ENV_TOKENS.get('BROKER_HEARTBEAT', 60.0)
-BROKER_HEARTBEAT_CHECKRATE = ENV_TOKENS.get('BROKER_HEARTBEAT_CHECKRATE', 2)
-
 # Each worker should only fetch one message at a time
 CELERYD_PREFETCH_MULTIPLIER = 1
 
@@ -88,6 +83,11 @@ CELERY_ROUTES = "{}celery.Router".format(QUEUE_VARIANT)
 # Things like server locations, ports, etc.
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
+
+# When the broker is behind an ELB, use a heartbeat to refresh the
+# connection and to detect if it has been dropped.
+BROKER_HEARTBEAT = ENV_TOKENS.get('BROKER_HEARTBEAT', 60.0)
+BROKER_HEARTBEAT_CHECKRATE = ENV_TOKENS.get('BROKER_HEARTBEAT_CHECKRATE', 2)
 
 # Do NOT calculate this dynamically at startup with git because it's *slow*.
 EDX_PLATFORM_REVISION = ENV_TOKENS.get('EDX_PLATFORM_REVISION', EDX_PLATFORM_REVISION)

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -71,11 +71,6 @@ BROKER_CONNECTION_TIMEOUT = 1
 # For the Result Store, use the django cache named 'celery'
 CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 
-# When the broker is behind an ELB, use a heartbeat to refresh the
-# connection and to detect if it has been dropped.
-BROKER_HEARTBEAT = ENV_TOKENS.get('BROKER_HEARTBEAT', 60.0)
-BROKER_HEARTBEAT_CHECKRATE = ENV_TOKENS.get('BROKER_HEARTBEAT_CHECKRATE', 2)
-
 # Each worker should only fetch one message at a time
 CELERYD_PREFETCH_MULTIPLIER = 1
 
@@ -106,6 +101,11 @@ CELERYBEAT_SCHEDULE = {}  # For scheduling tasks, entries can be added to this d
 
 with open(CONFIG_ROOT / CONFIG_PREFIX + "env.json") as env_file:
     ENV_TOKENS = json.load(env_file)
+
+# When the broker is behind an ELB, use a heartbeat to refresh the
+# connection and to detect if it has been dropped.
+BROKER_HEARTBEAT = ENV_TOKENS.get('BROKER_HEARTBEAT', 60.0)
+BROKER_HEARTBEAT_CHECKRATE = ENV_TOKENS.get('BROKER_HEARTBEAT_CHECKRATE', 2)
 
 # STATIC_ROOT specifies the directory where static files are
 # collected


### PR DESCRIPTION
Previously this was causing a NameError, because it was attempting to
use ENV_TOKENS before it was defined.

This issue was introduced in https://github.com/open-craft/edx-platform/pull/198 where unfortunately it didn't get tested thoroughly (turns out ironwood and master differ enough in this case that while the patch backported cleanly, it was no longer valid). :(

**Test instructions**:

- launch a production sandbox or provision a devstack with this branch ([this sandbox](https://console.opencraft.com/instance/17390/) is being provisioned from this branch)
- verify that it provisions successfully and that BROKER_HEARTBEAT and BROKER_HEARTBEAT_CHECKRATE are set as expected.