### PR TITLE
[SE-3199] Specifies default value for Microfrontend Url 

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1680,7 +1680,9 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
             'web_app_course_url': reverse(COURSE_HOME_VIEW_NAME, args=[course.id]),
             'on_courseware_page': True,
             'verified_upgrade_link': verified_upgrade_deadline_link(request.user, course=course),
-            'is_learning_mfe': request.META.get('HTTP_REFERER', '').startswith(settings.LEARNING_MICROFRONTEND_URL),
+            'is_learning_mfe': (settings.LEARNING_MICROFRONTEND_URL and
+                                    (request.META.get('HTTP_REFERER', '')
+                                        .startswith(settings.LEARNING_MICROFRONTEND_URL))),
         }
         return render_to_response('courseware/courseware-chromeless.html', context)
 


### PR DESCRIPTION
Fix is based on upstream's edx/edx-platform#24731 - Commit Hash c2033f9667b07b3eab3bde9410692a27ad615bd8

**JIRA tickets**: SE-3199

**Discussions**: https://chat.opencraft.com/opencraft/pl/9cwgciag63gquxm3jmh6868ekr

**Sandbox URL**: TBD - sandbox is being provisioned.

Sandbox Instance: https://manage.opencraft.com/instance/20950/

**Merge deadline**: ASAP

**Testing instructions**:

- Apply [Manual Instance Checklist](https://gitlab.com/opencraft/documentation/private/blob/master/checklists/manual_instance_test.md) on the Sandbox
- 1. Setup a Chromeless XBlock
  2. Attempt to access the XBlock through the Web

**Author notes and concerns**:

This fix doesn't have to be updated with the next Open edX release since it was merged into upstream 

**Reviewers**
- [ ] @eLRuLL 