### PR TITLE
[SE-3248] Backport video player events to Autodesk branch

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/completion_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/completion_spec.js
@@ -76,22 +76,22 @@
             }).then(function() {
                 spyOn(state.completionHandler, 'computeProgress').and.callThrough();
                 spyOn(state.completionHandler, 'triggerProgress').and.callThrough();
-                // Less than 10 percents
+                // 4 percents should be equivalent to 0
+                time = 4 * duration / 100;
+                state.el.trigger('timeupdate', time);
+                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
+                expect(state.completionHandler.triggerProgress).toHaveBeenCalled();
+                state.completionHandler.computeProgress.calls.reset();
+                state.completionHandler.triggerProgress.calls.reset();
+                // 8 percents should be equivalent to 5
+                time = 8 * duration / 100;
+                state.el.trigger('timeupdate', time);
+                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
+                expect(state.completionHandler.triggerProgress).toHaveBeenCalled();
+                state.completionHandler.computeProgress.calls.reset();
+                state.completionHandler.triggerProgress.calls.reset();
+                // Another timeupdate in the same 5-range should not trigger "triggerProgress"
                 time = 9 * duration / 100;
-                state.el.trigger('timeupdate', time);
-                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
-                expect(state.completionHandler.triggerProgress).toHaveBeenCalled();
-                state.completionHandler.computeProgress.calls.reset();
-                state.completionHandler.triggerProgress.calls.reset();
-                // Between 10 and 20 percents
-                time = 15 * duration / 100;
-                state.el.trigger('timeupdate', time);
-                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
-                expect(state.completionHandler.triggerProgress).toHaveBeenCalled();
-                state.completionHandler.computeProgress.calls.reset();
-                state.completionHandler.triggerProgress.calls.reset();
-                // Another timeupdate in the same decade should not trigger "triggerProgress"
-                time = 18 * duration / 100;
                 state.el.trigger('timeupdate', time);
                 expect(state.completionHandler.computeProgress).toHaveBeenCalled();
                 expect(state.completionHandler.triggerProgress).not.toHaveBeenCalled();

--- a/common/lib/xmodule/xmodule/js/src/video/09_completion.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_completion.js
@@ -136,12 +136,11 @@
             /** Compute current video progression and trigger event if needed */
             computeProgress: function(currentTime, duration) {
                 // Compute current progress percentage
-                var currentProgressPercentage = currentTime * 100 / duration;
-                // Check if last "lastProgressPercentage" and current percentage are in the same decade
-                var sameDecade = Math.floor(
-                    currentProgressPercentage / 10) === Math.floor(this.lastProgressPercentage / 10);
-                // If no previous "lastProgressPercentage" or different decade, trigger the event
-                if (this.lastProgressPercentage === undefined || !sameDecade) {
+                var currentProgressPercentage = Math.floor(currentTime * 100 / duration / 5) * 5;
+                // Check if last "lastProgressPercentage" and current percentage are in the same 5-range
+                var newRange = currentProgressPercentage > this.lastProgressPercentage;
+                // If no previous "lastProgressPercentage" or different 5-range, trigger the event
+                if (this.lastProgressPercentage === undefined || newRange) {
                     this.triggerProgress(Math.floor(currentProgressPercentage));
                     // Save the lastProgressPercentage value
                     this.lastProgressPercentage = currentProgressPercentage;


### PR DESCRIPTION
This pull request is about back porting the change to video player events (every 5 percents instead of 10) to the Autodesk branch. (open-craft/edx-platform#266)

**JIRA tickets**: [SE-3248](https://tasks.opencraft.com/browse/SE-3248)

**Reviewers**
- [x] @nizarmah 