### PR TITLE
[SE-4305] Reordering tabs not working in Koa

### DIFF
--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -35,7 +35,6 @@ class CoursewareTab(EnrolledTab):
     """
     type = 'courseware'
     title = ugettext_noop('Course')
-    priority = 10
     view_name = 'courseware'
     is_movable = False
     is_default = False
@@ -70,7 +69,6 @@ class CourseInfoTab(CourseTab):
     """
     type = 'course_info'
     title = ugettext_noop('Home')
-    priority = 20
     view_name = 'info'
     tab_id = 'info'
     is_movable = False
@@ -87,7 +85,6 @@ class SyllabusTab(EnrolledTab):
     """
     type = 'syllabus'
     title = ugettext_noop('Syllabus')
-    priority = 30
     view_name = 'syllabus'
     allow_multiple = True
     is_default = False
@@ -105,7 +102,6 @@ class ProgressTab(EnrolledTab):
     """
     type = 'progress'
     title = ugettext_noop('Progress')
-    priority = 40
     view_name = 'progress'
     is_hideable = True
     is_default = False
@@ -319,7 +315,7 @@ class DatesTab(EnrolledTab):
     type = "dates"
     title = ugettext_noop(
         "Dates")  # We don't have the user in this context, so we don't want to translate it at this level.
-    priority = 50
+    # priority = 50
     view_name = "dates"
     is_dynamic = True
 

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -315,7 +315,6 @@ class DatesTab(EnrolledTab):
     type = "dates"
     title = ugettext_noop(
         "Dates")  # We don't have the user in this context, so we don't want to translate it at this level.
-    # priority = 50
     view_name = "dates"
     is_dynamic = True
 

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -35,6 +35,7 @@ class CoursewareTab(EnrolledTab):
     """
     type = 'courseware'
     title = ugettext_noop('Course')
+    priority = 10
     view_name = 'courseware'
     is_movable = False
     is_default = False
@@ -69,6 +70,7 @@ class CourseInfoTab(CourseTab):
     """
     type = 'course_info'
     title = ugettext_noop('Home')
+    priority = 20
     view_name = 'info'
     tab_id = 'info'
     is_movable = False


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

In this PR I removed static tabs priority, to [make this reordering function](https://github.com/open-craft/edx-platform/blob/esme-oxford-release/koa.2a/lms/djangoapps/courseware/tabs.py#L383) works correctly

While we had default `priority` attribute set for `ProgressTab` `CoursewareTab`

[get_course_tab_list()](https://github.com/open-craft/edx-platform/blob/esme-oxford-release/koa.2a/lms/djangoapps/courseware/tabs.py#L383) returned incorrect order.

Issue is starting from this line where we get all dynamic tabs:

`course_tab_list += _get_dynamic_tabs(course, user)` we are getting correct order. 
For example:
`[[10, 'Course'], [inf, 'New Page'], [inf, 'Test'], [inf, 'Discussion'], [inf, 'Wiki'], [40, 'Progress'], [inf, 'Instructor']]`

But after doing sorting next time(for correctly sort static tabs as wee see in [comment here](https://github.com/open-craft/edx-platform/blob/esme-oxford-release/koa.2a/lms/djangoapps/courseware/tabs.py#L383)), we receive this:

`[[10, 'Course'], [40, 'Progress'], [inf, 'New Page'], [inf, 'Test'], [inf, 'Discussion'], [inf, 'Wiki'], [inf, 'Instructor']]`



## Supporting information

Jira Issue: [SE-4305](https://tasks.opencraft.com/browse/SE-4305)

## Testing instructions

- Go to studio -> Select Demo Course
- On navigation Panel select Content -> Pages (`/tabs/course-v1:edX+DemoX+Demo_Course`)
- Create new pages and order them with default pages.
More information here [Reordering pages](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_assets/pages.html#reorder-the-pages)  

![Screenshot 2021-04-02 at 16 50 19](https://user-images.githubusercontent.com/3278913/113421306-898c7c00-93d3-11eb-8013-6cc479859ec1.png)

- Now visit LMS Demo course (`/courses/course-v1:edX+DemoX+Demo_Course/course/`)
- And check page order

![Screenshot 2021-04-02 at 16 51 08](https://user-images.githubusercontent.com/3278913/113421414-be98ce80-93d3-11eb-8984-c151f3e006f3.png)



## Deadline

ASAP

## Other information

-
