### PR TITLE
Allow course home behavior configuration to override unified course tab

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -373,22 +373,18 @@ def course_root(request, course_id):
     Renders the configured course home or redirects to the correct url. This
     behaviour can be controlled by the following variables:
 
-    * UNIFIED_COURSE_TAB_FLAG WaffleFlag
-        redirects / to the unified course experience.
     * COURSE_HOME_BEHAVIOUR SiteConfiguration:
         can redirect from / to any course related page. Some possible redirects
         are: 'info', 'about' and 'courseware'.
         If this fails to find a reverse, it uses the course info page as a
         default.
+    * UNIFIED_COURSE_TAB_FLAG WaffleFlag
+        redirects / to the unified course experience.
 
     If none of those are set, this redirects to course_info (the previous
     default behaviour).
     """
     course_key = CourseKey.from_string(course_id)
-
-    # If the unified course experience is enabled, redirect to the "Course" tab
-    if UNIFIED_COURSE_TAB_FLAG.is_enabled(course_key):
-        return redirect(reverse(course_home_url_name(course_key), args=[course_id]))
 
     course_home_behaviour = configuration_helpers.get_value('COURSE_HOME_BEHAVIOUR')
     if course_home_behaviour:
@@ -400,6 +396,10 @@ def course_root(request, course_id):
                 'COURSE_HOME_BEHAVIOUR incorrectly configured. The request url doesn\'t exist: %s',
                 course_home_behaviour
             )
+
+    # If the unified course experience is enabled, redirect to the "Course" tab
+    if UNIFIED_COURSE_TAB_FLAG.is_enabled(course_key):
+        return redirect(reverse(course_home_url_name(course_key), args=[course_id]))
 
     # Default behaviour if variable isn't set
     return course_info(request, course_id)


### PR DESCRIPTION
This PR amends a previous change (fe95b2b94fa25d20b60b2f40533b2bb4a24e7ef1), which allows for configuring where the root URL of a course redirects to.

This older commit ignores the added configuration value if the unified course tab is set, but this removes the option to set the course root redirection when the unified course tab is enabled.

Here we move the check for the `COURSE_HOME_BEHAVIOUR` option from the SiteConfiguration to before checking the unified course tab to allow us to still configure this when the unified course tab is enabled.


**JIRA tickets**: Implements BB-3399

**Discussions**: Discussed on JIRA

**Dependencies**: None

**Merge deadline**: ASAP

**Testing instructions**:

1. Set `course_experience.unified_course_tab` flag to true in [your devstack WaffleFlag settings](http://localhost:18000/admin/waffle/flag/)
2. In your [devstack site configuration](http://morton:18000/admin/site_configuration/siteconfiguration/1/change/) set the following value: `"COURSE_HOME_BEHAVIOUR":"courseware",`
3. Visit a course root such as http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/
4. Verify that this redirects directly to the courseware

**Reviewers**
- [ ] (@AdditionalPylons)
