### PR TITLE
[SE-3440] Adds grade cutoffs to gradebook grading information

### DIFF
--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -278,6 +278,7 @@ class CourseGradingView(BaseCourseView):
 
         with self.get_course(request, course_key) as course:
             results = {
+                'grade_cutoffs': course.grade_cutoffs,
                 'assignment_types': self._get_assignment_types(course),
                 'subsections': self._get_subsections(course, graded_only),
                 'grades_frozen': are_grades_frozen(course_key),

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -68,6 +68,9 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
         """
         Sets up the structure of the test course.
         """
+        course.grade_cutoffs = {
+            "Pass": 0.5,
+        }
         cls.section = ItemFactory.create(
             parent_location=course.location,
             category="chapter",
@@ -135,6 +138,9 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
 
     def _get_expected_data(self):
         return {
+            "grade_cutoffs": {
+                "Pass": 0.5,
+            },
             'assignment_types': {
                 'Final Exam': {
                     'drop_count': 0,


### PR DESCRIPTION
Adds course `grade_cutoffs` to the `/api/grades/v1/gradebook/{course_id}/grading-info`.

**JIRA tickets**: SE-3440

**Upstream Pull Request**: https://github.com/edx/edx-platform/pull/25978

**Sandbox URL**:
* LMS: https://pr305.sandbox.stage.opencraft.hosting/
* Studio: https://studio.pr305.sandbox.stage.opencraft.hosting/

**Testing instructions**:

Run the following function and verify that `grade_cutoffs` is highlighted 😃 

```bash
curl --request POST \
  --insecure --url https://pr305.sandbox.stage.opencraft.hosting/oauth2/access_token/ \
  --header 'content-type: multipart/form-data;' \
  --form grant_type=client_credentials \
  --form client_id=LgIomajnBojAT0l65g0jFWxiJTODMejydpoDQDPR \
  --form client_secret=qO7Ng8OcwB4tQFbXilDdKIR2uADwfEJNGanSVaDieoq4n39XTExuEpN1qV4yCPiKpyFjKT7y1Awwsy17aCCNNtPl7F8YPYeu0oHV7WtHWOyZCKQ01Bj7POe2QDiZWZeF \
  | awk '{print substr($9, 2, length($9)-3)}' \
  | xargs -I "TOKEN" sh -c \
    "curl --request GET \
          --insecure --url 'https://pr305.sandbox.stage.opencraft.hosting/api/grades/v1/gradebook/course-v1:edX+DemoX+Demo_Course/grading-info' \
          --header 'authorization: Bearer TOKEN'" \
  | grep "grade_cutoff"

```

_You can also update the grading scale for the Demo course, and verify those changes are reflected._

**Author notes and concerns**:

1. If you'd prefer that I add a separate API endpoint for this, please let me know 👍🏼 
2. I know I shouldn't be sharing credentials, but this is a sandbox 🤷🏼‍♂️ 

**Reviewers**
- [ ] @s0b0lev 
