### PR TITLE
FAL-2248: Monkey-patch django db introspection to avoid performance issues

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -22,3 +22,28 @@ kombu.utils.entrypoints = lambda namespace: iter([])
 # that shared_task will use this app, and also ensures that the celery
 # singleton is always configured for the CMS.
 from .celery import APP as CELERY_APP
+
+# FAL-2248: Monkey patch django's get_storage_engine to work around long migrations times.
+# This fixes a performance issue with database migrations in Ocim. We will need to keep
+# this patch in our opencraft-release/* branches until edx-platform upgrades to Django 4.*
+# which will include this commit:
+# https://github.com/django/django/commit/518ce7a51f994fc0585d31c4553e2072bf816f76
+import django.db.backends.mysql.introspection
+
+def get_storage_engine(self, cursor, table_name):
+    """
+    This is a patched version of `get_storage_engine` that fixes a
+    performance issue with migrations. For more info see FAL-2248 and
+    https://github.com/django/django/pull/14766
+    """
+    cursor.execute("""
+        SELECT engine
+        FROM information_schema.tables
+        WHERE table_name = %s
+            AND table_schema = DATABASE()""", [table_name])
+    result = cursor.fetchone()
+    if not result:
+        return self.connection.features._mysql_storage_engine
+    return result[0]
+
+django.db.backends.mysql.introspection.DatabaseIntrospection.get_storage_engine = get_storage_engine

--- a/lms/__init__.py
+++ b/lms/__init__.py
@@ -18,3 +18,28 @@ kombu.utils.entrypoints = lambda namespace: iter([])
 # that shared_task will use this app, and also ensures that the celery
 # singleton is always configured for the LMS.
 from .celery import APP as CELERY_APP
+
+# FAL-2248: Monkey patch django's get_storage_engine to work around long migrations times.
+# This fixes a performance issue with database migrations in Ocim. We will need to keep
+# this patch in our opencraft-release/* branches until edx-platform upgrades to Django 4.*
+# which will include this commit:
+# https://github.com/django/django/commit/518ce7a51f994fc0585d31c4553e2072bf816f76
+import django.db.backends.mysql.introspection
+
+def get_storage_engine(self, cursor, table_name):
+    """
+    This is a patched version of `get_storage_engine` that fixes a
+    performance issue with migrations. For more info see FAL-2248 and
+    https://github.com/django/django/pull/14766
+    """
+    cursor.execute("""
+        SELECT engine
+        FROM information_schema.tables
+        WHERE table_name = %s
+            AND table_schema = DATABASE()""", [table_name])
+    result = cursor.fetchone()
+    if not result:
+        return self.connection.features._mysql_storage_engine
+    return result[0]
+
+django.db.backends.mysql.introspection.DatabaseIntrospection.get_storage_engine = get_storage_engine


### PR DESCRIPTION
**Description**

This pulls in a [django patch](https://github.com/django/django/pull/14766) which significantly reduces migration times for our instances hosted on Ocim.

Migrations take around 15 minutes with this patch applied.
Without the patch, they can take more than an hour, depending on the number of MySQL users in the database. We've even had Ocim hit the 2 hour timeout while running migrations in some cases.

See https://tasks.opencraft.com/browse/FAL-2248 for more info.

**Test instructions**:

1. Verify that [the sandbox](https://manage.opencraft.com/instance/29780/) was provisioned successfully.
2. Check the logs on [the appserver](https://manage.opencraft.com/instance/29780/edx-appserver/20394/) to verify that migrations took around 15 minutes and compare that time to some other Ocim instances.

**Sandbox**:
- https://manage.opencraft.com/instance/29780/