### PR TITLE
[BB-1840] Ironwood SSO fixes

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -714,6 +714,7 @@ def user_details_force_sync(auth_entry, strategy, details, user=None, *args, **k
         field_mapping.update({
             'fullname': (user.profile, 'name'),
             'country': (user.profile, 'country'),
+            'gender': (user.profile, 'gender'),
         })
 
         # Remove username from list of fields for update

--- a/common/djangoapps/third_party_auth/strategy.py
+++ b/common/djangoapps/third_party_auth/strategy.py
@@ -29,9 +29,10 @@ class ConfigurationModelStrategy(DjangoStrategy):
             setting 'name' is configured via LTIProviderConfig.
         """
         if isinstance(backend, OAuthAuth):
-            provider_config = OAuth2ProviderConfig.current(backend.name)
-            if not provider_config.enabled_for_current_site:
+            providers = [p for p in Registry.displayed_for_login() if p.backend_name == backend.name]
+            if not providers:
                 raise Exception("Can't fetch setting of a disabled backend/provider.")
+            provider_config = providers[0]
             try:
                 return provider_config.get_setting(name)
             except KeyError:


### PR DESCRIPTION
This PR cherry-picks an existing ginkgo customization code drift required for SSO to work and also adds `gender` to the list of fields synced by the platform from SSO user data.

**Testing instructions**:
* Deploy this branch.
* Also deploy the changes to the `edx-oauth-client` from the corresponding PR branch.
* Create an account on the Drupal frontend, log in and navigate to the LMS.
* Verify that the user is logged into the LMS and all the user data is copied properly to the corresponding fields in the `User` model and the `UserProfile` model.