### PR TITLE
[BB-4385] Prevent course details AJAX request from getting into browser history (backport)

### DIFF
--- a/cms/static/js/factories/settings.js
+++ b/cms/static/js/factories/settings.js
@@ -26,7 +26,8 @@ define([
                 });
                 editor.render();
             },
-            reset: true
+            reset: true,
+            cache: false
         });
     };
 });


### PR DESCRIPTION
Backport of https://github.com/edx/edx-platform/pull/27979 to `opencraft-release/koa.3`.

![Peek 2021-06-18 06-44](https://user-images.githubusercontent.com/18251194/122503232-c0505680-d000-11eb-83d0-337d042a586f.gif)

**JIRA tickets**:
- [BB-4385](https://tasks.opencraft.com/browse/BB-4385)

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

1. Using your local devstack, make the same action as shown on image from description and make sure that issue is resolved.

**Reviewers**
- [ ] @shimulch 