### PR TITLE
[BB-3624] Add Site Configuration in email context

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -403,6 +403,13 @@ def get_email_params(course, auto_enroll, secure=True, course_key=None, display_
 
     is_shib_course = uses_shib(course)
 
+    # Collect mailing address and platform name to pass as context
+    contact_mailing_address = configuration_helpers.get_value(
+        'contact_mailing_address',
+        settings.CONTACT_MAILING_ADDRESS
+    )
+    platform_name = configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+
     # Composition of email
     email_params = {
         'site_name': stripped_site_name,
@@ -413,6 +420,9 @@ def get_email_params(course, auto_enroll, secure=True, course_key=None, display_
         'course_url': course_url,
         'course_about_url': course_about_url,
         'is_shib_course': is_shib_course,
+        'contact_mailing_address': contact_mailing_address,
+        'platform_name': platform_name,
+        'site_configuration_values': configuration_helpers.get_current_site_configuration_values(),
     }
     return email_params
 

--- a/openedx/core/djangoapps/ace_common/template_context.py
+++ b/openedx/core/djangoapps/ace_common/template_context.py
@@ -37,4 +37,5 @@ def get_base_template_context(site):
             'CONTACT_MAILING_ADDRESS', site=site, site_config_name='contact_mailing_address'),
         'social_media_urls': get_config_value_from_site_or_settings('SOCIAL_MEDIA_FOOTER_URLS', site=site),
         'mobile_store_urls': get_config_value_from_site_or_settings('MOBILE_STORE_URLS', site=site),
+        'site_configuration_values': site.configuration.site_values if hasattr(site, 'configuration') else {},
     }

--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -29,6 +29,14 @@ def get_current_site_configuration():
         return None
 
 
+def get_current_site_configuration_values(default={}):
+    """
+    Returns `SiteConfiguration.site_values` for current site.
+    """
+    site_configuration = get_current_site_configuration()
+    return site_configuration.site_values if site_configuration else default
+
+
 def is_site_configuration_enabled():
     """
     Returns True is there is SiteConfiguration instance associated with the current site and it is enabled, otherwise

--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -29,10 +29,11 @@ def get_current_site_configuration():
         return None
 
 
-def get_current_site_configuration_values(default={}):
+def get_current_site_configuration_values(default=None):
     """
     Returns `SiteConfiguration.site_values` for current site.
     """
+    default = default if default is not None else {}
     site_configuration = get_current_site_configuration()
     return site_configuration.site_values if site_configuration else default
 

--- a/openedx/core/djangoapps/site_configuration/tests/test_helpers.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_helpers.py
@@ -195,3 +195,17 @@ class TestHelpers(TestCase):
             list(configuration_helpers.get_current_site_orgs()),
             test_orgs
         )
+
+    def test_get_current_site_configuration_values(self):
+        """
+        Test get_current_site_configuration_values helper function
+        """
+        site_values = configuration_helpers.get_current_site_configuration_values()
+        self.assertTrue(isinstance(site_values, dict))
+
+        # without any site configuration it should return empty dict
+        self.assertEqual(site_values, {})
+
+        with with_site_configuration_context(configuration=test_config):
+            site_values = configuration_helpers.get_current_site_configuration_values()
+            self.assertEqual(site_values, test_config)


### PR DESCRIPTION
When using multiple sites, there is not much room for custom email per site. To achieve customization per-site basis, this PR puts Site Configuration in the context while rendering email templates.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3624

~~**Discussions**:~~

**Dependencies**: None

**Screenshots**:  N/A

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. Pull this PR on local devstack
2. Set ``PLATFORM_NAME`` in default site configuration from Django admin.
3. From the login page ask for password reset and check password reset email has platform name from the site configuration.
4. From the instructor dashboard enroll a user and check if enroll request email has the platform name from the site configuration. 

**Author notes and concerns**:

1. Should we try to upstream this? Is there a better way?

**Reviewers**
- [ ] @lgp171188 