### PR TITLE
[BB-1933] Backport CourseEnrollmentForm changes

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -149,7 +149,6 @@ class LinkedInAddToProfileConfigurationAdmin(admin.ModelAdmin):
 
 
 class CourseEnrollmentForm(forms.ModelForm):
-
     def __init__(self, *args, **kwargs):
         # If args is a QueryDict, then the ModelForm addition request came in as a POST with a course ID string.
         # Change the course ID string to a CourseLocator object by copying the QueryDict to make it mutable.
@@ -184,6 +183,15 @@ class CourseEnrollmentForm(forms.ModelForm):
 
         return course_key
 
+    def save(self, *args, **kwargs):
+        course_enrollment = super(CourseEnrollmentForm, self).save(commit=False)
+        user = self.cleaned_data['user']
+        course_overview = self.cleaned_data['course']
+        enrollment = CourseEnrollment.get_or_create_enrollment(user, course_overview.id)
+        course_enrollment.id = enrollment.id
+        course_enrollment.created = enrollment.created
+        return course_enrollment
+
     class Meta:
         model = CourseEnrollment
         fields = '__all__'
@@ -194,7 +202,7 @@ class CourseEnrollmentAdmin(admin.ModelAdmin):
     """ Admin interface for the CourseEnrollment model. """
     list_display = ('id', 'course_id', 'mode', 'user', 'is_active',)
     list_filter = ('mode', 'is_active',)
-    raw_id_fields = ('user',)
+    raw_id_fields = ('user', 'course')
     search_fields = ('course__id', 'mode', 'user__username',)
     form = CourseEnrollmentForm
 

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -150,23 +150,27 @@ class LinkedInAddToProfileConfigurationAdmin(admin.ModelAdmin):
 
 class CourseEnrollmentForm(forms.ModelForm):
 
-    def __init__(self, data=None, *args, **kwargs):
-        # This code should be safe to remove once
-        # https://github.com/edx/opaque-keys/commit/5b5119979a7d5f186350a92b4b5748c3d4bcc92f
-        # is released and the correct opaque-keys version is used in edx-platform.
-        try:
-            # If data has _mutable attribute is a POST QuerDict and we have to update it.
-            data._mutable = True
-        except AttributeError:
-            pass
-
-        if data and data.get('course'):
+    def __init__(self, *args, **kwargs):
+        # If args is a QueryDict, then the ModelForm addition request came in as a POST with a course ID string.
+        # Change the course ID string to a CourseLocator object by copying the QueryDict to make it mutable.
+        if args and 'course' in args[0] and isinstance(args[0], QueryDict):
+            args_copy = args[0].copy()
             try:
-                data['course'] = CourseKey.from_string(data['course'])
+                args_copy['course'] = CourseKey.from_string(args_copy['course'])
             except InvalidKeyError:
-                raise forms.ValidationError("Cannot make a valid CourseKey from id {}!".format(data['course']))
+                raise forms.ValidationError("Cannot make a valid CourseKey from id {}!".format(args_copy['course']))
+            args = [args_copy]
 
-        super(CourseEnrollmentForm, self).__init__(data, *args, **kwargs)
+        super(CourseEnrollmentForm, self).__init__(*args, **kwargs)
+
+        if self.data.get('course'):
+            try:
+                self.data['course'] = CourseKey.from_string(self.data['course'])
+            except AttributeError:
+                # Change the course ID string to a CourseLocator.
+                # On a POST request, self.data is a QueryDict and is immutable - so this code will fail.
+                # However, the args copy above before the super() call handles this case.
+                pass
 
     def clean_course_id(self):
         course_id = self.cleaned_data['course']
@@ -180,15 +184,6 @@ class CourseEnrollmentForm(forms.ModelForm):
 
         return course_key
 
