### PR TITLE
Query Site Configuration Language When Rendering Datetimes

### DIFF
--- a/lms/djangoapps/courseware/context_processor.py
+++ b/lms/djangoapps/courseware/context_processor.py
@@ -8,6 +8,7 @@ to the templates without having to append every view file.
 from openedx.core.djangoapps.user_api.errors import UserAPIInternalError, UserNotFound
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 from openedx.core.lib.cache_utils import get_cache
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 RETRIEVABLE_PREFERENCES = {
     'user_timezone': 'time_zone',
@@ -41,6 +42,9 @@ def user_timezone_locale_prefs(request):
                     key: user_preferences.get(pref_name, None)
                     for key, pref_name in RETRIEVABLE_PREFERENCES.iteritems()
                 }
+            language = configuration_helpers.get_value('LANGUAGE_CODE', None)
+            if language:
+                user_prefs['user_language'] = language
 
         cached_value.update(user_prefs)
     return cached_value


### PR DESCRIPTION
We noted that when using the Site Configuration language customizations, course ending dates on the dashboard were not translated. These bypass the [DarkLangMiddleware where we have the other customizations which select language from the SiteConfiguration](https://github.com/open-craft/edx-platform/blob/6ff823abf27a8fb733532403456a7448bac780d8/openedx/core/djangoapps/dark_lang/middleware.py#L84).

**JIRA tickets**: Implements BB-3977

**Discussions**:  Issue discussed primarily on slack with client.

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. Add a [DarkLangConfig in the devstack](http://localhost:18000/admin/dark_lang/darklangconfig/) for a language other than English which has dates sufficiently different from English ("ar", "ja", or "zh_CN" are good candidates)
2. Set `"LANGUAGE_CODE": "ar"` to match the language set above in [the SiteConfiguration](http://localhost:18000/admin/site_configuration/siteconfiguration/1/change/)
3. Check the course end dates on the dashboard to see that they're translated correctly. 
4. Check again versus the base branch to see that course date ends are not translated correctly without this branch.

**Author notes and concerns**:

1. This isn't directly related to work in BB-3977 but was noted while testing that work.

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)