### PR TITLE
[SE-3437] Sets default X-Frame-Options for login and registration forms to environment setting

### DIFF
--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -17,13 +17,13 @@ from third_party_auth.provider import Registry
 def xframe_allow_whitelisted(view_func):
     """
     Modifies a view function so that its response has the X-Frame-Options HTTP header
-    set to 'DENY' if the request HTTP referrer is not from a whitelisted hostname.
+    set to `settings.X_FRAME_OPTIONS` if the request HTTP referrer is not from a whitelisted hostname.
     """
 
     def wrapped_view(request, *args, **kwargs):
         """ Modify the response with the correct X-Frame-Options. """
         resp = view_func(request, *args, **kwargs)
-        x_frame_option = 'DENY'
+        x_frame_option = settings.X_FRAME_OPTIONS
         if settings.FEATURES['ENABLE_THIRD_PARTY_AUTH']:
             referer = request.META.get('HTTP_REFERER')
             if referer is not None:


### PR DESCRIPTION
Update the `X-Frame-Options` default value for login and registration forms to the existing `EDXAPP_X_FRAME_OPTIONS` environment settings to match the default setting across the whole platform. 

**JIRA tickets**: SE-3437, [OSPR-5053](https://openedx.atlassian.net/browse/OSPR-5053)

**Upstream PR**: https://github.com/edx/edx-platform/pull/25338

**Sandbox URL**:
- **LMS**: https://pr25338.sandbox.opencraft.hosting/
- **Studio**: https://studio.pr25338.sandbox.opencraft.hosting/

**Testing instructions**:

1. Send a request to the Login page with a specific `Referer: customhostname.com` header
2. Verify that the response header contains `X-Frame-Options: ALLOW`

**Reviewers**
- [ ] @toxinu 
- [ ] @gabor-boros 

**Settings**
```yaml
EDXAPP_LMS_ENV_EXTRA:
  X_FRAME_ALLOW_WHITELISTED_REFERERS: [
    'customhostname.com'
  ]
```