### PR TITLE
Cherry pick fix for Studio file upload issues

### DIFF
--- a/cms/static/js/views/uploads.js
+++ b/cms/static/js/views/uploads.js
@@ -33,7 +33,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'edx-ui
             renderContents: function() {
                 var isValid = this.model.isValid(),
                     selectedFile = this.model.get('selectedFile'),
-                    oldInput = this.$('input[type=file]').get(0);
+                    oldInput = this.$('input[type=file]');
                 BaseModal.prototype.renderContents.call(this);
                 // Ideally, we'd like to tell the browser to pre-populate the
                 // <input type="file"> with the selectedFile if we have one -- but
@@ -44,7 +44,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/modals/base_modal', 'edx-ui
                 // a blank input to prompt the user to upload a different (valid) file.
                 if (selectedFile && isValid) {
                     $(oldInput).removeClass('error');
-                    this.$('input[type=file]').replaceWith(HtmlUtils.ensureHtml(oldInput).toString());
+                    this.$('input[type=file]').replaceWith(HtmlUtils.HTML(oldInput).toString());
                     this.$('.action-upload').removeClass('disabled');
                 } else {
                     this.$('.action-upload').addClass('disabled');


### PR DESCRIPTION
This cherry picks a fix from `open-release/juniper.master` to fix file upload issues on the studio.

When selecting a file for uploading to the Course Card image, or the Certificate Signatory Editor view, instead of showing the file it shows "[object HTMLInputElement]", and the file upload fails. This cherry picked fix from upstream fixes the issue.

**JIRA tickets**: Fixes SE-3472.

**Screenshots**:
Without this fix after using the file selection dialog: 
![Screenshot_2020-10-07 Schedule Details Settings Demonstration Course Studio](https://user-images.githubusercontent.com/270966/95330657-ba915700-085d-11eb-931d-d20589e3771c.png)

**Testing instructions**:

1. Attempt to change Course Card Image in the studio to test the file upload dialog
2. Ensure that it correctly shows the path and the upload works

**Reviewers**
- [ ] (@swalladge )