### PR TITLE
[SE-4482] Allow delete course content in Studio only for admin users

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -56,3 +56,15 @@ REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = WaffleFlag(
     flag_name='library_authoring_mfe',
     module_name=__name__,
 )
+
+# .. toggle_name: studio.prevent_staff_structure_deletion
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Prevents staff from deleting course structures
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2021-06-25
+PREVENT_STAFF_STRUCTURE_DELETION = WaffleFlag(
+    waffle_flags(),
+    'prevent_staff_structure_deletion',
+    module_name=__name__,
+)

--- a/cms/djangoapps/contentstore/permissions.py
+++ b/cms/djangoapps/contentstore/permissions.py
@@ -1,0 +1,10 @@
+"""
+Permission definitions for the contentstore djangoapp
+"""
+
+from bridgekeeper import perms
+
+from lms.djangoapps.courseware.rules import HasRolesRule
+
+DELETE_COURSE_CONTENT = 'contentstore.delete_course_content'
+perms[DELETE_COURSE_CONTENT] = HasRolesRule('instructor')

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -31,7 +31,7 @@ from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Scope
 
-from cms.djangoapps.contentstore.config.waffle import SHOW_REVIEW_RULES_FLAG
+from cms.djangoapps.contentstore.config.waffle import PREVENT_STAFF_STRUCTURE_DELETION, SHOW_REVIEW_RULES_FLAG
 from cms.djangoapps.contentstore.permissions import DELETE_COURSE_CONTENT
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.djangoapps.xblock_config.models import CourseEditLTIFieldsEnabledFlag
@@ -1338,10 +1338,9 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             else:
                 xblock_info['staff_only_message'] = False
 
-            if user is not None:
+            xblock_info['show_delete_button'] = True
+            if user is not None and PREVENT_STAFF_STRUCTURE_DELETION.is_enabled():
                 xblock_info['show_delete_button'] = user.has_perm(DELETE_COURSE_CONTENT, xblock)
-            else:
-                xblock_info['show_delete_button'] = False
 
             xblock_info['has_partition_group_components'] = has_children_visible_to_specific_partition_groups(
                 xblock

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -32,6 +32,7 @@ from xblock.core import XBlock
 from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.config.waffle import SHOW_REVIEW_RULES_FLAG
+from cms.djangoapps.contentstore.permissions import DELETE_COURSE_CONTENT
 from cms.djangoapps.models.settings.course_grading import CourseGradingModel
 from cms.djangoapps.xblock_config.models import CourseEditLTIFieldsEnabledFlag
 from cms.lib.xblock.authoring_mixin import VISIBILITY_VIEW
@@ -1336,6 +1337,11 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
                 )
             else:
                 xblock_info['staff_only_message'] = False
+
+            if user is not None:
+                xblock_info['show_delete_button'] = user.has_perm(DELETE_COURSE_CONTENT, xblock)
+            else:
+                xblock_info['show_delete_button'] = False
 
             xblock_info['has_partition_group_components'] = has_children_visible_to_specific_partition_groups(
                 xblock

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -36,6 +36,7 @@ from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from cms.djangoapps.contentstore.views import item as item_module
 from lms.djangoapps.lms_xblock.mixin import NONSENSICAL_ACCESS_RESTRICTION
+from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.xblock_django.models import (
     XBlockConfiguration, XBlockStudioConfiguration, XBlockStudioConfigurationFlag
@@ -3369,3 +3370,37 @@ class TestXBlockPublishingInfo(ItemTest):
         # Check that in self paced course content has live state now
         xblock_info = self._get_xblock_info(chapter.location)
         self._verify_visibility_state(xblock_info, VisibilityState.live)
+
+    def test_staff_show_delte_button(self):
+        """
+        Test delete button is *not visible* to user with CourseStaffRole
+        """
+        # add user as course staff
+        CourseStaffRole(self.course_key).add_users(self.user)
+
+        # Get xblock outline
+        xblock_info = create_xblock_info(
+            self.course,
+            include_child_info=True,
+            course_outline=True,
+            include_children_predicate=lambda xblock: not xblock.category == 'vertical',
+            user=self.user
+        )
+        self.assertFalse(xblock_info['show_delete_button'])
+
+    def test_instructor_show_delete_button(self):
+        """
+        Test delete button is *visible* to user with CourseCreatorRole only
+        """
+        # add user as course instructor
+        CourseInstructorRole(self.course_key).add_users(self.user)
+
+        # Get xblock outline
+        xblock_info = create_xblock_info(
+            self.course,
+            include_child_info=True,
+            course_outline=True,
+            include_children_predicate=lambda xblock: not xblock.category == 'vertical',
+            user=self.user
+        )
+        self.assertTrue(xblock_info['show_delete_button'])

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -40,7 +40,8 @@ describe('CourseOutlinePage', function() {
             user_partitions: [],
             user_partition_info: {},
             highlights_enabled: true,
-            highlights_enabled_for_messaging: false
+            highlights_enabled_for_messaging: false,
+            show_delete_button: true
         }, options, {child_info: {children: children}});
     };
 
@@ -92,7 +93,8 @@ describe('CourseOutlinePage', function() {
             group_access: {},
             user_partition_info: {},
             highlights: [],
-            highlights_enabled: true
+            highlights_enabled: true,
+            show_delete_button: true
         }, options, {child_info: {children: children}});
     };
 
