### PR TITLE
SE-2361 Fix help link styling

### DIFF
--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -81,7 +81,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         </a>
       </div>
     % endif
-    <div class="mobile-nav-item hidden-mobile nav-item">
+    <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
       <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
     </div>
     <%include file="user_dropdown.html"/>

--- a/themes/edx.org/lms/templates/header/navbar-authenticated.html
+++ b/themes/edx.org/lms/templates/header/navbar-authenticated.html
@@ -72,7 +72,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         </a>
       </div>
     % endif
-    <div class="mobile-nav-item hidden-mobile nav-item">
+    <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
       % if online_help_token == "instructor":
         <a class="help-link" href="${get_online_help_info(online_help_token)['doc_url']}" rel="noopener" target="_blank">${_("Help")}</a>
       % else:


### PR DESCRIPTION
Small fix to apply nav-tab class to Help link.

**Testing Instructions:**
1. Spin up new instance using this branch.
2. Verify that the 'Help' link in the header has the same styling as other tabs in the header (like courses, profile, discover new).

**Reviewers:**
- [ ] @lgp171188 

