### PR TITLE
[BB-3057] Use BytesIO as unicodecsv expects a bytestream, not unicode

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -26,7 +26,7 @@ from django.views.decorators.http import condition
 from django.views.generic.base import TemplateView
 from opaque_keys.edx.keys import CourseKey
 from path import Path as path
-from six import StringIO, text_type
+from six import BytesIO, StringIO, text_type
 
 import dashboard.git_import as git_import
 import track.views
@@ -77,7 +77,7 @@ class SysadminDashboardView(TemplateView):
         data should be iterable and is used to stream object over http
         """
 
-        csv_file = StringIO()
+        csv_file = BytesIO()
         writer = csv.writer(csv_file, dialect='excel', quotechar='"',
                             quoting=csv.QUOTE_ALL)
 


### PR DESCRIPTION
This fixes the error thrown when trying to download the list of all
users, staff and instructors from the Sysadmin dashboard

Reference: [unicodecsv README file](https://github.com/jdunck/python-unicodecsv/blob/master/README.rst)

**Testing instructions**:
* In the Juniper devstack, enable the `Sysadmin dashboard` by setting the `ENABLE_SYSADMIN_DASHBOARD` feature flag to `true` in `/edx/etc/lms.yml` and restart the LMS.
* Log in to the LMS as a user with superuser permissions.
* Navigate to the Sysadmin dashboard by clicking on the link in the top nav bar.
* In the `Users` section, try to download a list of all the users in CSV file format. An exception complaining `TypeError: string argument expected, got 'bytes'` will be thrown.
* In the `Staffing and enrollment` section, try downloading the staff and instructor list in a CSV file format. A similar exception will be thrown.
* In a sandbox/production Juniper environment, a 500 internal server error response page will be shown and the same exception will be logged in the LMS logs.
* Checkout the source branch of this PR.
* Repeat the previous two steps and verify that the files can be downloaded and no errors are thrown.
* Also verify that the downloaded files contain the expected data. 