### PR TITLE
Fix grade reports invalid reference to six

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/store.py
+++ b/openedx/core/djangoapps/content/block_structure/store.py
@@ -221,9 +221,9 @@ class BlockStructureStore(object):
             return text_type(bs_model)
 
         else:
-            return u"v{version}.root.key.{root_usage_key}".format(
-                version=six.text_type(BlockStructureBlockData.VERSION),
-                root_usage_key=six.text_type(bs_model.data_usage_key),
+            return text_type("v{version}.root.key.{root_usage_key}").format(
+                version=text_type(BlockStructureBlockData.VERSION),
+                root_usage_key=text_type(bs_model.data_usage_key),
             )
 
     @staticmethod


### PR DESCRIPTION
This fixes an issue related to the relationship between https://github.com/open-craft/edx-platform/pull/205 and https://github.com/open-craft/edx-platform/pull/212. Because of a bad merge or something, the unicode handling in a particular code block was messed up (attempting to reference `six.text_type` when it was imported as `text_type`, returning string instead of text_type). 

**Sandbox URL**:


-    LMS: https://se-2481.sandbox.opencraft.hosting/
-    Studio: https://studio.se-2481.sandbox.opencraft.hosting/
- https://console.opencraft.com/instance/18700/edx-appserver/12336/

**Merge deadline**: ASAP - currently grade reports are broken for production instances

**Testing instructions**:

- ssh into the appserver and `sudo tail -f /edx/var/log/supervisor/lms_*`
- log in to the instance as an instructor
- run a grade report and verify that it completes successfully (viewing the tailed logs looking for tracebacks; there should be no tracebacks (original issue was a traceback relating to `six` global name not defined)).

**Reviewers**:

- [x] @itsjeyd 