### PR TITLE
[BB-3710] [Backport] fix: Stop rendering Visibility and Move buttons on libraries (Koa.2a)

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -295,10 +295,10 @@ def _studio_wrap_xblock(xblock, view, frag, context, display_name_only=False):
             'is_root': is_root,
             'is_reorderable': is_reorderable,
             'can_edit': context.get('can_edit', True),
-            'can_edit_visibility': context.get('can_edit_visibility', True),
+            'can_edit_visibility': context.get('can_edit_visibility', xblock.scope_ids.usage_id.context_key.is_course),
             'selected_groups_label': selected_groups_label,
             'can_add': context.get('can_add', True),
-            'can_move': context.get('can_move', True),
+            'can_move': context.get('can_move', xblock.scope_ids.usage_id.context_key.is_course),
             'language': getattr(course, 'language', None)
         }
 


### PR DESCRIPTION
Backport the fix for Stop rendering Visibility and Move buttons on libraries.

(cherry picked from commit 2379f1ca26c127f5fccfd770419273ce35f32136)