### PR TITLE
[SE-3248] Add progress_video event and update tests

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -59,6 +59,16 @@ import '../helper.js'
             expect(state.videoEventsPlugin.emitPlayVideoEvent).toBeTruthy();
         });
 
+        it('can emit "progress_video" event', function() {
+            state.el.trigger('progress', [10]);
+            expect(Logger.log).toHaveBeenCalledWith('progress_video', {
+                id: 'id',
+                code: this.code,
+                percentage: 10,
+                duration: this.duration
+            });
+        });
+
         it('can emit "speed_change_video" event', function() {
             state.el.trigger('speedchange', ['2.0', '1.0']);
             expect(Logger.log).toHaveBeenCalledWith('speed_change_video', {
@@ -204,6 +214,7 @@ import '../helper.js'
                 skip: plugin.onSkip,
                 speedchange: plugin.onSpeedChange,
                 autoadvancechange: plugin.onAutoAdvanceChange,
+                progress: plugin.onProgress,
                 'language_menu:show': plugin.onShowLanguageMenu,
                 'language_menu:hide': plugin.onHideLanguageMenu,
                 'transcript:show': plugin.onShowTranscript,

--- a/common/lib/xmodule/xmodule/js/src/video/09_completion.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_completion.js
@@ -42,6 +42,7 @@
                 // the beginning of the video, except for lastSentTime, which refers to a
                 // timestamp in seconds since the Unix epoch.
                 this.lastSentTime = undefined;
+                this.lastProgressPercentage = undefined;
                 this.isComplete = false;
                 this.completionPercentage = this.state.config.completionPercentage;
                 this.startTime = this.state.config.startTime;
@@ -102,7 +103,7 @@
 
             /** Handler to call when a timeupdate event is triggered */
             handleTimeUpdate: function(currentTime) {
-                var duration;
+                var duration = this.state.videoPlayer.duration();
                 if (this.isComplete) {
                     return;
                 }
@@ -110,6 +111,12 @@
                     // Throttle attempts to submit in case of network issues
                     return;
                 }
+
+                // Duration may not be available at initialization time
+                if (duration) {
+                    this.computeProgress(currentTime, duration);
+                }
+
                 if (this.completeAfterTime === undefined) {
                     // Duration is not available at initialization time
                     duration = this.state.videoPlayer.duration();
@@ -124,6 +131,26 @@
                 if (currentTime > this.completeAfterTime) {
                     this.markCompletion(currentTime);
                 }
+            },
+
+            /** Compute current video progression and trigger event if needed */
+            computeProgress: function(currentTime, duration) {
+                // Compute current progress percentage
+                var currentProgressPercentage = currentTime * 100 / duration;
+                // Check if last "lastProgressPercentage" and current percentage are in the same decade
+                var sameDecade = Math.floor(
+                    currentProgressPercentage / 10) === Math.floor(this.lastProgressPercentage / 10);
+                // If no previous "lastProgressPercentage" or different decade, trigger the event
+                if (this.lastProgressPercentage === undefined || !sameDecade) {
+                    this.triggerProgress(Math.floor(currentProgressPercentage));
+                    // Save the lastProgressPercentage value
+                    this.lastProgressPercentage = currentProgressPercentage;
+                }
+            },
+
+            /** Trigger progress event */
+            triggerProgress: function(percentage) {
+                this.state.el.trigger('progress', [percentage]);
             },
 
             /** Submit completion to the LMS */

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -15,7 +15,8 @@
                 return new EventsPlugin(state, i18n, options);
             }
 
-            _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onEnded', 'onSeek',
+            // eslint-disable-next-line no-undef
+            _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onEnded', 'onSeek', 'onProgress',
             'onSpeedChange', 'onAutoAdvanceChange', 'onShowLanguageMenu', 'onHideLanguageMenu',
             'onSkip', 'onShowTranscript', 'onHideTranscript', 'onShowCaptions', 'onHideCaptions',
             'destroy');
@@ -46,6 +47,7 @@
                     skip: this.onSkip,
                     speedchange: this.onSpeedChange,
                     autoadvancechange: this.onAutoAdvanceChange,
+                    progress: this.onProgress,
                     'language_menu:show': this.onShowLanguageMenu,
                     'language_menu:hide': this.onHideLanguageMenu,
                     'transcript:show': this.onShowTranscript,
@@ -134,6 +136,10 @@
 
             onHideCaptions: function() {
                 this.log('edx.video.closed_captions.hidden', {current_time: this.getCurrentTime()});
+            },
+
+            onProgress: function(event, percentage) {
+                this.log('progress_video', {percentage: percentage});
             },
 
             getCurrentTime: function() {


### PR DESCRIPTION
This pull request is about adding new events to video player about watching progression.

Upstream pull request: edx/edx-platform#25038

**JIRA tickets**: [SE-3248](https://tasks.opencraft.com/browse/SE-3248)

**Sandbox URL**: 

- [LMS](https://pr25038.sandbox.opencraft.hosting/)
- [Studio](https://studio.pr25038.sandbox.opencraft.hosting/)

*Sandbox is being provisioned.*

**Testing instructions**:

1. Create a video unit
2. Enroll into the course
3. Open the web inspector (network panel)
4. Watch the video
5. Check that events are being fired every decades

**Reviewers**
- [x] @nizarmah 