### PR TITLE
fix: pin setuptools version [BB-4212]

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -32,3 +32,5 @@ singledispatch==3.4.0.3
 six==1.11.0
 sympy==0.7.1
 tornado==5.1.1            # via matplotlib
+
+setuptools==44.1.1  # 45.0.0 is installed by default, but it requires Python>=3.5

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -247,3 +247,5 @@ xblock-review==1.1.5
 xblock-utils==1.2.0
 xblock==1.2.2
 zendesk==1.1.1
+
+setuptools==44.1.1  # 45.0.0 is installed by default, but it requires Python>=3.5


### PR DESCRIPTION
45.0.0 is installed by default, but it requires Python>=3.5.