### PR TITLE
SE-1496 (backport) Add flag to enable password change form in admin

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -319,6 +319,19 @@ FEATURES = {
 
     # Set this to true to make API docs available at /api-docs/.
     'ENABLE_API_DOCS': False,
+
+    # .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by default because enabling allows a method to bypass password policy.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2020-02-21
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
+    # .. toggle_status: supported
+    # .. toggle_warnings: None
+    'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 }
 
 ENABLE_JASMINE = False

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -208,8 +208,9 @@ if settings.FEATURES.get('AUTH_USE_CAS'):
     ]
 # The password pages in the admin tool are disabled so that all password
 # changes go through our user portal and follow complexity requirements.
+if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+    urlpatterns.append(url(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(url(r'^admin/password_change/$', handler404))
-urlpatterns.append(url(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(url(r'^admin/', include(admin.site.urls)))
 
 # enable entrance exams

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -1,6 +1,7 @@
 """ Django admin pages for student app """
 from config_models.admin import ConfigurationModelAdmin
 from django import forms
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.sites import NotRegistered
 from django.contrib.auth import get_user_model
@@ -277,13 +278,17 @@ class UserChangeForm(BaseUserChangeForm):
     Override the default UserChangeForm such that the password field
     does not contain a link to a 'change password' form.
     """
-    password = ReadOnlyPasswordHashField(
-        label=_("Password"),
-        help_text=_(
-            "Raw passwords are not stored, so there is no way to see this "
-            "user's password."
-        ),
-    )
+    def __init__(self, *args, **kwargs):
+        super(UserChangeForm, self).__init__(*args, **kwargs)
+
+        if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+            self.fields["password"] = ReadOnlyPasswordHashField(
+                label=_("Password"),
+                help_text=_(
+                    "Raw passwords are not stored, so there is no way to see this "
+                    "user's password."
+                ),
+            )
 
 
 class UserAdmin(BaseUserAdmin):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -406,6 +406,19 @@ FEATURES = {
 
     # Whether to display the account deletion section the account settings page
     'ENABLE_ACCOUNT_DELETION': True,
+
+    # .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by default because enabling allows a method to bypass password policy.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2020-02-21
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
+    # .. toggle_status: supported
+    # .. toggle_warnings: None
+    'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -793,11 +793,17 @@ if settings.FEATURES.get('CLASS_DASHBOARD'):
 
 if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     # Jasmine and admin
+
+    # The password pages in the admin tool are disabled so that all password
+    # changes go through our user portal and follow complexity requirements.
+    # The form to change another user's password is conditionally enabled
+    # for backwards compatibility.
+    if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+        urlpatterns += [
+            url(r'^admin/auth/user/\d+/password/$', handler404),
+        ]
     urlpatterns += [
-        # The password pages in the admin tool are disabled so that all password
-        # changes go through our user portal and follow complexity requirements.
         url(r'^admin/password_change/$', handler404),
-        url(r'^admin/auth/user/\d+/password/$', handler404),
         url(r'^admin/', include(admin.site.urls)),
     ]
 


### PR DESCRIPTION
This was previously disabled because changing another user's password is
both not usually recommended and bypasses password policy. Here, we add
a feature flag (`ENABLE_CHANGE_USER_PASSWORD_ADMIN`) to allow
re-enabling this password change form. This allows continued use of this
functionality by clients that require it.

(cherry picked from commit 39de23c666d1a6a6313129709ea71832ef12f71b)

---

See upstream PR https://github.com/edx/edx-platform/pull/21616 for test instructions. This is identical apart from being based on our ironwood branch instead of master.

**Reviewer**:

- [x] @clemente 