### PR TITLE
[BB-3624] Add site configuration in activation email context

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -370,10 +370,15 @@ def generate_activation_email_context(user, registration):
         'key': registration.activation_key,
         'lms_url': configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+        'contact_mailing_address':configuration_helpers.get_value(
+            'contact_mailing_address',
+            settings.CONTACT_MAILING_ADDRESS
+        ),
         'support_url': configuration_helpers.get_value(
             'ACTIVATION_EMAIL_SUPPORT_LINK', settings.ACTIVATION_EMAIL_SUPPORT_LINK
         ) or settings.SUPPORT_SITE_LINK,
         'support_email': configuration_helpers.get_value('CONTACT_EMAIL', settings.CONTACT_EMAIL),
+        'site_configuration_values': configuration_helpers.get_current_site_configuration_values(),
     }
 
 


### PR DESCRIPTION
This PR adds the `mailing_address` and `site_configuration_values` added in https://github.com/open-craft/edx-platform/pull/315 to the `generate_activation_email_context()` function as well so that they can be used in the activation emails.