### PR TITLE
Fix unicode error

### DIFF
--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -4,9 +4,9 @@ Helper methods for Studio views.
 
 from __future__ import absolute_import
 
-import urllib
 from uuid import uuid4
 
+import six
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils.translation import ugettext as _
@@ -111,7 +111,7 @@ def xblock_studio_url(xblock, parent_xblock=None):
     elif category in ('chapter', 'sequential'):
         return u'{url}?show={usage_key}'.format(
             url=reverse_course_url('course_handler', xblock.location.course_key),
-            usage_key=urllib.quote(unicode(xblock.location))
+            usage_key=six.moves.urllib.parse.quote(six.text_type(xblock.location).encode('utf-8'))
         )
     elif category == 'library':
         library_key = xblock.location.course_key

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1556,11 +1556,11 @@ class CourseEnrollment(models.Model):
 
         if not status_hash:
             enrollments = cls.enrollments_for_user(user).values_list('course_id', 'mode')
-            enrollments = [(six.text_type(e[0]).lower(), e[1].lower()) for e in enrollments]
+            enrollments = [(six.text_type(e[0]).lower().encode('utf-8'), e[1].lower()) for e in enrollments]
             enrollments = sorted(enrollments, key=lambda e: e[0])
             hash_elements = [user.username]
             hash_elements += ['{course_id}={mode}'.format(course_id=e[0], mode=e[1]) for e in enrollments]
-            status_hash = hashlib.md5('&'.join(hash_elements).encode('utf-8')).hexdigest()
+            status_hash = hashlib.md5('&'.join(str(element) for element in hash_elements)).hexdigest()
 
             # The hash is cached indefinitely. It will be invalidated when the user enrolls/unenrolls.
             cache.set(cache_key, status_hash, None)

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -282,7 +282,7 @@ def course_run_refund_status(request, course_id):
         return JsonResponse({'course_refundable_status': ''}, status=406)
 
     refundable_status = course_enrollment.refundable()
-    logging.info("Course refund status for course {0} is {1}".format(course_id, refundable_status))
+    logging.info("Course refund status for course {0} is {1}".format(str(course_id), refundable_status))
 
     return JsonResponse({'course_refundable_status': refundable_status}, status=200)
 

--- a/lms/djangoapps/courseware/url_helpers.py
+++ b/lms/djangoapps/courseware/url_helpers.py
@@ -1,6 +1,7 @@
 """
 Module to define url helpers functions
 """
+import six
 from urllib import urlencode
 
 from django.urls import reverse
@@ -48,5 +49,5 @@ def get_redirect_url(course_key, usage_key):
             'courseware_position',
             args=(unicode(course_key), chapter, section, navigation_index(position))
         )
-    redirect_url += "?{}".format(urlencode({'activate_block_id': unicode(final_target_id)}))
+    redirect_url += "?{}".format(urlencode({'activate_block_id': six.text_type(final_target_id).encode('utf-8')}))
     return redirect_url

--- a/openedx/core/djangoapps/content/block_structure/store.py
+++ b/openedx/core/djangoapps/content/block_structure/store.py
@@ -5,6 +5,7 @@ Module for the Storage of BlockStructure objects.
 from logging import getLogger
 
 from openedx.core.lib.cache_utils import zpickle, zunpickle
+from six import text_type
 
 from . import config
 from .block_structure import BlockStructureBlockData
@@ -217,12 +218,12 @@ class BlockStructureStore(object):
         BlockStructureModel or StubModel.
         """
         if _is_storage_backing_enabled():
-            return unicode(bs_model)
+            return text_type(bs_model)
 
         else:
             return "v{version}.root.key.{root_usage_key}".format(
-                version=unicode(BlockStructureBlockData.VERSION),
-                root_usage_key=unicode(bs_model.data_usage_key),
+                version=text_type(BlockStructureBlockData.VERSION),
+                root_usage_key=text_type(bs_model.data_usage_key).encode('utf-8'),
             )
 
     @staticmethod


### PR DESCRIPTION
This PR fixes a unicode error that is noticed when creating a course in a non-english language.

**JIRA tickets:** [SE-1981](https://tasks.opencraft.com/browse/SE-1981)

**Dependencies:** None

**Sandbox URL:** TBD

**Testing Instructions:**
1. Enable a unicode language (say ja-jp) in the instance config.
2. Create a new course in the unicode language (make sure browser preference is set to the language as well) from Studio.
3. Verify that the course gets created successfully and user is able to enroll into it.

**Reviewers:**

- [ ] @mtyaka 