### PR TITLE
fix: prevent invalidation of allowlisted certificates [BB-4287]

### DIFF
--- a/lms/djangoapps/certificates/services.py
+++ b/lms/djangoapps/certificates/services.py
@@ -8,6 +8,7 @@ import logging
 from django.core.exceptions import ObjectDoesNotExist
 from opaque_keys.edx.keys import CourseKey
 
+from lms.djangoapps.certificates.models import CertificateWhitelist
 from lms.djangoapps.utils import _get_key
 
 from .models import GeneratedCertificate
@@ -25,6 +26,10 @@ class CertificateService(object):
         Invalidate the user certificate in a given course if it exists.
         """
         course_key = _get_key(course_key_or_id, CourseKey)
+        if CertificateWhitelist.objects.filter(user=user_id, course_id=course_key, whitelist=True).exists():
+            log.info(f'User {user_id} is on the allowlist for {course_key}. The certificate will not be invalidated.')
+            return False
+
         try:
             generated_certificate = GeneratedCertificate.objects.get(
                 user=user_id,

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -85,6 +85,10 @@ def _listen_for_failing_grade(sender, user, course_id, grade, **kwargs):  # pyli
     if it is currently passing,
     downstream signal from COURSE_GRADE_CHANGED
     """
+    if CertificateWhitelist.objects.filter(user=user, course_id=course_id, whitelist=True).exists():
+        log.info('{course_id} is using allowlist certificates, and the user {user_id} is on its allowlist. The '
+                 'failing grade will not affect the certificate.'.format(course_id=course_id, user_id=user.id))
+        return
     cert = GeneratedCertificate.certificate_for_student(user, course_id)
     if cert is not None:
         if CertificateStatuses.is_passing_status(cert.status):


### PR DESCRIPTION
The allowlisted certificates were getting invalidated upon visiting the Course Progress page by users.

This is a rough backport of the Lilac fix (edx#26356). In Lilac, this is gated by the `certificates_revamp.use_allowlist` Waffle flag. In post-Lilac branches, this is working out of the box (the flag has been removed in edx#27576).

**Note:** if you are using the Lilac release, you don't need these changes - you can get them by enabling the [certificates_revamp.use_allowlist](https://github.com/edx/edx-platform/blob/13d174fdda00e898c7af58551e63c70d69ba5c5a/lms/djangoapps/certificates/generation_handler.py#L34-L47) flag in [Django admin](http://localhost:18000/admin/waffle/flag/)

## Testing instructions
1. Add `FEATURES['CERTIFICATES_HTML_VIEW'] = True` to `{lms,cms}/envs/private.py`.
1. Add a "Verified" mode (set "price" to 1) to [Course Modes](http://localhost:18000/admin/course_modes/coursemode/add/), if it doesn't exist - it should already be on devstack.
1. Enable generating certificates [here](http://localhost:18000/admin/certificates/certificategenerationconfiguration/).
1. Go to [Manual verifications](http://localhost:18000/admin/verify_student/manualverification/) and add an entry for user `verified` with the status `approved`.
1. Go to [Waffle Switches](http://localhost:18000/admin/waffle/switch/) and add:
   1. `certificates.auto_certificate_generation`, marked as `Active`.
   1. `student.courseenrollment_admin`, marked as `Active`.
1. Go to [student enrollments](http://localhost:18000/admin/student/courseenrollment/) and change the enrollment mode of user `verified`: from `audit` to `verified`.
1. Go to [Advanced Settings](http://localhost:18010/settings/advanced/course-v1:edX+DemoX+Demo_Course) and set "Certificates Display Behavior" to "early_with_info".
1. Go to [Certificates](http://localhost:18010/certificates/course-v1:edX+DemoX+Demo_Course), set up a new certificate, and click the "Activate" button.
1. Go to [Instructor Dashboard/Certificates](http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-certificates).
1. Check `All users on the Exception list` and click the "Generate Exception Certificates" button (if the `verified@example.com` user is not in the list below the button, you should add it).
1. Log in as `verified@example.com`, visit the [dashboard](http://localhost:18000/dashboard), and use the "View Certificate" button (it should be under the course listing item).
1. Visit the [progress page](http://localhost:18000/courses/course-v1:certs3+certs3+certs3/progress) and use the "View Certificate" button (it should be above the progress graph).