### PR TITLE
Show Enroll links on public courses only if self-enrollment is allowed

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -618,7 +618,7 @@ class CourseTabView(EdxFragmentView):
         else:
             if not CourseEnrollment.is_enrolled(request.user, course.id) and not allow_anonymous:
                 # Only show enroll button if course is open for enrollment.
-                if course_open_for_self_enrollment(course.id):
+                if course_open_for_self_enrollment(course.id) and not course.invitation_only:
                     enroll_message = _(u'You must be enrolled in the course to see course content. \
                             {enroll_link_start}Enroll now{enroll_link_end}.')
                     PageLevelMessages.register_warning_message(

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -124,6 +124,14 @@ class CourseHomePageTestCase(SharedModuleStoreTestCase):
                     number='test',
                     display_name='Test Course',
                     start=now() - timedelta(days=30),
+                    metadata={"invitation_only": False}
+                )
+                cls.private_course = CourseFactory.create(
+                    org='edX',
+                    number='test',
+                    display_name='Test Private Course',
+                    start=now() - timedelta(days=30),
+                    metadata={"invitation_only": True}
                 )
                 with cls.store.bulk_operations(cls.course.id):
                     chapter = ItemFactory.create(
@@ -291,6 +299,9 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
                 url = course_home_url(self.course)
                 response = self.client.get(url)
 
+                private_url = course_home_url(self.private_course)
+                private_response = self.client.get(private_url)
+
         # Verify that the course tools and dates are always shown
         self.assertContains(response, TEST_COURSE_TOOLS)
         self.assertContains(response, TEST_COURSE_TODAY)
@@ -311,7 +322,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         # Verify the outline is shown to enrolled users, unenrolled_staff and anonymous users if allowed
         self.assertContains(response, TEST_CHAPTER_NAME, count=(1 if expected_course_outline else 0))
 
-        # Verify that the expected message is shown to the user
+        # Verify the message shown to the user
         if not enable_unenrolled_access or course_visibility != COURSE_VISIBILITY_PUBLIC:
             self.assertContains(
                 response, 'To see course content', count=(1 if is_anonymous else 0)
@@ -319,6 +330,12 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
             self.assertContains(response, '<div class="user-messages"', count=(1 if expected_enroll_message else 0))
             if expected_enroll_message:
                 self.assertContains(response, 'You must be enrolled in the course to see course content.')
+
+        if enable_unenrolled_access and course_visibility == COURSE_VISIBILITY_PUBLIC:
+            if user_type == CourseUserType.UNENROLLED and self.private_course.invitation_only:
+                if expected_enroll_message:
+                    self.assertContains(private_response,
+                                        'You must be enrolled in the course to see course content.')
 
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -5,16 +5,12 @@ View logic for handling course messages.
 from datetime import datetime
 
 from babel.dates import format_date, format_timedelta
+from courseware.courses import get_course_date_blocks, get_course_with_access
 from django.contrib import auth
 from django.template.loader import render_to_string
 from django.utils.http import urlquote_plus
-from django.utils.translation import ugettext as _
 from django.utils.translation import get_language, to_locale
-from opaque_keys.edx.keys import CourseKey
-from pytz import UTC
-from web_fragments.fragment import Fragment
-
-from courseware.courses import get_course_date_blocks, get_course_with_access
+from django.utils.translation import ugettext as _
 from lms.djangoapps.course_goals.api import (
     get_course_goal,
     get_course_goal_options,
@@ -23,10 +19,15 @@ from lms.djangoapps.course_goals.api import (
     valid_course_goals_ordered
 )
 from lms.djangoapps.course_goals.models import GOAL_KEY_CHOICES
+from lms.djangoapps.courseware.courses import allow_public_access
+from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import CourseHomeMessages
+from pytz import UTC
 from student.models import CourseEnrollment
+from web_fragments.fragment import Fragment
+from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
 
 
 class CourseHomeMessageFragmentView(EdxFragmentView):
@@ -107,36 +108,45 @@ def _register_course_home_messages(request, course, user_access, course_start_da
     """
     Register messages to be shown in the course home content page.
     """
-    if user_access['is_anonymous']:
+    allow_anonymous = allow_public_access(course, [COURSE_VISIBILITY_PUBLIC])
+
+    if user_access['is_anonymous'] and not allow_anonymous:
         CourseHomeMessages.register_info_message(
             request,
             Text(_(
-                '{sign_in_link} or {register_link} and then enroll in this course.'
+                u'{sign_in_link} or {register_link} and then enroll in this course.'
             )).format(
-                sign_in_link=HTML('<a href="/login?next={current_url}">{sign_in_label}</a>').format(
+                sign_in_link=HTML(u'<a href="/login?next={current_url}">{sign_in_label}</a>').format(
                     sign_in_label=_('Sign in'),
                     current_url=urlquote_plus(request.path),
                 ),
-                register_link=HTML('<a href="/register?next={current_url}">{register_label}</a>').format(
+                register_link=HTML(u'<a href="/register?next={current_url}">{register_label}</a>').format(
                     register_label=_('register'),
                     current_url=urlquote_plus(request.path),
                 )
             ),
             title=Text(_('You must be enrolled in the course to see course content.'))
         )
-    if not user_access['is_anonymous'] and not user_access['is_staff'] and not user_access['is_enrolled']:
-        CourseHomeMessages.register_info_message(
-            request,
-            Text(_(
-                '{open_enroll_link}Enroll now{close_enroll_link} to access the full course.'
-            )).format(
-                open_enroll_link=HTML('<button class="enroll-btn btn-link">'),
-                close_enroll_link=HTML('</button>')
-            ),
-            title=Text(_('Welcome to {course_display_name}')).format(
-                course_display_name=course.display_name
+    if not user_access['is_anonymous'] and not user_access['is_staff'] and \
+            not user_access['is_enrolled']:
+        if not course.invitation_only:
+            CourseHomeMessages.register_info_message(
+                request,
+                Text(_(
+                    u'{open_enroll_link}Enroll now{close_enroll_link} to access the full course.'
+                )).format(
+                    open_enroll_link=HTML('<button class="enroll-btn btn-link">'),
+                    close_enroll_link=HTML('</button>')
+                ),
+                title=Text(_(u'Welcome to {course_display_name}')).format(
+                    course_display_name=course.display_name
+                )
             )
-        )
+        else:
+            CourseHomeMessages.register_info_message(
+                request,
+                Text(_('You must be enrolled in the course to see course content.')),
+            )
 
 
 def _register_course_goal_message(request, course):
@@ -146,7 +156,7 @@ def _register_course_goal_message(request, course):
     course_goal_options = get_course_goal_options()
     goal_choices_html = Text(_(
         'To start, set a course goal by selecting the option below that best describes '
-        'your learning plan. {goal_options_container}'
+        u'your learning plan. {goal_options_container}'
     )).format(
         goal_options_container=HTML('<div class="row goal-options-container">')
     )
@@ -156,11 +166,11 @@ def _register_course_goal_message(request, course):
         '{initial_tag}{choice}{closing_tag}'
     ).format(
         initial_tag=HTML(
-            '<div tabindex="0" aria-label="{aria_label_choice}" class="goal-option dismissible" '
+            u'<div tabindex="0" aria-label="{aria_label_choice}" class="goal-option dismissible" '
             'data-choice="{goal_key}">'
         ).format(
             goal_key=GOAL_KEY_CHOICES.unsure,
-            aria_label_choice=Text(_("Set goal to: {choice}")).format(
+            aria_label_choice=Text(_(u"Set goal to: {choice}")).format(
                 choice=course_goal_options[GOAL_KEY_CHOICES.unsure],
             ),
         ),
@@ -179,11 +189,11 @@ def _register_course_goal_message(request, course):
             '{initial_tag}{goal_text}{closing_tag}'
         ).format(
             initial_tag=HTML(
-                '<button tabindex="0" aria-label="{aria_label_choice}" class="goal-option btn-outline-primary" '
+                u'<button tabindex="0" aria-label="{aria_label_choice}" class="goal-option btn-outline-primary" '
                 'data-choice="{goal_key}">'
             ).format(
                 goal_key=goal_key,
-                aria_label_choice=Text(_("Set goal to: {goal_text}")).format(
+                aria_label_choice=Text(_(u"Set goal to: {goal_text}")).format(
                     goal_text=Text(_(goal_text))
                 )
             ),
@@ -197,7 +207,7 @@ def _register_course_goal_message(request, course):
             goal_choices_html=goal_choices_html,
             closing_tag=HTML('</div>')
         ),
-        title=Text(_('Welcome to {course_display_name}')).format(
+        title=Text(_(u'Welcome to {course_display_name}')).format(
             course_display_name=course.display_name
         )
     )


### PR DESCRIPTION
This commit updates the Info messages on the course page to display
more informative messages to the user. Specifically, messages for Public
and Invitation-only courses.

(cherry picked from commit c6f87d49f28782dd84d9c07aecfbce19814b0892)