### PR TITLE
fix: Produce grade report when subsections have future start dates

### DIFF
--- a/lms/djangoapps/grades/course_grade.py
+++ b/lms/djangoapps/grades/course_grade.py
@@ -60,7 +60,10 @@ class CourseGradeBase:
         grade doesn't exist then either the user does not have access to
         it or hasn't attempted any problems in the subsection.
         """
-        return self._get_subsection_grade(self.course_data.effective_structure[subsection_key])
+        if subsection_key in self.course_data.effective_structure:
+            return self._get_subsection_grade(self.course_data.effective_structure[subsection_key])
+        # if the user cannot access the subsection, the grade must be zero
+        return ZeroSubsectionGrade(self.course_data.collected_structure[subsection_key], self.course_data)
 
     @lazy
     def graded_subsections_by_format(self):

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1760,9 +1760,8 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
     def test_grade_report(self, persistent_grades_enabled):
         self.submit_student_answer(self.student.username, 'Problem1', ['Option 1'])
 
-        with patch(
-            'lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'
-        ), patch.dict(settings.FEATURES, {'PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS': persistent_grades_enabled}):
+        with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'), \
+             patch.dict(settings.FEATURES, {'PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS': persistent_grades_enabled}):
             result = CourseGradeReport.generate(None, None, self.course.id, None, 'graded')
             self.assertDictContainsSubset(
                 {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0},
@@ -1854,12 +1853,12 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
     def test_fast_generation(self, create_non_zero_grade):
         if create_non_zero_grade:
             self.submit_student_answer(self.student.username, 'Problem1', ['Option 1'])
-        with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
-            with patch('lms.djangoapps.grades.course_data.get_course_blocks') as mock_course_blocks:
-                with patch('lms.djangoapps.grades.subsection_grade.get_score') as mock_get_score:
-                    CourseGradeReport.generate(None, None, self.course.id, None, 'graded')
-                    assert not mock_get_score.called
-                    assert not mock_course_blocks.called
+        with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'), \
+             patch('lms.djangoapps.grades.course_data.get_course_blocks') as mock_course_blocks, \
+             patch('lms.djangoapps.grades.subsection_grade.get_score') as mock_get_score:
+            CourseGradeReport.generate(None, None, self.course.id, None, 'graded')
+            assert not mock_course_blocks.called
+            assert not mock_get_score.called
 
 
 @ddt.ddt


### PR DESCRIPTION
When getting a subsection grade for a user, instead of failing
if the user can't access that subsection, assume the grade is zero.

This addresses one of my main concerns with the grading code so far, which is that `CourseData.effective_structure` returns different results depending on what methods were called before.
I would prefer that `effective_structure` is never used, but the "fast" test case makes an assertion that makes that impossible.