-    def save(self, *args, **kwargs):
-        course_enrollment = super(CourseEnrollmentForm, self).save(commit=False)
-        user = self.cleaned_data['user']
-        course_overview = self.cleaned_data['course']
-        enrollment = CourseEnrollment.get_or_create_enrollment(user, course_overview.id)
-        course_enrollment.id = enrollment.id
-        course_enrollment.created = enrollment.created
-        return course_enrollment
-
     class Meta:
         model = CourseEnrollment
         fields = '__all__'
@@ -199,7 +194,7 @@ class CourseEnrollmentAdmin(admin.ModelAdmin):
     """ Admin interface for the CourseEnrollment model. """
     list_display = ('id', 'course_id', 'mode', 'user', 'is_active',)
     list_filter = ('mode', 'is_active',)
-    raw_id_fields = ('user', 'course')
+    raw_id_fields = ('user',)
     search_fields = ('course__id', 'mode', 'user__username',)
     form = CourseEnrollmentForm
 

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -6,16 +6,13 @@ from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.forms import ValidationError
 from django.urls import reverse
-from django.utils.timezone import now
 from django.test import TestCase
 from mock import Mock
 
-from student.admin import COURSE_ENROLLMENT_ADMIN_SWITCH, UserAdmin, CourseEnrollmentForm
-from student.models import CourseEnrollment
+from student.admin import COURSE_ENROLLMENT_ADMIN_SWITCH, UserAdmin
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 
 
 class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
@@ -301,53 +298,3 @@ class CourseEnrollmentAdminTest(SharedModuleStoreTestCase):
                     reverse('admin:student_courseenrollment_change', args=(self.course_enrollment.id, )),
                     data=data,
                 )
-
-
-class CourseEnrollmentAdminFormTest(SharedModuleStoreTestCase):
-    """
-    Unit test for CourseEnrollment admin ModelForm.
-    """
-    @classmethod
-    def setUpClass(cls):
-        super(CourseEnrollmentAdminFormTest, cls).setUpClass()
-        cls.course = CourseOverviewFactory(start=now())
-
-    def setUp(self):
-        super(CourseEnrollmentAdminFormTest, self).setUp()
-        self.user = UserFactory.create()
-
-    def test_admin_model_form_create(self):
-        """
-        Test CourseEnrollmentAdminForm creation.
-        """
-        self.assertEqual(CourseEnrollment.objects.count(), 0)
-
-        form = CourseEnrollmentForm({
-            'user': self.user.id,
-            'course': unicode(self.course.id),
-            'is_active': True,
-            'mode': 'audit',
-        })
-        self.assertTrue(form.is_valid())
-        enrollment = form.save()
-        self.assertEqual(CourseEnrollment.objects.count(), 1)
-        self.assertEqual(CourseEnrollment.objects.first(), enrollment)
-
-    def test_admin_model_form_update(self):
-        """
-        Test CourseEnrollmentAdminForm update.
-        """
-        enrollment = CourseEnrollment.get_or_create_enrollment(self.user, self.course.id)
-        count = CourseEnrollment.objects.count()
-        form = CourseEnrollmentForm({
-            'user': self.user.id,
-            'course': unicode(self.course.id),
-            'is_active': False,
-            'mode': 'audit'},
-            instance=enrollment
-        )
-        self.assertTrue(form.is_valid())
-        course_enrollment = form.save()
-        self.assertEqual(count, CourseEnrollment.objects.count())
-        self.assertFalse(course_enrollment.is_active)
-        self.assertEqual(enrollment.id, course_enrollment.id)


### PR DESCRIPTION
Reverts early-merged changes from b0cf5d57 and backports the upstreamed ones from 0e85af8.

## Testing Instructions

1. Login as a superuser or a user that has access to `/admin`.
2. Go to `admin/waffle/switch/` and create a switch with the name `student.courseenrollment_admin` in case it's not there already.
3. Go to `admin/student/courseenrollment/`.
4. Click on any of the row IDs.
5. Uncheck the `active` box and save it.

**The course enrollment should be updated without any errors.**