### PR TITLE
WIP: Fix console error on account settings page

### DIFF
--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -70,7 +70,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
         extendedProfileFields,
         displayAccountDeletion,
         isSecondaryEmailFeatureEnabled,
-        ${ beta_language | n, dump_js_escaped_json },
+        ${ beta_language | n, dump_js_escaped_json }
     );
 </%static:require_module>
 


### PR DESCRIPTION
The user profile page and account settings page currently don't load and result in a console error. This fixes the issue on the account settings page.

**Testing Instructions:**
1. Spawn an instance using this branch (I have already created a [test instance](https://manage.opencraft.com/instance/20570/edx-appserver/13595/) for testing).
2. Register a user and login to lms.
3. Navigate to account setting page and verify it loads properly.
4. Navigate to profile page and verify it loads properly (To be fixed)

**Reviewers:**
- [ ] @lgp171188 