### PR TITLE
[BB-2924] Added a constant to help modify countries list in drop-down

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3923,3 +3923,9 @@ GITHUB_REPO_ROOT = '/edx/var/edxapp/data'
 
 ##################### SUPPORT URL ############################
 SUPPORT_HOW_TO_UNENROLL_LINK = ''
+
+######################## Setting for django-countries ########################
+# django-countries provides an option to make the desired countries come up in
+# selection forms, if left empty countries will come up in ascending order as before
+# https://github.com/SmileyChris/django-countries#show-certain-countries-first
+COUNTRIES_FIRST = []

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -943,6 +943,12 @@ MAINTENANCE_BANNER_TEXT = ENV_TOKENS.get('MAINTENANCE_BANNER_TEXT', None)
 ########################## limiting dashboard courses ######################
 DASHBOARD_COURSE_LIMIT = ENV_TOKENS.get('DASHBOARD_COURSE_LIMIT', None)
 
+######################## Setting for django-countries ########################
+# django-countries provides an option to make the desired countries come up in
+# selection forms, if left empty countries will come up in ascending order as before
+# https://github.com/SmileyChris/django-countries#show-certain-countries-first
+COUNTRIES_FIRST = ENV_TOKENS.get('DJANGO_COUNTRIES_FIRST', [])
+
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded


### PR DESCRIPTION
This change introduces a way to help filling form, with the constant we
can specify the order of the countries that should come first. This will
reduce the chance of committing a mistake while filling form.

**JIRA tickets**: [BB-2924](https://tasks.opencraft.com/browse/BB-2924)

**Screenshots**: 
![image](https://user-images.githubusercontent.com/7670449/92711024-e2cc8980-f375-11ea-8658-f0dd11207f3f.png)


**Sandbox URL**: 
None

**Testing instructions**:

1. Pull the changes from this branch
2. Start `LMS` by `make dev.up.lms`
3. Drop in the `LMS` shell with `make dev.shell.lms`
4. Open the `lms.yml` file `vim /edx/etc/lms.yml` in `LMS` shell
5. Add 
```
DJANGO_COUNTRIES_FIRST: ['SA', 'BH', 'QA', 'KW', 'AE', 'OM', 'YE', 'JO', 'IQ', 'ER', 'IL', 'IR', 'PS', 'EG', 'SY', 'LB', 'DJ', 'CY', 'ET', 'SD', 'AM']
```
in `lms.yml` file
6. Restart the server `make lms-restart`
4. Go to the register page, and click on the countries and region
5. You will see the selected countries come up

**Author notes and concerns**:

1. If this parameter left empty it doesn't have any effect on the current flow, only when it is set to the appropriate value 
Eg:

```
COUNTRIES_FIRST = ['SA', 'BH', 'QA', 'KW', 'AE', 'OM', 'YE', 'JO', 'IQ', 'ER', 'IL', 'IR', 'PS', 'EG', 'SY', 'LB', 'DJ', 'CY', 'ET', 'SD', 'AM']
```
Then it will give priority to these countries

**Reviewers**
- [ ] @0x29a 

