### PR TITLE
[SE-4235] Update lti-consumer-xblock to new commit

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -19,6 +19,7 @@
 -e openedx/core/lib/xblock_builtin/xblock_discussion  # via -r requirements/edx/local.in
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive  # via -r requirements/edx/github.in
 -e common/lib/xmodule  # via -r requirements/edx/local.in
+-e git+https://github.com/open-craft/xblock-lti-consumer.git@a512a7cac78ca5365cc13a491d486d9ac4fb439c#egg=lti-consumer #via -r requirements/edx/base.in
 amqp==2.6.1               # via kombu
 analytics-python==1.2.9   # via -r requirements/edx/base.in
 aniso8601==8.0.0          # via edx-tincan-py35
@@ -174,7 +175,6 @@ pbr==5.5.1                # via -r requirements/edx/paver.txt, stevedore
 piexif==1.1.3             # via -r requirements/edx/base.in
 pillow==7.2.0             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise, edx-organizations
 polib==1.1.0              # via edx-i18n-tools
-lti-consumer-xblock==2.4  # via -r requirements/edx/testing.txt
 psutil==5.7.3             # via -r requirements/edx/paver.txt, edx-django-utils
 py2neo==3.1.2             # via -r requirements/edx/base.in
 pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -19,7 +19,7 @@
 -e openedx/core/lib/xblock_builtin/xblock_discussion  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive  # via -r requirements/edx/testing.txt
 -e common/lib/xmodule  # via -r requirements/edx/testing.txt
--e git+https://github.com/open-craft/xblock-lti-consumer.git@85f40a3999dfde57afef224c9cc0dcce431447f6#egg=lti-consumer #via -r requirements/edx/base.in
+-e git+https://github.com/open-craft/xblock-lti-consumer.git@a512a7cac78ca5365cc13a491d486d9ac4fb439c#egg=lti-consumer #via -r requirements/edx/base.in
 alabaster==0.7.12         # via sphinx
 amqp==2.6.1               # via -r requirements/edx/testing.txt, kombu
 analytics-python==1.2.9   # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -19,7 +19,7 @@
 -e openedx/core/lib/xblock_builtin/xblock_discussion  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive  # via -r requirements/edx/base.txt
 -e common/lib/xmodule  # via -r requirements/edx/base.txt
--e git+https://github.com/open-craft/xblock-lti-consumer.git@85f40a3999dfde57afef224c9cc0dcce431447f6#egg=lti-consumer #via -r requirements/edx/base.in
+-e git+https://github.com/open-craft/xblock-lti-consumer.git@a512a7cac78ca5365cc13a491d486d9ac4fb439c#egg=lti-consumer #via -r requirements/edx/base.in
 amqp==2.6.1               # via -r requirements/edx/base.txt, kombu
 analytics-python==1.2.9   # via -r requirements/edx/base.txt
 aniso8601==8.0.0          # via -r requirements/edx/base.txt, edx-tincan-py35


### PR DESCRIPTION
This PR updates the lti-consumer-xblock version to a [new branch](https://github.com/open-craft/xblock-lti-consumer/tree/opencraft-release/koa.3) in opencraft's fork of xblock-lti-consumer, that contains the backported fix from [edx/xblock-lti-consumer#150](https://github.com/edx/xblock-lti-consumer/pull/150).