### PR TITLE
[SE-3401] Sorts XModules and XBlocks JS Bundles to Make Webpack Hashes Consistent

### DIFF
--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -78,7 +78,7 @@ XBLOCK_CLASSES = [
 
 def write_module_styles(output_root):
     """Write all registered XModule css, sass, and scss files to output root."""
-    return _write_styles('.xmodule_display', output_root, sorted(_list_modules(), key=str), 'get_preview_view_css')
+    return _write_styles('.xmodule_display', output_root, _list_modules(), 'get_preview_view_css')
 
 
 def write_module_js(output_root):
@@ -98,20 +98,26 @@ def write_descriptor_js(output_root):
 
 def _list_descriptors():
     """Return a list of all registered XModuleDescriptor classes."""
-    return [
-        desc for desc in [
-            desc for (_, desc) in XModuleDescriptor.load_classes()
-        ]
-    ] + XBLOCK_CLASSES
+    return sorted(
+        [
+            desc for desc in [
+                desc for (_, desc) in XModuleDescriptor.load_classes()
+            ]
+        ] + XBLOCK_CLASSES,
+        key=str
+    )
 
 
 def _list_modules():
     """Return a list of all registered XModule classes."""
-    return [
-        desc.module_class for desc in [
-            desc for (_, desc) in XModuleDescriptor.load_classes()
-        ]
-    ] + XBLOCK_CLASSES
+    return sorted(
+        [
+            desc.module_class for desc in [
+                desc for (_, desc) in XModuleDescriptor.load_classes()
+            ]
+        ] + XBLOCK_CLASSES,
+        key=str
+    )
 
 
 def _ensure_dir(directory):
@@ -273,7 +279,13 @@ def write_webpack(output_file, module_files, descriptor_files):
         outfile.write(
             textwrap.dedent(u"""\
                 module.exports = {config_json};
-            """).format(config_json=json.dumps(config, indent=4))
+            """).format(
+                config_json=json.dumps(
+                    config,
+                    indent=4,
+                    sort_keys=True
+                )
+            )
         )
 
 


### PR DESCRIPTION
There is a small bug that started happening in Juniper related to webpack's cached files, where the hashes were not consistent on different machines and would change on every assets update. Accordingly, this caused 404 errors with multiple instances and load balancers, which made the Studio and LMS unusable.

Some examples of the Studio and LMS being unusable:
- Studio would load but no courses would be populated
- LMS would load but no units would load in
- Any functionality relying on JavaScript became unusable (such as XBlocks and XModules)

**JIRA tickets**: SE-3401

**Sandbox URL**: 
- **LMS**: https://pr264.sandbox.stage.opencraft.hosting/
- **Studio**: https://studio.pr264.sandbox.stage.opencraft.hosting/

**Testing instructions**:

1. Spawn multiple instances and add to load-balancer. 
1. Open the Developer console for the LMS and Studio and verify there are no 404 messages for `commons.js`.
1. SSH into the different instances and verify that the output for `ls /edx/var/edxapp/staticfiles/studio/bundles/ | grep -i commons` is the same among the different instances.
1. Compare the files in `/edx/var/edxapp/staticfiles/studio/bundles/` and `/edx/var/edxapp/staticfiles/bundles/` between both App Servers and make sure they have the same filename (including hashes).
1. Compare the files in `/edx/var/edxapp/staticfiles/studio/bundles/` and `/edx/var/edxapp/staticfiles/bundles/` between app servers with old instances (without the fix) and new ones (with the fix) and make sure everything is similar/acting normal. 
1. Verify that the assets are getting loaded correctly.

**Reviewers**
- [ ] @pkulkark 
- [ ] @gabor-boros 