### PR TITLE
Revert "[SE-3381] Allows adding new tinymce plugins through platform configuration"

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1000,11 +1000,6 @@ COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 ##### EMBARGO #####
 EMBARGO_SITE_REDIRECT_URL = None
 
-##### custom vendor plugin variables #####
-# JavaScript code can access this data using `process.env.JS_ENV_EXTRA_CONFIG`
-# One of the current use cases for this is enabling custom TinyMCE plugins
-JS_ENV_EXTRA_CONFIG = {}
-
 ############################### PIPELINE #######################################
 
 PIPELINE = {

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -95,8 +95,7 @@
         tinyMCE incorrectly decides that the suffix should be "", which means it fails to load files.
          */
         tinyMCE.suffix = ".min";
-
-        var tinyMceConfig = {
+        this.tiny_mce_textarea = $(".tiny-mce", this.element).tinymce({
           script_url: baseUrl + "js/vendor/tinymce/js/tinymce/tinymce.full.min.js",
           font_formats: _getFonts(),
           theme: "modern",
@@ -172,41 +171,7 @@
            */
           init_instance_callback: this.initInstanceCallback,
           browser_spellcheck: true
-        };
-
-        if (typeof process != "undefined" && process.env.JS_ENV_EXTRA_CONFIG) {
-          var tinyMceAdditionalPlugins = process.env.JS_ENV_EXTRA_CONFIG.TINYMCE_ADDITIONAL_PLUGINS;
-          // check if we have any additional plugins passed
-          if (tinyMceAdditionalPlugins) {
-            // go over each plugin
-            tinyMceAdditionalPlugins.forEach(function (tinyMcePlugin) {
-              // check if plugins is not empty (ie there are existing plugins)
-              if (tinyMceConfig.plugins.trim()) {
-                tinyMceConfig.plugins += ', ';
-              }
-
-              // add the plugin to the list of plugins
-              tinyMceConfig.plugins += tinyMcePlugin.name;
-
-              // check if the plugin should be included in the toolbar
-              if (tinyMcePlugin.toolbar) {
-                // check if toolbar is not empty (ie there are already items in the toolbar)
-                if (tinyMceConfig.toolbar.trim()) {
-                  tinyMceConfig.toolbar += ' | ';
-                }
-
-                tinyMceConfig.toolbar += tinyMcePlugin.name;
-              }
-
-              // add the additional settings for each plugin (if there is any)
-              if (tinyMcePlugin.extra_settings) {
-                tinyMceConfig[tinyMcePlugin.name] = tinyMcePlugin.extra_settings;
-              }
-            });
-          }
-        }
-
-        this.tiny_mce_textarea = $(".tiny-mce", this.element).tinymce(tinyMceConfig);
+        });
         tinymce.addI18n('en', {
 
           /*

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -5,9 +5,7 @@ Asset compilation and collection.
 
 import argparse
 import glob
-import json
 import os
-import re
 import traceback
 from datetime import datetime
 from functools import wraps
@@ -765,32 +763,14 @@ def webpack(options):
     """
     Run a Webpack build.
     """
-    def json_format_setting(setting_value):
-        """
-        Replaces capitalized booleans with booleans that
-        are compatible with parsed JSON in javascript.
-        """
-        if isinstance(setting_value, str):
-            # replace python bools with json valid bools
-            setting_value = re.sub(r'(\:\s?)True', r'\1true', setting_value)
-            setting_value = re.sub(r'(\:\s?)False', r'\1false', setting_value)
-
-        return setting_value
-
     settings = getattr(options, 'settings', Env.DEVSTACK_SETTINGS)
     static_root_lms = Env.get_django_setting("STATIC_ROOT", "lms", settings=settings)
     static_root_cms = Env.get_django_setting("STATIC_ROOT", "cms", settings=settings)
     config_path = Env.get_django_setting("WEBPACK_CONFIG_PATH", "lms", settings=settings)
-    js_env_extra_config_setting = Env.get_django_setting("JS_ENV_EXTRA_CONFIG", "cms", settings=settings)
-    js_env_extra_config = json.dumps(json_format_setting(js_env_extra_config_setting) or {})
-    environment = (
-        u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} '
-        u'JS_ENV_EXTRA_CONFIG={js_env_extra_config}'
-    ).format(
+    environment = u'NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms}'.format(
         node_env="development" if config_path == 'webpack.dev.config.js' else "production",
         static_root_lms=static_root_lms,
-        static_root_cms=static_root_cms,
-        js_env_extra_config=js_env_extra_config,
+        static_root_cms=static_root_cms
     )
     sh(
         cmd(

--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -1,8 +1,6 @@
 """Unit tests for the Paver server tasks."""
 
 
-import json
-
 import ddt
 from paver.easy import call_task
 
@@ -48,12 +46,10 @@ EXPECTED_INDEX_COURSE_COMMAND = (
 EXPECTED_PRINT_SETTINGS_COMMAND = [
     u"python manage.py lms --settings={settings} print_setting STATIC_ROOT 2>{log_file}",
     u"python manage.py cms --settings={settings} print_setting STATIC_ROOT 2>{log_file}",
-    u"python manage.py lms --settings={settings} print_setting WEBPACK_CONFIG_PATH 2>{log_file}",
-    u"python manage.py cms --settings={settings} print_setting JS_ENV_EXTRA_CONFIG 2>{log_file}",
+    u"python manage.py lms --settings={settings} print_setting WEBPACK_CONFIG_PATH 2>{log_file}"
 ]
 EXPECTED_WEBPACK_COMMAND = (
     u"NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} "
-    u"JS_ENV_EXTRA_CONFIG={js_env_extra_config} "
     u"$(npm bin)/webpack --config={webpack_config_path}"
 )
 
@@ -256,7 +252,6 @@ class TestPaverServerTasks(PaverTestCase):
                 node_env="production",
                 static_root_lms=None,
                 static_root_cms=None,
-                js_env_extra_config=json.dumps({}),
                 webpack_config_path=None
             ))
             expected_messages.extend(self.expected_sass_commands(system=system, asset_settings=expected_asset_settings))
@@ -303,7 +298,6 @@ class TestPaverServerTasks(PaverTestCase):
                 node_env="production",
                 static_root_lms=None,
                 static_root_cms=None,
-                js_env_extra_config=json.dumps({}),
                 webpack_config_path=None
             ))
             expected_messages.extend(self.expected_sass_commands(asset_settings=expected_asset_settings))

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -20,8 +20,7 @@ module.exports = _.values(Merge.smart(commonConfig, {
                 debug: true
             }),
             new webpack.DefinePlugin({
-                'process.env.NODE_ENV': JSON.stringify('development'),
-                'process.env.JS_ENV_EXTRA_CONFIG': process.env.JS_ENV_EXTRA_CONFIG
+                'process.env.NODE_ENV': JSON.stringify('development')
             })
         ],
         module: {

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -17,8 +17,7 @@ var optimizedConfig = Merge.smart(commonConfig, {
     devtool: false,
     plugins: [
         new webpack.DefinePlugin({
-            'process.env.NODE_ENV': JSON.stringify('production'),
-            'process.env.JS_ENV_EXTRA_CONFIG': process.env.JS_ENV_EXTRA_CONFIG
+            'process.env.NODE_ENV': JSON.stringify('production')
         }),
         new webpack.LoaderOptionsPlugin({  // This may not be needed; legacy option for loaders written for webpack 1
             minimize: true


### PR DESCRIPTION
Reverts open-craft/edx-platform#295

The reason behind the revert is that with multiple app servers, the TinyMCE object in the JavaScript code doesn't get sorted by key. This is a huge problem because the changes being upstreamed are already being sorted by key...

So it seems like there's a specific backport that is missing, which should be done before merging this change.

Here's what I'm talking about:
* File 1:

```javascript
                           var d = {
                              TINYMCE_ADDITIONAL_PLUGINS: [{
                                 toolbar: !0,
                                 extra_settings: {
                                    linktypes: ["download", "offer"],
                                    orientations: ["Vertical", "Horizontal"],
                                    filetypes: ["PDF", "zip", "Video", "Design"],
                                    styles: ["Primary", "Normal", "Secondary"]
                                 },
                                 name: "adsklink"
                              }]
                           }.TINYMCE_ADDITIONAL_PLUGINS;
```

* File 2:

```javascript
                           var d = {
                              TINYMCE_ADDITIONAL_PLUGINS: [{
                                 toolbar: !0,
                                 name: "adsklink",
                                 extra_settings: {
                                    linktypes: ["download", "offer"],
                                    orientations: ["Vertical", "Horizontal"],
                                    filetypes: ["PDF", "zip", "Video", "Design"],
                                    styles: ["Primary", "Normal", "Secondary"]
                                 }
                              }]
                           }.TINYMCE_ADDITIONAL_PLUGINS;
```