### PR TITLE
BB-3710: Revert "Backport for Stop rendering Visibility and Move buttons on libraries (esme juniper.3)

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -298,10 +298,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'is_root': is_root,
             'is_reorderable': is_reorderable,
             'can_edit': context.get('can_edit', True),
-            'can_edit_visibility': context.get('can_edit_visibility', xblock.course_id.is_course),
+            'can_edit_visibility': context.get('can_edit_visibility', True),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', xblock.course_id.is_course),
+            'can_move': context.get('can_move', True),
             'language': getattr(course, 'language', None)
         }
 

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -298,10 +298,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'is_root': is_root,
             'is_reorderable': is_reorderable,
             'can_edit': context.get('can_edit', True),
-            'can_edit_visibility': context.get('can_edit_visibility', True),
+            'can_edit_visibility': context.get('can_edit_visibility', xblock.scope_ids.usage_id.context_key.is_course),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', True),
+            'can_move': context.get('can_move', xblock.scope_ids.usage_id.context_key.is_course),
             'language': getattr(course, 'language', None)
         }
 


### PR DESCRIPTION
This reverts commit 812d9d593319fa608e0525b468e57c769e92d825.

(cherry picked from commit 8e18f19821aff747cb50b068e35977a7563a59d7)

This probably shouldn't be merged, as it's a temporary fix. The best solution is https://github.com/edx/edx-platform/pull/27121 , which needs to be backported to opencraft-release/juniper.3, and then that branch merged into esme-oxford-release/juniper.3.

@shimulch 

EDIT: update - added the change from https://github.com/edx/edx-platform/pull/27121 