### PR TITLE
[SE-3437] Changes Default Value of X_FRAME_OPTION for Login and Registration Form

### DIFF
--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -17,13 +17,13 @@ from third_party_auth.provider import Registry
 def xframe_allow_whitelisted(view_func):
     """
     Modifies a view function so that its response has the X-Frame-Options HTTP header
-    set to 'DENY' if the request HTTP referrer is not from a whitelisted hostname.
+    set to 'ALLOW' if the request HTTP referrer is not from a whitelisted hostname.
     """
 
     def wrapped_view(request, *args, **kwargs):
         """ Modify the response with the correct X-Frame-Options. """
         resp = view_func(request, *args, **kwargs)
-        x_frame_option = 'DENY'
+        x_frame_option = 'ALLOW'
         if settings.FEATURES['ENABLE_THIRD_PARTY_AUTH']:
             referer = request.META.get('HTTP_REFERER')
             if referer is not None:


### PR DESCRIPTION
This enables `X-Frame-Options` for the Login and Registration Forms on Autodesk instances. This is because using LTI third party auth is not an option.

This change targets the `x_frame_option` because it hasn't changed since 5 years (check git blame).

**JIRA tickets**: SE-3437

**Author notes and concerns**:

1. This is a temporary fix that needs to be replaced with a better solution later on.

**Reviewers**
- [ ] @toxinu 
- [ ] @gabor-boros 
