### PR TITLE
[BB-3710] Revert: Stop rendering Visibility and Move buttons on libraries (koa.2a)

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -295,10 +295,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'is_root': is_root,
             'is_reorderable': is_reorderable,
             'can_edit': context.get('can_edit', True),
-            'can_edit_visibility': context.get('can_edit_visibility', xblock.course_id.is_course),
+            'can_edit_visibility': context.get('can_edit_visibility', True),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', xblock.course_id.is_course),
+            'can_move': context.get('can_move', True),
             'language': getattr(course, 'language', None)
         }
 


### PR DESCRIPTION
This reverts https://github.com/open-craft/edx-platform/pull/323 since upstream found an issue and [reverted it](https://github.com/edx/edx-platform/pull/26885#issuecomment-805022096).