### PR TITLE
FAL-867 Revert "Unhide student-generated certificates toggle"

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -50,6 +50,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         % endif
     </div>
 
+    % if not section_data['is_self_paced']:
     <hr />
 
     <div class="enable-certificates">
@@ -71,6 +72,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
             <button class="is-disabled" disabled>${_('Enable Student-Generated Certificates')}</button>
         % endif
     </div>
+    % endif
 
     % if section_data['instructor_generation_enabled'] and not (section_data['enabled_for_course'] and section_data['html_cert_enabled']):
     <hr class="section-divider" />


### PR DESCRIPTION
This reverts commit 8910ccfb7521e3a1fde00da1c4b286ee9fd96fcb ( https://github.com/open-craft/edx-platform/pull/219 ).

Our clients are no longer using this feature, and edX won't accept this
upstream as-is currently.  See https://github.com/edx/edx-platform/pull/23735 for more information.

Reverting to reduce code drift from upstream.

**Test instructions**:

- verify that this cleanly reverts https://github.com/open-craft/edx-platform/pull/219

**Reviewers**:

- [ ] @pomegranited 