### PR TITLE
[SE-3248] Revert `progress_video` event changes

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/completion_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/completion_spec.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
     describe('VideoPlayer completion', function() {
-        var state, oldOTBD, completionAjaxCall, time;
+        var state, oldOTBD, completionAjaxCall;
 
         beforeEach(function() {
             oldOTBD = window.onTouchBasedDevice;
@@ -66,36 +66,6 @@
             spyOn(state.completionHandler, 'markCompletion').and.callThrough();
             state.el.trigger('ended');
             expect(state.completionHandler.markCompletion).toHaveBeenCalled();
-        });
-
-        it('triggers progress', function(done) {
-            var duration = 0;
-            jasmine.waitUntil(function() {
-                duration = state.videoPlayer.duration();
-                return duration > 0;
-            }).then(function() {
-                spyOn(state.completionHandler, 'computeProgress').and.callThrough();
-                spyOn(state.completionHandler, 'triggerProgress').and.callThrough();
-                // 4 percents should be equivalent to 0
-                time = 4 * duration / 100;
-                state.el.trigger('timeupdate', time);
-                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
-                expect(state.completionHandler.triggerProgress).toHaveBeenCalled();
-                state.completionHandler.computeProgress.calls.reset();
-                state.completionHandler.triggerProgress.calls.reset();
-                // 8 percents should be equivalent to 5
-                time = 8 * duration / 100;
-                state.el.trigger('timeupdate', time);
-                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
-                expect(state.completionHandler.triggerProgress).toHaveBeenCalled();
-                state.completionHandler.computeProgress.calls.reset();
-                state.completionHandler.triggerProgress.calls.reset();
-                // Another timeupdate in the same 5-range should not trigger "triggerProgress"
-                time = 9 * duration / 100;
-                state.el.trigger('timeupdate', time);
-                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
-                expect(state.completionHandler.triggerProgress).not.toHaveBeenCalled();
-            }).always(done);
         });
     });
 }).call(this);

--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -59,16 +59,6 @@ import '../helper.js'
             expect(state.videoEventsPlugin.emitPlayVideoEvent).toBeTruthy();
         });
 
-        it('can emit "progress_video" event', function() {
-            state.el.trigger('progress', [10]);
-            expect(Logger.log).toHaveBeenCalledWith('progress_video', {
-                id: 'id',
-                code: this.code,
-                percentage: 10,
-                duration: this.duration
-            });
-        });
-
         it('can emit "speed_change_video" event', function() {
             state.el.trigger('speedchange', ['2.0', '1.0']);
             expect(Logger.log).toHaveBeenCalledWith('speed_change_video', {
@@ -214,7 +204,6 @@ import '../helper.js'
                 skip: plugin.onSkip,
                 speedchange: plugin.onSpeedChange,
                 autoadvancechange: plugin.onAutoAdvanceChange,
-                progress: plugin.onProgress,
                 'language_menu:show': plugin.onShowLanguageMenu,
                 'language_menu:hide': plugin.onHideLanguageMenu,
                 'transcript:show': plugin.onShowTranscript,

--- a/common/lib/xmodule/xmodule/js/src/video/09_completion.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_completion.js
@@ -42,7 +42,6 @@
                 // the beginning of the video, except for lastSentTime, which refers to a
                 // timestamp in seconds since the Unix epoch.
                 this.lastSentTime = undefined;
-                this.lastProgressPercentage = undefined;
                 this.isComplete = false;
                 this.completionPercentage = this.state.config.completionPercentage;
                 this.startTime = this.state.config.startTime;
@@ -103,18 +102,13 @@
 
             /** Handler to call when a timeupdate event is triggered */
             handleTimeUpdate: function(currentTime) {
-                var duration = this.state.videoPlayer.duration();
+                var duration;
                 if (this.isComplete) {
                     return;
                 }
                 if (this.lastSentTime !== undefined && currentTime - this.lastSentTime < this.repostDelaySeconds()) {
                     // Throttle attempts to submit in case of network issues
                     return;
-                }
-
-                // Duration may not be available at initialization time
-                if (duration) {
-                    this.computeProgress(currentTime, duration);
                 }
 
                 if (this.completeAfterTime === undefined) {
@@ -131,25 +125,6 @@
                 if (currentTime > this.completeAfterTime) {
                     this.markCompletion(currentTime);
                 }
-            },
-
-            /** Compute current video progression and trigger event if needed */
-            computeProgress: function(currentTime, duration) {
-                // Compute current progress percentage
-                var currentProgressPercentage = Math.floor(currentTime * 100 / duration / 5) * 5;
-                // Check if last "lastProgressPercentage" and current percentage are in the same 5-range
-                var newRange = currentProgressPercentage > this.lastProgressPercentage;
-                // If no previous "lastProgressPercentage" or different 5-range, trigger the event
-                if (this.lastProgressPercentage === undefined || newRange) {
-                    this.triggerProgress(Math.floor(currentProgressPercentage));
-                    // Save the lastProgressPercentage value
-                    this.lastProgressPercentage = currentProgressPercentage;
-                }
-            },
-
-            /** Trigger progress event */
-            triggerProgress: function(percentage) {
-                this.state.el.trigger('progress', [percentage]);
             },
 
             /** Submit completion to the LMS */

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -15,8 +15,7 @@
                 return new EventsPlugin(state, i18n, options);
             }
 
-            // eslint-disable-next-line no-undef
-            _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onEnded', 'onSeek', 'onProgress',
+            _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onEnded', 'onSeek',
             'onSpeedChange', 'onAutoAdvanceChange', 'onShowLanguageMenu', 'onHideLanguageMenu',
             'onSkip', 'onShowTranscript', 'onHideTranscript', 'onShowCaptions', 'onHideCaptions',
             'destroy');
@@ -47,7 +46,6 @@
                     skip: this.onSkip,
                     speedchange: this.onSpeedChange,
                     autoadvancechange: this.onAutoAdvanceChange,
-                    progress: this.onProgress,
                     'language_menu:show': this.onShowLanguageMenu,
                     'language_menu:hide': this.onHideLanguageMenu,
                     'transcript:show': this.onShowTranscript,
@@ -136,10 +134,6 @@
 
             onHideCaptions: function() {
                 this.log('edx.video.closed_captions.hidden', {current_time: this.getCurrentTime()});
-            },
-
-            onProgress: function(event, percentage) {
-                this.log('progress_video', {percentage: percentage});
             },
 
             getCurrentTime: function() {


### PR DESCRIPTION
This pull request is about reverting #256 and #266 since we won't merge those into `upstream` (https://github.com/edx/edx-platform/pull/25038).

**Jira ticket**: [SE-3248](https://tasks.opencraft.com/browse/SE-3248)

**Testing instructions**: Manually check that the changes have been reverted by doing a diff.

**Reviewers**: @nizarmah 