@@ -122,7 +124,8 @@ describe('CourseOutlinePage', function() {
             },
             user_partitions: [],
             group_access: {},
-            user_partition_info: {}
+            user_partition_info: {},
+            show_delete_button: true
         }, options, {child_info: {children: children}});
     };
 

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -68,7 +68,8 @@ describe('CourseOutlinePage', function() {
             show_review_rules: true,
             user_partition_info: {},
             highlights_enabled: true,
-            highlights_enabled_for_messaging: false
+            highlights_enabled_for_messaging: false,
+            show_delete_button: true
         }, options, {child_info: {children: children}});
     };
 
@@ -143,7 +144,8 @@ describe('CourseOutlinePage', function() {
             edited_by: 'MockUser',
             user_partitions: [],
             group_access: {},
-            user_partition_info: {}
+            user_partition_info: {},
+            show_delete_button: true
         }, options);
     };
 

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -871,6 +871,13 @@ describe('CourseOutlinePage', function() {
             expect(outlinePage.$('[data-locator="mock-section-2"]')).toExist();
         });
 
+        it('remains un-visible if show_delete_button is false ', function() {
+            createCourseOutlinePage(this, createMockCourseJSON({show_delete_button: false}, [
+                createMockSectionJSON({show_delete_button: false})
+            ]));
+            expect(getItemHeaders('section').find('.delete-button').first()).not.toExist();
+        });
+
         it('can be deleted if it is the only section', function() {
             var promptSpy = EditHelpers.createPromptSpy();
             createCourseOutlinePage(this, mockSingleSectionCourseJSON);

--- a/cms/static/js/views/xblock_outline.js
+++ b/cms/static/js/views/xblock_outline.js
@@ -109,7 +109,8 @@ define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'common/js/compo
                     includesChildren: this.shouldRenderChildren(),
                     hasExplicitStaffLock: this.model.get('has_explicit_staff_lock'),
                     staffOnlyMessage: this.model.get('staff_only_message'),
-                    course: course
+                    course: course,
+                    showDeleteButton: this.model.get('show_delete_button')
                 };
             },
 

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -161,7 +161,7 @@ if (is_proctored_exam) {
                         </a>
                     </li>
                 <% } %>
-                <% if (xblockInfo.isDeletable()) { %>
+                <% if (xblockInfo.isDeletable() && showDeleteButton) { %>
                     <li class="action-item action-delete">
                         <a href="#" data-tooltip="<%- gettext('Delete') %>" class="delete-button action-button">
                             <span class="icon fa fa-trash-o" aria-hidden="true"></span>


### PR DESCRIPTION
## Description

This PR and a check to show/hide the delete button on the course content in Studio. With these changes, the delete button is only visible to the admin user one with the `CourseInstructor`  role only and will not be visible to the  `CourseStaff`  role users.

Course Outline view for the user when it has *admin* access to the course
![admin_role_user_page_view](https://user-images.githubusercontent.com/15611967/120972898-e0278500-c78b-11eb-8a96-47a6d613536e.png)

Course Outline view for the user when it has *staff* access to the course
![staff_role_user_page_view](https://user-images.githubusercontent.com/15611967/120973072-1533d780-c78c-11eb-9400-b9101db08a64.png)


## Supporting information
JIRA Ticket: [SE-4482](https://tasks.opencraft.com/browse/SE-4482)

## Testing instructions
FYI: This testing instruction is for the sandbox deployed against this [PR](https://github.com/open-craft/edx-platform/pull/360)
- Login with `staff@example.com`  on `https://studio.pr360.sandbox.opencraft.hosting/`. 
-  Go to the setting > Course team of the  *Demonstration Course* 
-  Add `verified@example.com` as the staff for the course
-  Login from the `verified@example.com` on the studio page
-  `verified@example.com` should not be able to see the delete button on the course outline page.

## Reviewers

- [ ] @nizarmah 
