### PR TITLE
[SE-3401] Sorts Modules and Descriptors Before Writing Them

### DIFF
--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -74,7 +74,7 @@ XBLOCK_CLASSES = [
 
 def write_module_styles(output_root):
     """Write all registered XModule css, sass, and scss files to output root."""
-    return _write_styles('.xmodule_display', output_root, sorted(_list_modules(), key=str), 'get_preview_view_css')
+    return _write_styles('.xmodule_display', output_root, _list_modules(), 'get_preview_view_css')
 
 
 def write_module_js(output_root):
@@ -94,20 +94,26 @@ def write_descriptor_js(output_root):
 
 def _list_descriptors():
     """Return a list of all registered XModuleDescriptor classes."""
-    return [
-        desc for desc in [
-            desc for (_, desc) in XModuleDescriptor.load_classes()
-        ]
-    ] + XBLOCK_CLASSES
+    return sorted(
+        [
+            desc for desc in [
+                desc for (_, desc) in XModuleDescriptor.load_classes()
+            ]
+        ] + XBLOCK_CLASSES,
+        key=str
+    )
 
 
 def _list_modules():
     """Return a list of all registered XModule classes."""
-    return [
-        desc.module_class for desc in [
-            desc for (_, desc) in XModuleDescriptor.load_classes()
-        ]
-    ] + XBLOCK_CLASSES
+    return sorted(
+        [
+            desc.module_class for desc in [
+                desc for (_, desc) in XModuleDescriptor.load_classes()
+            ]
+        ] + XBLOCK_CLASSES,
+        key=str
+    )
 
 
 def _ensure_dir(directory):


### PR DESCRIPTION
This sorts the modules and descriptors before writing them. This helps guarantee that a similar issue will not happen in the future, or that if any addition is added later on, they wouldn't have to worry about adding the `sorted` in the `_write_...` method.

**JIRA tickets**: SE-3401, SE-3149

**Sandbox URL**: 
- **LMS**: https://pr264.sandbox.stage.opencraft.hosting/
- **Studio**: https://studio.pr264.sandbox.stage.opencraft.hosting/

**Testing instructions**:

1. Spawn a new edX juniper instance and check the css files generated in `/edx/var/edxapp/staticfiles/css` and `/edx/var/edxapp/staticfiles/js`.
1. Run `paver update_assets` command and recheck that no new css files are generated in `/edx/var/edxapp/staticfiles/css` and `/edx/var/edxapp/staticfiles/js`.
1. Spawn multiple instances and add to load-balancer. Verify that the assets are getting loaded correctly.

**Reviewers**
- [ ] @pkulkark 
- [ ] @Kelketek 
