### PR TITLE
[SE-3816] Adds waffle switch to enable third party auth email association

### DIFF
--- a/common/djangoapps/third_party_auth/config/waffle.py
+++ b/common/djangoapps/third_party_auth/config/waffle.py
@@ -1,0 +1,15 @@
+"""
+This module contains various configuration settings via
+waffle switches for third party authentication.
+"""
+
+
+from openedx.core.djangoapps.waffle_utils import WaffleSwitch
+
+
+WAFFLE_NAMESPACE = 'third_party_auth'
+
+ALWAYS_ASSOCIATE_USER_BY_EMAIL = WaffleSwitch(
+    WAFFLE_NAMESPACE,
+    'always_associate_user_by_email',
+)

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -88,6 +88,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.user_api import accounts
 from openedx.core.djangoapps.user_authn import cookies as user_authn_cookies
 from third_party_auth.utils import user_exists
+from third_party_auth.config.waffle import ALWAYS_ASSOCIATE_USER_BY_EMAIL
 from track import segment
 from util.json_request import JsonResponse
 
@@ -720,7 +721,7 @@ def associate_by_email_if_login_api(auth_entry, backend, details, user, current_
 
     This association is done ONLY if the user entered the pipeline through a LOGIN API.
     """
-    if auth_entry == AUTH_ENTRY_LOGIN_API:
+    if auth_entry == AUTH_ENTRY_LOGIN_API or ALWAYS_ASSOCIATE_USER_BY_EMAIL.is_enabled():
         association_response = associate_by_email(backend, details, user, *args, **kwargs)
         if (
             association_response and

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -77,7 +77,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from social_core.exceptions import AuthException
 from social_core.pipeline import partial
-from social_core.pipeline.social_auth import associate_by_email
+from social_core.pipeline.social_auth import associate_by_email as _associate_by_email
 from social_core.utils import module_member, slugify
 
 import third_party_auth
@@ -713,16 +713,19 @@ def login_analytics(strategy, auth_entry, current_partial=None, *args, **kwargs)
 
 
 @partial.partial
-def associate_by_email_if_login_api(auth_entry, backend, details, user, current_partial=None, *args, **kwargs):
+def associate_user_by_email(auth_entry, backend, details, user, current_partial=None, *args, **kwargs):
     """
     This pipeline step associates the current social auth with the user with the
     same email address in the database.  It defers to the social library's associate_by_email
     implementation, which verifies that only a single database user is associated with the email.
 
-    This association is done ONLY if the user entered the pipeline through a LOGIN API.
+    This association is done ONLY if:
+        the user entered the pipeline through a LOGIN API.
+    OR
+        the `third_party_auth.always_associate_user_by_email` Waffle Switch is Active
     """
     if auth_entry == AUTH_ENTRY_LOGIN_API or ALWAYS_ASSOCIATE_USER_BY_EMAIL.is_enabled():
-        association_response = associate_by_email(backend, details, user, *args, **kwargs)
+        association_response = _associate_by_email(backend, details, user, *args, **kwargs)
         if (
             association_response and
             association_response.get('user') and

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -53,7 +53,7 @@ def apply_settings(django_settings):
         'social_core.pipeline.social_auth.social_uid',
         'social_core.pipeline.social_auth.auth_allowed',
         'social_core.pipeline.social_auth.social_user',
-        'third_party_auth.pipeline.associate_by_email_if_login_api',
+        'third_party_auth.pipeline.associate_user_by_email',
         'third_party_auth.pipeline.get_username',
         'third_party_auth.pipeline.set_pipeline_timeout',
         'third_party_auth.pipeline.ensure_user_information',

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -117,6 +117,8 @@ class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, 
         Tests associate_user_by_email method of running pipeline
         """
         pipeline.associate_user_by_email(
+            strategy=mock.MagicMock(),
+            pipeline_index=0,
             auth_entry=auth_entry,
             backend=self.provider.backend_class(),
             details=None,
@@ -143,6 +145,8 @@ class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, 
         """
         with override_waffle_switch(waffle_switch, switch_is_active):
             pipeline.associate_user_by_email(
+                strategy=mock.MagicMock(),
+                pipeline_index=0,
                 auth_entry='login',
                 backend=self.provider.backend_class(),
                 details=None,

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -5,9 +5,11 @@ import json
 import unittest
 
 import ddt
+from edx_toggles.toggles.testutils import override_waffle_switch
 import mock
 
 from third_party_auth import pipeline
+from third_party_auth.pipeline import ALWAYS_ASSOCIATE_USER_BY_EMAIL
 from third_party_auth.tests import testutil
 from third_party_auth.tests.specs.base import IntegrationTestMixin
 from third_party_auth.tests.specs.test_testshib import SamlIntegrationTestUtilities
@@ -98,3 +100,53 @@ class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, 
             mock_uuid.return_value = uuid4
             final_username = pipeline.get_username(strategy, details, self.provider.backend_class())
             self.assertEqual(expected_username, final_username['username'])
+
+    @ddt.data(
+        ('login', False),
+        ('login_api', True),
+    )
+    @ddt.unpack
+    @mock.patch('common.djangoapps.third_party_auth.pipeline._associate_by_email')
+    def test_associate_user_by_email_in_pipeline_auth_entry(
+        self,
+        auth_entry,
+        called_expected,
+        mock_associate_by_email,
+    ):
+        """
+        Tests associate_user_by_email method of running pipeline
+        """
+        pipeline.associate_user_by_email(
+            auth_entry=auth_entry,
+            backend=self.provider.backend_class(),
+            details=None,
+            user=None,
+        )
+
+        self.assertEqual(mock_associate_by_email.called, called_expected)
+
+    @ddt.data(
+        (ALWAYS_ASSOCIATE_USER_BY_EMAIL, True, True),
+        (ALWAYS_ASSOCIATE_USER_BY_EMAIL, False, False),
+    )
+    @ddt.unpack
+    @mock.patch('common.djangoapps.third_party_auth.pipeline._associate_by_email')
+    def test_associate_user_by_email_in_pipeline_waffle_switches(
+        self,
+        waffle_switch,
+        switch_is_active,
+        called_expected,
+        mock_associate_by_email,
+    ):
+        """
+        Tests associate_user_by_email method of running pipeline
+        """
+        with override_waffle_switch(waffle_switch, switch_is_active):
+            pipeline.associate_user_by_email(
+                auth_entry='login',
+                backend=self.provider.backend_class(),
+                details=None,
+                user=None,
+            )
+
+            self.assertEqual(mock_associate_by_email.called, called_expected)


### PR DESCRIPTION
Currently, in the edX platform, if you try to login with an SSO account using the login form, a username is generated for you based on the email that is used with the SSO provider.

The username is generated using the pipeline `third_party_auth.pipeline.get_username`.

If the username already exists in the platform, you run into a small conflict which sends you back to the login form and requests the following:
![image](https://user-images.githubusercontent.com/5631091/103084549-537b7700-45f0-11eb-9f17-80945a29cf8d.png)
It basically requests that you link your edX account and your SSO account.

However, sometimes we would want the edX account and SSO account to be associated by email. There's already a special pipeline available in the platform for that, `third_party_auth.pipeline.associate_by_email_if_login_api`. Sadly, however, it is only available for a certain entry method of authentication, called `login_api`.

So in order to start associating the edX account and SSO account by email, this pull request adds a waffle switch.

**JIRA tickets**: SE-3816

**Upstream Pull Request**: https://github.com/edx/edx-platform/pull/25935

**Testing instructions**:

* [Internal testing instructions](https://tasks.opencraft.com/browse/SE-3816?focusedCommentId=181631&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-181631)

**Reviewers**
- [ ] @0x29a 
