### PR TITLE
[BB-4649] Fix duplicate Arabic month in course start date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9362,9 +9362,9 @@
       }
     },
     "moment": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
-      "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
       "version": "0.5.14",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jquery.scrollto": "2.1.2",
     "js-cookie": "2.2.0",
     "jwt-decode": "^2.2.0",
-    "moment": "2.19.3",
+    "moment": "2.29.1",
     "moment-timezone": "0.5.14",
     "node-sass": "4.12.0",
     "picturefill": "3.0.2",


### PR DESCRIPTION
## Description

This PR fixes duplicate Arabic month issue reported by NELP. The issue is due to our dependency on an old version of Moment JS. Relevant issues can be found on Moment JS [Github Issues](https://github.com/moment/moment/issues/4270).

## Supporting information

https://tasks.opencraft.com/browse/BB-4649

## Screenshots
Before this PR -
<img width="356" alt="Screenshot 2021-08-11 at 4 07 26 PM" src="https://user-images.githubusercontent.com/1010244/129012847-9ca2c26e-98b5-4844-b6fd-a16cacc0cb7f.png">

After this PR -
<img width="338" alt="Screenshot 2021-08-11 at 4 12 50 PM" src="https://user-images.githubusercontent.com/1010244/129012867-fba2c7f3-5d96-4936-b195-9d83ae4c1bcf.png">


## Testing instructions

1. Checkout this PR on your local devstack
2. Change language to `ar` from `/update_lang` in the LMS
3. Check course start dates on the course listing page are correct.

## Deadline

None

## Other information

**Reviewer**
- [x] @alfredchavez 