### PR TITLE
[SE-4101] address VisibleBlocks caching race condition

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -18,7 +18,7 @@ from hashlib import sha1
 import six
 from django.apps import apps
 from django.contrib.auth.models import User
-from django.db import models
+from django.db import models, IntegrityError
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now
 from lazy import lazy
@@ -212,16 +212,39 @@ class VisibleBlocks(models.Model):
         for the block records' course with the new VisibleBlocks.
         Returns the newly created visible blocks.
         """
-        created = cls.objects.bulk_create([
+        visual_blocks = [
             VisibleBlocks(
                 blocks_json=brl.json_value,
                 hashed=brl.hash_value,
                 course_id=course_key,
             )
             for brl in block_record_lists
-        ])
-        cls._update_cache(user_id, course_key, created)
-        return created
+        ]
+
+        created_visual_blocks = []
+        existing_visual_blocks = []
+
+        try:
+            # Try to bulk create the blocks assuming all blocks are new
+            created_visual_blocks = cls.objects.bulk_create(visual_blocks)
+        except IntegrityError:
+            # Try to create blocks one by one and mark newly created blocks
+            for visual_block in visual_blocks:
+                existing_blocks = cls.objects.filter(hashed=visual_block.hashed)
+
+                if existing_blocks.exists():
+                    # As only one record has a matching hash it is safe to use first
+                    existing_visual_blocks.append(existing_blocks.first())
+                else:
+                    # Create the visual block and add mark as newly created
+                    visual_block.save()
+                    created_visual_blocks.append(visual_block)
+
+        # Update the cache with the conjunction of created and existing blocks
+        cls._update_cache(user_id, course_key, existing_visual_blocks + created_visual_blocks)
+
+        # Return the new visual blocks
+        return created_visual_blocks
 
     @classmethod
     def bulk_get_or_create(cls, user_id, course_key, block_record_lists):


### PR DESCRIPTION
This PR is trying to address a hard-to-reproduce VisibleBlocks per-user caching issue in which case bulk create results an IntegrityError, though it shouldn't

**Discussions**: [Forum post](https://discuss.openedx.org/t/need-information-about-persistent-grades/1412/7?u=gabor)

**Dependencies**: None

N/A

**Sandbox URL**: TBD

**Merge deadline**: None

**Testing instructions**:

1. TBD

**Author notes and concerns**:

1. The issue is really hard to reproduce as it is based on a possible race condition

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD