### PR TITLE
[SE-3381] Allows adding new tinymce plugins through platform configuration

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1000,6 +1000,9 @@ COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 ##### EMBARGO #####
 EMBARGO_SITE_REDIRECT_URL = None
 
+##### custom vendor plugin variables #####
+ADDITIONAL_NODE_ENV_VARS = {}
+
 ############################### PIPELINE #######################################
 
 PIPELINE = {

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1001,7 +1001,7 @@ COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 EMBARGO_SITE_REDIRECT_URL = None
 
 ##### custom vendor plugin variables #####
-ADDITIONAL_NODE_ENV_VARS = {}
+JS_ENV_EXTRA_CONFIG = {}
 
 ############################### PIPELINE #######################################
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1001,6 +1001,8 @@ COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 EMBARGO_SITE_REDIRECT_URL = None
 
 ##### custom vendor plugin variables #####
+# JavaScript code can access this data using `process.env.JS_ENV_EXTRA_CONFIG`
+# One of the current use cases for this is enabling custom TinyMCE plugins
 JS_ENV_EXTRA_CONFIG = {}
 
 ############################### PIPELINE #######################################

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -175,7 +175,7 @@
         };
 
         if (process.env.ADDITIONAL_NODE_ENV_VARS) {
-          var tinyMceAdditionalPlugins = JSON.parse(process.env.ADDITIONAL_NODE_ENV_VARS).ADDITIONAL_TINYMCE_PLUGINS;
+          var tinyMceAdditionalPlugins = JSON.parse(process.env.ADDITIONAL_NODE_ENV_VARS).TINYMCE_ADDITIONAL_PLUGINS;
           // check if we have any additional plugins passed
           if (tinyMceAdditionalPlugins) {
             // go over each plugin

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -179,26 +179,30 @@
           // check if we have any additional plugins passed
           if (tinyMceAdditionalPlugins) {
             // go over each plugin
-            for (var plugin_name in tinyMceAdditionalPlugins) {
+            tinyMceAdditionalPlugins.forEach(function (tinyMcePlugin) {
               // check if plugins is not empty (ie there are existing plugins)
               if (tinyMceConfig.plugins.trim()) {
                 tinyMceConfig.plugins += ', ';
               }
 
               // add the plugin to the list of plugins
-              tinyMceConfig.plugins += plugin_name;
+              tinyMceConfig.plugins += tinyMcePlugin.name;
 
-              // check if toolbar is not empty (ie there are already items in the toolbar)
-              if (tinyMceConfig.toolbar.trim()) {
-                tinyMceConfig.toolbar += ' | ';
-              }
-              tinyMceConfig.toolbar += plugin_name;
+              // check if the plugin should be included in the toolbar
+              if (tinyMcePlugin.toolbar) {
+                // check if toolbar is not empty (ie there are already items in the toolbar)
+                if (tinyMceConfig.toolbar.trim()) {
+                  tinyMceConfig.toolbar += ' | ';
+                }
 
-              // add the additional context for each plugin (if there is any)
-              if (tinyMceAdditionalPlugins[plugin_name]) {
-                tinyMceConfig[plugin_name] = tinyMceAdditionalPlugins[plugin_name];
+                tinyMceConfig.toolbar += tinyMcePlugin.name;
               }
-            }
+
+              // add the additional settings for each plugin (if there is any)
+              if (tinyMcePlugin.extra_settings) {
+                tinyMceConfig[tinyMcePlugin.name] = tinyMcePlugin.extra_settings;
+              }
+            });
           }
         }
 

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -175,7 +175,7 @@
         };
 
         if (typeof process != "undefined" && process.env.JS_ENV_EXTRA_CONFIG) {
-          var tinyMceAdditionalPlugins = JSON.parse(process.env.JS_ENV_EXTRA_CONFIG).TINYMCE_ADDITIONAL_PLUGINS;
+          var tinyMceAdditionalPlugins = process.env.JS_ENV_EXTRA_CONFIG.TINYMCE_ADDITIONAL_PLUGINS;
           // check if we have any additional plugins passed
           if (tinyMceAdditionalPlugins) {
             // go over each plugin

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -174,8 +174,8 @@
           browser_spellcheck: true
         };
 
-        if (process.env.ADDITIONAL_NODE_ENV_VARS) {
-          var tinyMceAdditionalPlugins = JSON.parse(process.env.ADDITIONAL_NODE_ENV_VARS).TINYMCE_ADDITIONAL_PLUGINS;
+        if (process.env.JS_ENV_EXTRA_CONFIG) {
+          var tinyMceAdditionalPlugins = JSON.parse(process.env.JS_ENV_EXTRA_CONFIG).TINYMCE_ADDITIONAL_PLUGINS;
           // check if we have any additional plugins passed
           if (tinyMceAdditionalPlugins) {
             // go over each plugin

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -95,7 +95,8 @@
         tinyMCE incorrectly decides that the suffix should be "", which means it fails to load files.
          */
         tinyMCE.suffix = ".min";
-        this.tiny_mce_textarea = $(".tiny-mce", this.element).tinymce({
+
+        var tinyMceConfig = {
           script_url: baseUrl + "js/vendor/tinymce/js/tinymce/tinymce.full.min.js",
           font_formats: _getFonts(),
           theme: "modern",
@@ -171,7 +172,37 @@
            */
           init_instance_callback: this.initInstanceCallback,
           browser_spellcheck: true
-        });
+        };
+
+        if (process.env.ADDITIONAL_NODE_ENV_VARS) {
+          var tinyMceAdditionalPlugins = JSON.parse(process.env.ADDITIONAL_NODE_ENV_VARS).ADDITIONAL_TINYMCE_PLUGINS;
+          // check if we have any additional plugins passed
+          if (tinyMceAdditionalPlugins) {
+            // go over each plugin
+            for (var plugin_name in tinyMceAdditionalPlugins) {
+              // check if plugins is not empty (ie there are existing plugins)
+              if (!tinyMceConfig.plugins.trim()) {
+                tinyMceConfig.plugins += ', ';
+              }
+
+              // add the plugin to the list of plugins
+              tinyMceConfig.plugins += plugin_name;
+
+              // check if toolbar is not empty (ie there are already items in the toolbar)
+              if (!tinyMceConfig.toolbar.trim()) {
+                tinyMceConfig.toolbar += ' | ';
+              }
+              tinyMceConfig.toolbar += plugin_name;
+
+              // add the additional context for each plugin (if there is any)
+              if (tinyMceAdditionalPlugins[plugin_name]) {
+                tinyMceConfig[plugin_name] = tinyMceAdditionalPlugins[plugin_name];
+              }
+            }
+          }
+        }
+
+        this.tiny_mce_textarea = $(".tiny-mce", this.element).tinymce(tinyMceConfig);
         tinymce.addI18n('en', {
 
           /*

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -181,7 +181,7 @@
             // go over each plugin
             for (var plugin_name in tinyMceAdditionalPlugins) {
               // check if plugins is not empty (ie there are existing plugins)
-              if (!tinyMceConfig.plugins.trim()) {
+              if (tinyMceConfig.plugins.trim()) {
                 tinyMceConfig.plugins += ', ';
               }
 
@@ -189,7 +189,7 @@
               tinyMceConfig.plugins += plugin_name;
 
               // check if toolbar is not empty (ie there are already items in the toolbar)
-              if (!tinyMceConfig.toolbar.trim()) {
+              if (tinyMceConfig.toolbar.trim()) {
                 tinyMceConfig.toolbar += ' | ';
               }
               tinyMceConfig.toolbar += plugin_name;

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -174,7 +174,7 @@
           browser_spellcheck: true
         };
 
-        if (process.env.JS_ENV_EXTRA_CONFIG) {
+        if (typeof process != "undefined" && process.env.JS_ENV_EXTRA_CONFIG) {
           var tinyMceAdditionalPlugins = JSON.parse(process.env.JS_ENV_EXTRA_CONFIG).TINYMCE_ADDITIONAL_PLUGINS;
           // check if we have any additional plugins passed
           if (tinyMceAdditionalPlugins) {

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -769,10 +769,7 @@ def webpack(options):
     static_root_cms = Env.get_django_setting("STATIC_ROOT", "cms", settings=settings)
     config_path = Env.get_django_setting("WEBPACK_CONFIG_PATH", "lms", settings=settings)
     js_env_extra_config_setting = Env.get_django_setting("JS_ENV_EXTRA_CONFIG", "cms", settings=settings)
-    # the reason behind the following null check is because when testing, devstack settings might be null
-    if js_env_extra_config_setting is None:
-        js_env_extra_config_setting = str({})
-    js_env_extra_config = json.dumps(js_env_extra_config_setting.replace("'", '"'))
+    js_env_extra_config = json.dumps(js_env_extra_config_setting or {})
     environment = (
         u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} '
         u'JS_ENV_EXTRA_CONFIG={js_env_extra_config}'
@@ -780,7 +777,7 @@ def webpack(options):
         node_env="development" if config_path == 'webpack.dev.config.js' else "production",
         static_root_lms=static_root_lms,
         static_root_cms=static_root_cms,
-        js_env_extra_config=js_env_extra_config
+        js_env_extra_config=js_env_extra_config,
     )
     sh(
         cmd(

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -5,6 +5,7 @@ Asset compilation and collection.
 
 import argparse
 import glob
+import json
 import os
 import traceback
 from datetime import datetime
@@ -767,10 +768,14 @@ def webpack(options):
     static_root_lms = Env.get_django_setting("STATIC_ROOT", "lms", settings=settings)
     static_root_cms = Env.get_django_setting("STATIC_ROOT", "cms", settings=settings)
     config_path = Env.get_django_setting("WEBPACK_CONFIG_PATH", "lms", settings=settings)
-    environment = u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms}'.format(
+    additional_node_env_vars = json.dumps(Env.get_django_settings("ADDITIONAL_NODE_ENV_VARS", "cms",
+                                                                  settings=settings).replace("'", '"'))
+    environment = 'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} \
+    ADDITIONAL_NODE_ENV_VARS={additional_node_env_vars}'.format(
         node_env="development" if config_path == 'webpack.dev.config.js' else "production",
         static_root_lms=static_root_lms,
-        static_root_cms=static_root_cms
+        static_root_cms=static_root_cms,
+        additional_node_env_vars=additional_node_env_vars
     )
     sh(
         cmd(

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -768,13 +768,10 @@ def webpack(options):
     static_root_lms = Env.get_django_setting("STATIC_ROOT", "lms", settings=settings)
     static_root_cms = Env.get_django_setting("STATIC_ROOT", "cms", settings=settings)
     config_path = Env.get_django_setting("WEBPACK_CONFIG_PATH", "lms", settings=settings)
+    js_env_extra_config_setting = Env.get_django_setting("JS_ENV_EXTRA_CONFIG", "cms", settings=settings)
     js_env_extra_config_sorted_json = json.dumps(
         json.loads(
-            Env.get_django_setting(  # pylint: disable=no-member
-                "JS_ENV_EXTRA_CONFIG",
-                "cms",
-                settings=settings
-            ).replace("'", '"')
+            js_env_extra_config_setting.replace("'", '"')
         ),
         sort_keys=True,
     )

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -772,13 +772,7 @@ def webpack(options):
     # the reason behind the following null check is because when testing, devstack settings might be null
     if js_env_extra_config_setting is None:
         js_env_extra_config_setting = str({})
-    js_env_extra_config_sorted_json = json.dumps(
-        json.loads(
-            js_env_extra_config_setting.replace("'", '"')
-        ),
-        sort_keys=True,
-    )
-    js_env_extra_config = json.dumps(js_env_extra_config_sorted_json)
+    js_env_extra_config = json.dumps(js_env_extra_config_setting.replace("'", '"'))
     environment = (
         u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} '
         u'JS_ENV_EXTRA_CONFIG={js_env_extra_config}'

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -768,23 +768,23 @@ def webpack(options):
     static_root_lms = Env.get_django_setting("STATIC_ROOT", "lms", settings=settings)
     static_root_cms = Env.get_django_setting("STATIC_ROOT", "cms", settings=settings)
     config_path = Env.get_django_setting("WEBPACK_CONFIG_PATH", "lms", settings=settings)
-    additional_node_env_vars_sorted_json = json.dumps(
+    js_env_extra_config_sorted_json = json.dumps(
         json.loads(
             Env.get_django_setting(  # pylint: disable=no-member
-                "ADDITIONAL_NODE_ENV_VARS",
+                "JS_ENV_EXTRA_CONFIG",
                 "cms",
                 settings=settings
             ).replace("'", '"')
         ),
         sort_keys=True,
     )
-    additional_node_env_vars = json.dumps(additional_node_env_vars_sorted_json)
+    js_env_extra_config = json.dumps(js_env_extra_config_sorted_json)
     environment = u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} \
-    ADDITIONAL_NODE_ENV_VARS={additional_node_env_vars}'.format(
+    JS_ENV_EXTRA_CONFIG={js_env_extra_config}'.format(
         node_env="development" if config_path == 'webpack.dev.config.js' else "production",
         static_root_lms=static_root_lms,
         static_root_cms=static_root_cms,
-        additional_node_env_vars=additional_node_env_vars
+        js_env_extra_config=js_env_extra_config
     )
     sh(
         cmd(

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -7,6 +7,7 @@ import argparse
 import glob
 import json
 import os
+import re
 import traceback
 from datetime import datetime
 from functools import wraps
@@ -764,12 +765,23 @@ def webpack(options):
     """
     Run a Webpack build.
     """
+    def json_format_setting(setting_value):
+        """
+        Replaces capitalized booleans with booleans that
+        are compatible with parsed JSON in javascript.
+        """
+        # replace python bools with json valid bools
+        setting_value = re.sub(r'(\:\s?)True', r'\1true', setting_value)
+        setting_value = re.sub(r'(\:\s?)False', r'\1false', setting_value)
+
+        return setting_value
+
     settings = getattr(options, 'settings', Env.DEVSTACK_SETTINGS)
     static_root_lms = Env.get_django_setting("STATIC_ROOT", "lms", settings=settings)
     static_root_cms = Env.get_django_setting("STATIC_ROOT", "cms", settings=settings)
     config_path = Env.get_django_setting("WEBPACK_CONFIG_PATH", "lms", settings=settings)
     js_env_extra_config_setting = Env.get_django_setting("JS_ENV_EXTRA_CONFIG", "cms", settings=settings)
-    js_env_extra_config = json.dumps(js_env_extra_config_setting or {})
+    js_env_extra_config = json.dumps(json_format_setting(js_env_extra_config_setting) or {})
     environment = (
         u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} '
         u'JS_ENV_EXTRA_CONFIG={js_env_extra_config}'

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -769,6 +769,9 @@ def webpack(options):
     static_root_cms = Env.get_django_setting("STATIC_ROOT", "cms", settings=settings)
     config_path = Env.get_django_setting("WEBPACK_CONFIG_PATH", "lms", settings=settings)
     js_env_extra_config_setting = Env.get_django_setting("JS_ENV_EXTRA_CONFIG", "cms", settings=settings)
+    # the reason behind the following null check is because when testing, devstack settings might be null
+    if js_env_extra_config_setting is None:
+        js_env_extra_config_setting = str({})
     js_env_extra_config_sorted_json = json.dumps(
         json.loads(
             js_env_extra_config_setting.replace("'", '"')

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -768,8 +768,17 @@ def webpack(options):
     static_root_lms = Env.get_django_setting("STATIC_ROOT", "lms", settings=settings)
     static_root_cms = Env.get_django_setting("STATIC_ROOT", "cms", settings=settings)
     config_path = Env.get_django_setting("WEBPACK_CONFIG_PATH", "lms", settings=settings)
-    additional_node_env_vars = json.dumps(Env.get_django_settings("ADDITIONAL_NODE_ENV_VARS", "cms",
-                                                                  settings=settings).replace("'", '"'))
+    additional_node_env_vars_sorted_json = json.dumps(
+        json.loads(
+            Env.get_django_settings(  # pylint: disable=no-member
+                "ADDITIONAL_NODE_ENV_VARS",
+                "cms",
+                settings=settings
+            ).replace("'", '"')
+        ),
+        sort_keys=True,
+    )
+    additional_node_env_vars = json.dumps(additional_node_env_vars_sorted_json)
     environment = 'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} \
     ADDITIONAL_NODE_ENV_VARS={additional_node_env_vars}'.format(
         node_env="development" if config_path == 'webpack.dev.config.js' else "production",

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -770,9 +770,10 @@ def webpack(options):
         Replaces capitalized booleans with booleans that
         are compatible with parsed JSON in javascript.
         """
-        # replace python bools with json valid bools
-        setting_value = re.sub(r'(\:\s?)True', r'\1true', setting_value)
-        setting_value = re.sub(r'(\:\s?)False', r'\1false', setting_value)
+        if isinstance(setting_value, str):
+            # replace python bools with json valid bools
+            setting_value = re.sub(r'(\:\s?)True', r'\1true', setting_value)
+            setting_value = re.sub(r'(\:\s?)False', r'\1false', setting_value)
 
         return setting_value
 

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -770,7 +770,7 @@ def webpack(options):
     config_path = Env.get_django_setting("WEBPACK_CONFIG_PATH", "lms", settings=settings)
     additional_node_env_vars_sorted_json = json.dumps(
         json.loads(
-            Env.get_django_settings(  # pylint: disable=no-member
+            Env.get_django_setting(  # pylint: disable=no-member
                 "ADDITIONAL_NODE_ENV_VARS",
                 "cms",
                 settings=settings
@@ -779,7 +779,7 @@ def webpack(options):
         sort_keys=True,
     )
     additional_node_env_vars = json.dumps(additional_node_env_vars_sorted_json)
-    environment = 'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} \
+    environment = u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} \
     ADDITIONAL_NODE_ENV_VARS={additional_node_env_vars}'.format(
         node_env="development" if config_path == 'webpack.dev.config.js' else "production",
         static_root_lms=static_root_lms,

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -779,8 +779,10 @@ def webpack(options):
         sort_keys=True,
     )
     js_env_extra_config = json.dumps(js_env_extra_config_sorted_json)
-    environment = u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} \
-    JS_ENV_EXTRA_CONFIG={js_env_extra_config}'.format(
+    environment = (
+        u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} '
+        u'JS_ENV_EXTRA_CONFIG={js_env_extra_config}'
+    ).format(
         node_env="development" if config_path == 'webpack.dev.config.js' else "production",
         static_root_lms=static_root_lms,
         static_root_cms=static_root_cms,

--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -256,7 +256,7 @@ class TestPaverServerTasks(PaverTestCase):
                 node_env="production",
                 static_root_lms=None,
                 static_root_cms=None,
-                js_env_extra_config=json.dumps(str({})),
+                js_env_extra_config=json.dumps({}),
                 webpack_config_path=None
             ))
             expected_messages.extend(self.expected_sass_commands(system=system, asset_settings=expected_asset_settings))
@@ -303,7 +303,7 @@ class TestPaverServerTasks(PaverTestCase):
                 node_env="production",
                 static_root_lms=None,
                 static_root_cms=None,
-                js_env_extra_config=json.dumps(str({})),
+                js_env_extra_config=json.dumps({}),
                 webpack_config_path=None
             ))
             expected_messages.extend(self.expected_sass_commands(asset_settings=expected_asset_settings))

--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -1,6 +1,8 @@
 """Unit tests for the Paver server tasks."""
 
 
+import json
+
 import ddt
 from paver.easy import call_task
 
@@ -46,10 +48,12 @@ EXPECTED_INDEX_COURSE_COMMAND = (
 EXPECTED_PRINT_SETTINGS_COMMAND = [
     u"python manage.py lms --settings={settings} print_setting STATIC_ROOT 2>{log_file}",
     u"python manage.py cms --settings={settings} print_setting STATIC_ROOT 2>{log_file}",
-    u"python manage.py lms --settings={settings} print_setting WEBPACK_CONFIG_PATH 2>{log_file}"
+    u"python manage.py lms --settings={settings} print_setting WEBPACK_CONFIG_PATH 2>{log_file}",
+    u"python manage.py cms --settings={settings} print_setting JS_ENV_EXTRA_CONFIG 2>{log_file}",
 ]
 EXPECTED_WEBPACK_COMMAND = (
     u"NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} "
+    u"JS_ENV_EXTRA_CONFIG={js_env_extra_config} "
     u"$(npm bin)/webpack --config={webpack_config_path}"
 )
 
@@ -252,6 +256,7 @@ class TestPaverServerTasks(PaverTestCase):
                 node_env="production",
                 static_root_lms=None,
                 static_root_cms=None,
+                js_env_extra_config=json.dumps(str({})),
                 webpack_config_path=None
             ))
             expected_messages.extend(self.expected_sass_commands(system=system, asset_settings=expected_asset_settings))
@@ -298,6 +303,7 @@ class TestPaverServerTasks(PaverTestCase):
                 node_env="production",
                 static_root_lms=None,
                 static_root_cms=None,
+                js_env_extra_config=json.dumps(str({})),
                 webpack_config_path=None
             ))
             expected_messages.extend(self.expected_sass_commands(asset_settings=expected_asset_settings))

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -20,7 +20,8 @@ module.exports = _.values(Merge.smart(commonConfig, {
                 debug: true
             }),
             new webpack.DefinePlugin({
-                'process.env.NODE_ENV': JSON.stringify('development')
+                'process.env.NODE_ENV': JSON.stringify('development'),
+                'process.env.ADDITIONAL_NODE_ENV_VARS': JSON.stringify(process.env.ADDITIONAL_NODE_ENV_VARS)
             })
         ],
         module: {

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -21,7 +21,7 @@ module.exports = _.values(Merge.smart(commonConfig, {
             }),
             new webpack.DefinePlugin({
                 'process.env.NODE_ENV': JSON.stringify('development'),
-                'process.env.ADDITIONAL_NODE_ENV_VARS': JSON.stringify(process.env.ADDITIONAL_NODE_ENV_VARS)
+                'process.env.JS_ENV_EXTRA_CONFIG': JSON.stringify(process.env.JS_ENV_EXTRA_CONFIG)
             })
         ],
         module: {

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -21,7 +21,7 @@ module.exports = _.values(Merge.smart(commonConfig, {
             }),
             new webpack.DefinePlugin({
                 'process.env.NODE_ENV': JSON.stringify('development'),
-                'process.env.JS_ENV_EXTRA_CONFIG': process.env.JS_ENV_EXTRA_CONFIG,
+                'process.env.JS_ENV_EXTRA_CONFIG': process.env.JS_ENV_EXTRA_CONFIG
             })
         ],
         module: {

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -21,7 +21,7 @@ module.exports = _.values(Merge.smart(commonConfig, {
             }),
             new webpack.DefinePlugin({
                 'process.env.NODE_ENV': JSON.stringify('development'),
-                'process.env.JS_ENV_EXTRA_CONFIG': JSON.stringify(process.env.JS_ENV_EXTRA_CONFIG)
+                'process.env.JS_ENV_EXTRA_CONFIG': process.env.JS_ENV_EXTRA_CONFIG,
             })
         ],
         module: {

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -17,7 +17,8 @@ var optimizedConfig = Merge.smart(commonConfig, {
     devtool: false,
     plugins: [
         new webpack.DefinePlugin({
-            'process.env.NODE_ENV': JSON.stringify('production')
+            'process.env.NODE_ENV': JSON.stringify('production'),
+            'process.env.ADDITIONAL_NODE_ENV_VARS': JSON.stringify(process.env.ADDITIONAL_NODE_ENV_VARS)
         }),
         new webpack.LoaderOptionsPlugin({  // This may not be needed; legacy option for loaders written for webpack 1
             minimize: true

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -18,7 +18,7 @@ var optimizedConfig = Merge.smart(commonConfig, {
     plugins: [
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify('production'),
-            'process.env.JS_ENV_EXTRA_CONFIG': process.env.JS_ENV_EXTRA_CONFIG,
+            'process.env.JS_ENV_EXTRA_CONFIG': process.env.JS_ENV_EXTRA_CONFIG
         }),
         new webpack.LoaderOptionsPlugin({  // This may not be needed; legacy option for loaders written for webpack 1
             minimize: true

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -18,7 +18,7 @@ var optimizedConfig = Merge.smart(commonConfig, {
     plugins: [
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify('production'),
-            'process.env.ADDITIONAL_NODE_ENV_VARS': JSON.stringify(process.env.ADDITIONAL_NODE_ENV_VARS)
+            'process.env.JS_ENV_EXTRA_CONFIG': JSON.stringify(process.env.JS_ENV_EXTRA_CONFIG)
         }),
         new webpack.LoaderOptionsPlugin({  // This may not be needed; legacy option for loaders written for webpack 1
             minimize: true

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -18,7 +18,7 @@ var optimizedConfig = Merge.smart(commonConfig, {
     plugins: [
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify('production'),
-            'process.env.JS_ENV_EXTRA_CONFIG': JSON.stringify(process.env.JS_ENV_EXTRA_CONFIG)
+            'process.env.JS_ENV_EXTRA_CONFIG': process.env.JS_ENV_EXTRA_CONFIG,
         }),
         new webpack.LoaderOptionsPlugin({  // This may not be needed; legacy option for loaders written for webpack 1
             minimize: true


### PR DESCRIPTION
This makes it possible to install new tinymce plugins through the environment settings.

This PR is responsible for adding the tinymce plugin settings to the tinymce javascript configuration.

**JIRA tickets**: SE-3381, SE-3247

**Dependencies**:

- https://github.com/open-craft/configuration/pull/143

**Upstream Pull Request**:

- https://github.com/edx/edx-platform/pull/25695

**Sandbox URL**:

- LMS: https://configurable-tinymce-plugins.stage.opencraft.hosting/ 
- Studio: https://studio.configurable-tinymce-plugins.stage.opencraft.hosting/

**Testing instructions**:

1. Login to Studio using `staff@example.com`/`edx`
2. Create a new Unit with an HTML Text
3. Make sure that the *ADSK Link* shows in the toolbar
4. Create a link and make sure you can preview it, and see it on the LMS

**Reviewers**
- [ ] @pkulkark 
- [ ] @bradenmacdonald 

**Settings**
```yaml
EDXAPP_CMS_ENV_EXTRA:
  JS_ENV_EXTRA_CONFIG:
    TINYMCE_ADDITIONAL_PLUGINS:
    - name: adsklink
      toolbar: true
      extra_settings:
        linktypes:
        - download
        - offer
        filetypes:
        - PDF
        - zip
        - Video
        - Design
        orientations:
        - Vertical
        - Horizontal
        styles:
        - Primary
        - Normal
        - Secondary

TINYMCE_ADDITIONAL_PLUGINS_LIST:
- repo: https://gitlab.com/nizarmah/tinymce-adsk-plugin
  name: adsklink
  plugin_path: "/adsklink"

edx_ansible_source_repo: "https://github.com/open-craft/configuration.git"
configuration_version: "nizar/tinymce_plugins_role_backport"
edx_platform_commit: "nizar/tinymce-easy-plugin-modification-backport"
```