### PR TITLE
[BB-3171] Dylan/opencraft release/juniper.3 fix for bb 3171

### DIFF
--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -383,7 +383,18 @@
 
             updateValueInField: function() {
                 var value = (_.isUndefined(this.modelValue()) || _.isNull(this.modelValue())) ? '' : this.modelValue();
-                this.$('.u-field-value input').val(value);
+
+                var fieldHasFocus = (document.activeElement === this.$('.u-field-value input')[0]);
+                var fieldChanged = this.fieldValue() !== value;
+                if (fieldHasFocus && fieldChanged) {
+                    // Race conidtion between successive user-changed input
+                    // If user changed input after it was submitted before it was saved,
+                    // do nothing, it will be handled by normal finishEditing hooks.
+                    console.log('TextareaFieldView: race condition ignored')
+                } else {
+                    console.log('TextareaFieldView: no race condition')
+                    this.$('.u-field-value input').val(value);
+                }
             },
 
             saveValue: function() {
@@ -478,7 +489,18 @@
 
             updateValueInField: function() {
                 if (this.editable !== 'never') {
-                    this.$('.u-field-value select').val(this.modelValue() || '');
+                    var value = this.modelValue() || '';
+                    var fieldHasFocus = (document.activeElement === this.$('.u-field-value select')[0]);
+                    var fieldChanged = this.fieldValue() !== value;
+                    if (fieldHasFocus && fieldChanged) {
+                        // Race conidtion between successive user-changed input
+                        // If user changed input after it was submitted before it was saved,
+                        // do nothing, it will be handled by normal finishEditing hooks.
+                        console.log('DropdownFieldView: race condition ignored')
+                    } else {
+                        this.$('.u-field-value select').val(value);
+                        console.log('DropdownFieldView: no race condition')
+                    }
                 }
 
                 var value = this.displayValue(this.modelValue() || '');

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -390,9 +390,7 @@
                     // Race conidtion between successive user-changed input
                     // If user changed input after it was submitted before it was saved,
                     // do nothing, it will be handled by normal finishEditing hooks.
-                    console.log('TextareaFieldView: race condition ignored')
                 } else {
-                    console.log('TextareaFieldView: no race condition')
                     this.$('.u-field-value input').val(value);
                 }
             },
@@ -496,10 +494,8 @@
                         // Race conidtion between successive user-changed input
                         // If user changed input after it was submitted before it was saved,
                         // do nothing, it will be handled by normal finishEditing hooks.
-                        console.log('DropdownFieldView: race condition ignored')
                     } else {
                         this.$('.u-field-value select').val(value);
-                        console.log('DropdownFieldView: no race condition')
                     }
                 }
 


### PR DESCRIPTION
    prevent a backbone fieldview race condition that can delete user input
    
    when the user is focused on an input, and the value of the input has
    changed from the model, ignore field updates because these would delete
    user input data.  This data will be submitted normally on finishEditing

**Dependencies**: None

**Screenshots**: Visually Identical, modified behavior prevents user-entered text in an html input tag from being deleted, which looks like normal form text entry with least astonishment.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None, Originally Nov 12 (passed due)

**Testing instructions**:

Manual testing:
1. prepare a development environment such as devstack with the Juniper.3-hms release or closest (I used `(export OPENEDX_RELEASE=juniper.master (make dev.checkout && make dev.provision))` detailed [here](https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/developing_on_named_release_branches.html?highlight=release)
1. checkout edx-platform to the fix branch (github repo `open-craft/edx-platform`, branch `dylan/opencraft-release/juniper.3-fix-for-BB-3171`) this should be sufficient to load the code changes with devstack
2. in your browser tools, disable network caching as this fix modifies static assets
2. register a dummy student user with lms (lms port in devstack is `:18000` and the registration document_uri is `/register`), create/login to this account so that we can modify account settings (document_uri is `/accounts/settings`)
3. Under lms /accounts/settings, focus an editable text field, and rapidly submit then modify the value.  I used`s<enter>s`.
If you were rapid enough to modify the text field before the network response (you can monitor the chrome "network" tab observing that the ajex request was still pending/in-flight after the second "s" was entered into the text field).  

With this fix, note that the server-side success response does not revert the text value to the first submitted value (what the value was when `<enter>` was pressed, instead the currently-being-modified text (with two "s"s) is still present.

This fix is also applied to DropDown widgets, due to requiring a physically harder keystroke, I used the utility `xdotool` to cause the dropdown submission/update fast enough.  These use the same branching logic, (copied twice, I'm open to converting it to a function, I don't have a good sense of preference for creating functions in backbone js contexts).

my manual testing journal:
    manual testing:
      - [x] observed that normal page loads (lms /accounts/settings) do not trigger any race conditions on normal form population
      - [x] observed TextFieldView elements ignore the race condition by focusing (username) and entrying the keysequence "s<enter>s<enter>" rapidly
      - [x] observed DropdownFieldView elements ignore the race condition bo focusing (country) and using `xdotool` to rapidly enter the key sequence:
            sleep 2; xdotool key  Down Tab Shift_L+Tab Down Tab Shift_L+Tab Up Up


    manual tests attempted to use javascript to reproduce the race condition, I didn't find an obvious or simple way to create the correct events, I am interested in ways to better automate these tests.
    
    the source ticket (tasks.opencraft.com) BB-3171 mentions this issue was identified by automated testing, I am not sure which automated test detects the issue or if its repeatable
    
Optionally, a patch similar to this reports the behavior explicitly, used in my manual testing to ensure events were submitted fast enough and behaved correctly
```
    ---- BEGING PATCH -----
    diff --git a/lms/static/js/views/fields.js b/lms/static/js/views/fields.js
    index a157910f9e..186b124f2e 100644
    --- a/lms/static/js/views/fields.js
    +++ b/lms/static/js/views/fields.js
    @@ -390,7 +390,9 @@
                         // Race conidtion between successive user-changed input
                         // If user changed input after it was submitted before it was saved,
                         // do nothing, it will be handled by normal finishEditing hooks.
    +                    console.log('TextareaFieldView: race condition ignored (new behavior)')
                     } else {
    +                    console.log('TextareaFieldView: no race condition (original behavior)')
                         this.$('.u-field-value input').val(value);
                     }
                 },
    @@ -494,8 +496,10 @@
                             // Race conidtion between successive user-changed input
                             // If user changed input after it was submitted before it was saved,
                             // do nothing, it will be handled by normal finishEditing hooks.
    +                        console.log('DropdownFieldView: race condition ignored (new behavior)')
                         } else {
                             this.$('.u-field-value select').val(value);
    +                        console.log('DropdownFieldView: no race condition (original behavior)')
                         }
                     }
    
    ----- END PATCH -----
```

**Author notes and concerns**:

2. There are currently no automated tests known by the author to exercise the broken or fixed behavior
3. The necessity to disable browser cache during development/testing indicates a fragile roll out.  Does it make sense to use a new namespace for the fixed javascript methods to ensure clean client side cache invalidation? My best guess is that backbone relies on fixed namespaces, a change to that may be very disruptive.
4. This behavior change required modifying a shared library, meaning this change as the potential to impact a huge number of input fields throughout the edx-platform.  No non-accounts/settings fields were tested, no discovery to identify impact has been done.  No discovery to identify if there are tests to exercise lms backbone FieldView use.
5. this was developed originally with edx/edx-platform:open-release/juniper.master and the backported to open-craft/edx-platform:opencraft-release/juniper.3, there was no diff between these two commits on the target file (lms/static/js/views/fields.js) but beware, I do not know the full scope of the differences to gauge relevance

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD


