### PR TITLE
Revert "[FAL-1813] fix: codejail issue when using matplotlib"

### DIFF
--- a/common/lib/capa/capa/safe_exec/safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/safe_exec.py
@@ -21,14 +21,11 @@ import os
 os.environ["OPENBLAS_NUM_THREADS"] = "1"    # See TNL-6456
 
 import random2 as random_module
-from random import SystemRandom
 import sys
 from six.moves import xrange
 
 random = random_module.Random(%r)
 random.Random = random_module.Random
-# numpy needs SystemRandom
-random.SystemRandom = SystemRandom
 sys.modules['random'] = random
 """
 

--- a/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
@@ -387,20 +387,3 @@ class TestRealProblems(unittest.TestCase):
         g = {}
         safe_exec(code, g)
         self.assertIn("aVAP", g)
-
-    def test_matplot(self):
-        if not jail_code.is_configured("python"):
-            pytest.skip()
-        code = textwrap.dedent("""\
-            import matplotlib.pyplot as plt
-            import numpy as np
-
-            xpoints = np.array([0, 6])
-            ypoints = np.array([0, 250])
-
-            plt.plot(xpoints, ypoints)
-            plotted = plt.show()
-            """)
-        g = {}
-        safe_exec(code, g)
-        self.assertIn("plotted", g)

--- a/requirements/edx-sandbox/py35.in
+++ b/requirements/edx-sandbox/py35.in
@@ -15,14 +15,15 @@
 -c ../constraints.txt
 
 -r shared.txt                       # Dependencies in common with LMS and Studio
-chem                                # A helper library for chemistry calculations
+chem
 matplotlib==2.2.4                   # 2D plotting library
 networkx==2.2                       # Utilities for creating, manipulating, and studying network graphs
-openedx-calc<2.0.0                  # Helper library for mathematical calculations
+numpy==1.16.5                       # Numeric array processing utilities; used by scipy
+openedx-calc
 pyparsing==2.2.0                    # Python Parsing module
 random2                             # Implementation of random module that works identically under Python 2 and 3
 scipy==1.2.1                        # Math, science, and engineering library
-sympy==1.6.2                        # Symbolic math library
+sympy==1.4                          # Symbolic math library
 
 # Install these packages from the edx-platform working tree
 # NOTE: if you change code in these packages, you MUST change the version

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -6,31 +6,32 @@
 #
 common/lib/sandbox-packages  # via -r requirements/edx-sandbox/py35.in
 common/lib/symmath  # via -r requirements/edx-sandbox/py35.in
-cffi==1.14.5              # via -r requirements/edx-sandbox/shared.txt, cryptography
+cffi==1.14.3              # via -r requirements/edx-sandbox/shared.txt, cryptography
 chem==1.2.0               # via -r requirements/edx-sandbox/py35.in
 click==7.1.2              # via -r requirements/edx-sandbox/shared.txt, nltk
-cryptography==3.2.1       # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt
+cryptography==3.2.1       # via -r requirements/edx-sandbox/shared.txt
 cycler==0.10.0            # via matplotlib
-decorator==5.0.7          # via networkx
+decorator==4.4.2          # via networkx
 joblib==0.14.1            # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt, nltk
 kiwisolver==1.1.0         # via -c requirements/edx-sandbox/../constraints.txt, matplotlib
 lxml==4.5.0               # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt
 markupsafe==1.1.1         # via chem
 matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in
-mpmath==1.2.1             # via sympy
+mpmath==1.1.0             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
-nltk==3.6.1               # via -r requirements/edx-sandbox/shared.txt, chem
-numpy==1.20.2             # via chem, matplotlib, openedx-calc
+nltk==3.5                 # via -r requirements/edx-sandbox/shared.txt, chem
+numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
 python-dateutil==2.4.0    # via -c requirements/edx-sandbox/../constraints.txt, matplotlib
+pytz==2020.4              # via matplotlib
 random2==1.0.1            # via -r requirements/edx-sandbox/py35.in
-regex==2021.4.4           # via -r requirements/edx-sandbox/shared.txt, nltk
-scipy==1.2.1              # via -r requirements/edx-sandbox/py35.in, chem, openedx-calc
-six==1.15.0               # via -r requirements/edx-sandbox/shared.txt, chem, cryptography, cycler, openedx-calc, python-dateutil
-sympy==1.6.2              # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, symmath
-tqdm==4.60.0              # via -r requirements/edx-sandbox/shared.txt, nltk
+regex==2020.11.11         # via -r requirements/edx-sandbox/shared.txt, nltk
+scipy==1.2.1              # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, openedx-calc
+six==1.15.0               # via -r requirements/edx-sandbox/shared.txt, chem, cryptography, cycler, matplotlib, openedx-calc, python-dateutil
+sympy==1.4                # via -r requirements/edx-sandbox/py35.in, symmath
+tqdm==4.51.0              # via -r requirements/edx-sandbox/shared.txt, nltk
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Reverts open-craft/edx-platform#343

Upstream [pushed back on this change](https://github.com/edx/edx-platform/pull/27372#issuecomment-858506456), questioning how `matplotlib` could even be used in Python-Evaluated Input problems. We reached out to the client about this but got no answer, so reverting the change to prevent code drift in our release branches.

**Sandbox**

* LMS: https://pr365.sandbox.stage.opencraft.hosting/
* Studio: https://studio.pr365.sandbox.stage.opencraft.hosting/

**Author Notes & Concerns**

1. This shouldn't need an internal review, will merge when the sandbox provisions ok.