### PR TITLE
Upgrade staff-graded-xblock to 0.9

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -228,7 +228,7 @@ git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef793
 sortedcontainers==2.1.0   # via -r requirements/edx/base.in, pdfminer.six
 soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/edx/base.in, django
-staff-graded-xblock==0.8  # via -r requirements/edx/base.in
+staff-graded-xblock==0.9  # via -r requirements/edx/base.in
 stevedore==1.32.0         # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
 super-csv==0.9.8          # via -r requirements/edx/base.in, edx-bulk-grades
 sympy==1.5.1              # via symmath


### PR DESCRIPTION
This upgrades the xblock to 0.9 which fixes a bug related to JS function intialization : https://github.com/edx/staff_graded-xblock/pull/18

**JIRA tickets**: [FAL-1730](https://tasks.opencraft.com/browse/FAL-1730)

**Reviewers**
- [ ] @eLRuLL 