### PR TITLE
SE-1908 Fix for autoadvance issue with hls videos

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/02_html5_hls_video.js
+++ b/common/lib/xmodule/xmodule/js/src/video/02_html5_hls_video.js
@@ -42,7 +42,11 @@
                 if (config.browserIsSafari) {
                     this.videoEl.attr('src', config.videoSources[0]);
                 } else {
-                    this.hls = new HLS({autoStartLoad: false});
+                    if (config.state.auto_advance) {
+			this.hls = new HLS({autoStartLoad: true});
+	            } else {
+                        this.hls = new HLS({autoStartLoad: false});
+	            }
                     this.hls.loadSource(config.videoSources[0]);
                     this.hls.attachMedia(this.video);
 

--- a/common/lib/xmodule/xmodule/js/src/video/02_html5_hls_video.js
+++ b/common/lib/xmodule/xmodule/js/src/video/02_html5_hls_video.js
@@ -43,10 +43,10 @@
                     this.videoEl.attr('src', config.videoSources[0]);
                 } else {
                     if (config.state.auto_advance) {
-			this.hls = new HLS({autoStartLoad: true});
-	            } else {
+                        this.hls = new HLS({autoStartLoad: true});
+                    } else {
                         this.hls = new HLS({autoStartLoad: false});
-	            }
+                    }
                     this.hls.loadSource(config.videoSources[0]);
                     this.hls.attachMedia(this.video);
 


### PR DESCRIPTION
This PR fixes the issue with autoadvance noted on cloudera courses which are HLS videos.

**Upstream PR:** [#22539](https://github.com/edx/edx-platform/pull/22539)

**Testing Instructions:**
1. Create a course with consecutive units containing videos. Add a m3u8 (HLS) video in the second unit.
2. Ensure "ENABLE_AUTOADVANCE_VIDEOS" is set to true in lms.env.json file.
3. Set the enable video auto-advance flag in Advanced settings in studio.
4. Enroll into the course from lms and start course.
5. Verify that at the end of the first video, the next unit is loaded automatically and the video starts playing.

**Reviewers:**

- [ ] @pomegranited 