### PR TITLE
Updates tpa email association waffle switch to support edx-toggles=1.1.1

### DIFF
--- a/common/djangoapps/third_party_auth/config/waffle.py
+++ b/common/djangoapps/third_party_auth/config/waffle.py
@@ -4,7 +4,7 @@ waffle switches for third party authentication.
 """
 
 
-from edx_toggles.toggles.__future__ import WaffleSwitch
+from edx_toggles.toggles import WaffleSwitch
 
 
 WAFFLE_NAMESPACE = 'third_party_auth'
@@ -19,6 +19,7 @@ WAFFLE_NAMESPACE = 'third_party_auth'
 # .. toggle_creation_date: 2020-12-23
 # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-5312
 ALWAYS_ASSOCIATE_USER_BY_EMAIL = WaffleSwitch(
-    f'{WAFFLE_NAMESPACE}.always_associate_user_by_email',
+    WAFFLE_NAMESPACE,
+    'always_associate_user_by_email',
     module_name=__name__,
 )


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This change updates the `third_party_auth.always_associate_user_by_email` waffle switch's definition because Koa uses `edx-toggles=1.1.1`, instead of `2.0.0>edx-toggles>=1.2.0`.

## Supporting information

* Jira Tickets: SE-3816, BB-3518

## Testing instructions

* Follow the testing instructions on https://github.com/edx/edx-platform/pull/25935

## Deadline

As soon as possible