### PR TITLE
SE-2092 Send user_logged_in when Mobile API user detail requested

### DIFF
--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -78,13 +78,13 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
         self.login()
         self.enroll(course_id)
 
-    def api_response(self, reverse_args=None, expected_response_code=200, data=None, **kwargs):
+    def api_response(self, reverse_args=None, expected_response_code=200, data=None, follow=False, **kwargs):
         """
         Helper method for calling endpoint, verifying and returning response.
         If expected_response_code is None, doesn't verify the response' status_code.
         """
         url = self.reverse_url(reverse_args, **kwargs)
-        response = self.url_method(url, data=data, **kwargs)
+        response = self.url_method(url, data=data, follow=follow)
         if expected_response_code is not None:
             self.assertEqual(response.status_code, expected_response_code)
         return response
@@ -100,9 +100,9 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
             reverse_args.update({'api_version': kwargs.get('api_version', self.api_version)})
         return reverse(self.REVERSE_INFO['name'], kwargs=reverse_args)
 
-    def url_method(self, url, data=None, **kwargs):  # pylint: disable=unused-argument
+    def url_method(self, url, data=None, **kwargs):
         """Base implementation that returns response from the GET method of the URL."""
-        return self.client.get(url, data=data)
+        return self.client.get(url, data=data, **kwargs)
 
 
 class MobileAuthTestMixin(object):

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -58,6 +58,21 @@ class TestUserDetailApi(MobileAPITestCase, MobileAuthUserTestMixin):
         self.assertEqual(response.data['username'], self.user.username)
         self.assertEqual(response.data['email'], self.user.email)
 
+    @ddt.data(API_V05, API_V1)
+    def test_last_loggedin_updated(self, api_version):
+        """Verify that a user's last logged in value updates after hitting the my_user_info endpoint"""
+        self.login()
+
+        self.user.refresh_from_db()
+        last_login_before = self.user.last_login
+
+        # just hit the api endpoint; we don't care about the response here (tested previously)
+        self.api_response(api_version=api_version)
+
+        self.user.refresh_from_db()
+        last_login_after = self.user.last_login
+        assert last_login_after > last_login_before
+
 
 @attr(shard=9)
 @ddt.ddt
@@ -83,8 +98,8 @@ class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
         self.user.refresh_from_db()
         last_login_before = self.user.last_login
 
-        # just hit the api endpoint; we don't care about the response here (tested previously)
-        self.api_response(expected_response_code=302, api_version=api_version)
+        # just follow the api endpoint; we don't care about the response here (tested previously)
+        self.api_response(api_version=api_version, follow=True)
 
         self.user.refresh_from_db()
         last_login_after = self.user.last_login

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -70,6 +70,12 @@ class UserDetail(generics.RetrieveAPIView):
     serializer_class = UserSerializer
     lookup_field = 'username'
 
+    def get(self, request, *args, **kwargs):
+        # update user's last logged in from here because
+        # updating it from the oauth2 related code is too complex
+        user_logged_in.send(sender=User, user=request.user, request=request)
+        return super(UserDetail, self).get(request, *args, **kwargs)
+
     def get_serializer_context(self):
         context = super(UserDetail, self).get_serializer_context()
         context['api_version'] = self.kwargs.get('api_version')
@@ -380,7 +386,4 @@ def my_user_info(request, api_version):
     """
     Redirect to the currently-logged-in user's info page
     """
-    # update user's last logged in from here because
-    # updating it from the oauth2 related code is too complex
-    user_logged_in.send(sender=User, user=request.user, request=request)
     return redirect("user-detail", api_version=api_version, username=request.user.username)


### PR DESCRIPTION
Moves user_logged_in signal to UserDetail.get so that it's triggered on initial app login and when app is re-launched.

cherry picked from commit 3b3c7bc07a61deab607967b67e201f9d3e09b74e, cf https://github.com/edx/edx-platform/pull/22999

**Testing instructions**

I believe the testing we did for the upstream PR is sufficient here.  So it's just a straight backport cherry-pick, and there were no conflicts.

**Reviewer**

- [x] @swalladge 
