### PR TITLE
SE-3126 Fix issue caused by XSS fix in Video > Advanced > Transcript Languages

### DIFF
--- a/cms/static/js/views/video/translations_editor.js
+++ b/cms/static/js/views/video/translations_editor.js
@@ -133,7 +133,7 @@ function($, _, HtmlUtils, TranscriptUtils, AbstractEditor, ViewUtils, FileUpload
                     value: value,
                     url: self.model.get('urlRoot')
                 }));
-                HtmlUtils.append($html, dropdown.clone().val(newLang));
+                HtmlUtils.append($html, HtmlUtils.HTML(dropdown.clone().val(newLang)));
                 frag.appendChild($html[0]);
             });
 

--- a/cms/static/js/views/video/translations_editor.js
+++ b/cms/static/js/views/video/translations_editor.js
@@ -133,7 +133,7 @@ function($, _, HtmlUtils, TranscriptUtils, AbstractEditor, ViewUtils, FileUpload
                     value: value,
                     url: self.model.get('urlRoot')
                 }));
-                HtmlUtils.append($html, HtmlUtils.HTML(dropdown.clone().val(newLang)));
+                HtmlUtils.prepend($html, HtmlUtils.HTML(dropdown.clone().val(newLang)));
                 frag.appendChild($html[0]);
             });
 


### PR DESCRIPTION
Fixes issue introduced by https://github.com/open-craft/edx-platform/pull/237 code ported from upstream.

**Screenshots**

Before this fix:

![broken](https://user-images.githubusercontent.com/7556571/90329176-86c64d80-dfe1-11ea-8df3-de29c629f60c.png)

After this fix:

![fixed](https://user-images.githubusercontent.com/7556571/90377148-b72beb80-e0b6-11ea-8bab-7d5e6896f768.png)

**Sandbox**

* LMS: https://se3126-juniper.sandbox.opencraft.hosting/
* Studio: https://studio.se3126-juniper.sandbox.opencraft.hosting/

**Testing instructions**

1. In Studio, add a Video unit, and edit the unit.
1. Under Basic, locate "Default Timed Transcript" and click the "Import YouTube Transcript" button, then "Download Transcript for Editing", to download an `.srt` file.
1. Change to the Advanced tab, and scroll down to "Transcript languages".
1. Add a language (any language), and upload the `.srt` file downloaded in the previous step.
1. Ensure that you can save the unit.
1. Re-edit the unit and ensure the `.srt` file you uploaded remains saved with the video.

**Reviewer**

- [x] @pkulkark 