### PR TITLE
BB-3954 Add toggle for enrollment behavior

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -485,6 +485,10 @@ FEATURES = {
 # e.g. COURSE_BLOCKS_API_EXTRA_FIELDS = [  ('course', 'other_course_settings'), ("problem", "weight")  ]
 COURSE_BLOCKS_API_EXTRA_FIELDS = []
 
+# Setting to redirect unauthenticated users to the login page when enrolling from the course about
+# page instead of showing an error message. After successful login redirects them back to the course about page.
+REDIRECT_UNAUTHENTICATED_USER_TO_LOGIN_ON_ENROLL = False
+
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews
 COURSE_REVIEWS_TOOL_PROVIDER_FRAGMENT_NAME = 'coursetalk-reviews-fragment.html'
 COURSE_REVIEWS_TOOL_PROVIDER_PLATFORM_KEY = 'edx'

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -40,9 +40,13 @@ from six import string_types
           location.href = xhr.responseText;
         }
       } else if (xhr.status == 403) {
-        $('#register_error').text(
-            (xhr.responseText ? xhr.responseText : "${_("An error has occurred. Please ensure that you are logged in to enroll.") | n, js_escaped_string}")
-        ).css("display", "block");
+        %if settings.REDIRECT_UNAUTHENTICATED_USER_TO_LOGIN_ON_ENROLL:
+          location.replace("${reverse('signin_user') | n, js_escaped_string}?next=${request.path | u}");
+        %else:
+          $('#register_error').text(
+              (xhr.responseText ? xhr.responseText : "${_("An error has occurred. Please ensure that you are logged in to enroll.") | n, js_escaped_string}")
+          ).css("display", "block");
+        %endif
       } else {
         $('#register_error').text(
             (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.") | n, js_escaped_string}")


### PR DESCRIPTION
Adds toggle REDIRECT_UNAUTHENTICATED_USER_TO_LOGIN_ON_ENROLL
for enrollment behaviour for unauthenticated user.
If true, the user will be redirected to 'signin_user' route.

**JIRA Tickets** [BB-3954](https://tasks.opencraft.com/browse/BB-3954)

**Testing Instructions**

1. Checkout to this branch in your `juniper` devstack.
2. Attach to `lms` shell using `make lms-shell`.
3. Edit `/edx/etc/lms.yml` and add `REDIRECT_UNAUTHENTICATED_USER_TO_LOGIN_ON_ENROLL: true`
4. Restart lms using `make lms-restart`
5. Visit about page for Demo course on LMS
6. Make sure you are unauthenticated.
7. Click 'Enroll Now'
8. Verify that the page redirects to login page.
9. Login with audit user.
10. Verify that the user is redirected to Demo course about page.