### PR TITLE
Switch grading data format in CourseEnrollmentSerializer

### DIFF
--- a/common/djangoapps/enrollment/serializers.py
+++ b/common/djangoapps/enrollment/serializers.py
@@ -107,11 +107,11 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
                         summary.append(section)
             except PermissionDenied:
                 pass
-        return [
-            {u'current_grade': current_grade,
-             u'certificate_eligible': course_grade.passed if course_grade else False,
-             u'summary': summary}
-        ]
+        return {
+            u'current_grade': current_grade,
+            u'certificate_eligible': course_grade.passed if course_grade else False,
+            u'summary': summary
+        }
 
     class Meta(object):
         model = CourseEnrollment


### PR DESCRIPTION
This updates the format of the grading key from the CourseEnrollmentSerializer to remove the unnecessary wrapping in a list since it will always be a single item.

**JIRA tickets**: BB-3440

**Merge deadline**: Promptly

**Testing instructions**:
Check the format of the grading key under the course enrollments API and ensure it's not a list: http://localhost:18000/api/enrollment/v1/enrollment?user=honor

**Author notes and concerns**:

1. The final format of upstream changes this endpoint is still under discussion on https://github.com/edx/edx-platform/pull/20948/files

**Reviewers**
- [x] 0x29a