### PR TITLE
[SE-4682] Esme Custom Search

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -567,6 +567,8 @@ class CourseAboutSearchIndexer(object):
         AboutInfo("org", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
         AboutInfo("modes", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_MODE),
         AboutInfo("language", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("invitation_only", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
+        AboutInfo("catalog_visibility", AboutInfo.PROPERTY, AboutInfo.FROM_COURSE_PROPERTY),
     ]
 
     @classmethod

--- a/lms/djangoapps/esme_custom_search/apps.py
+++ b/lms/djangoapps/esme_custom_search/apps.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""
+App to add custom search filter for excluding invitation-only 
+and non-catalog courses
+"""
+
+
+from django.apps import AppConfig
+
+
+class EsmeCustomSearchConfig(AppConfig):
+    """
+    Application configuration for CustomSearch
+    """
+    name = 'lms.djangoapps.esme_custom_search'

--- a/lms/djangoapps/esme_custom_search/search.py
+++ b/lms/djangoapps/esme_custom_search/search.py
@@ -1,0 +1,9 @@
+from lms.lib.courseware_search.lms_filter_generator import LmsSearchFilterGenerator
+
+
+class EsmeCustomSearchFilterGenerator(LmsSearchFilterGenerator):
+    def exclude_dictionary(self, **kwargs):
+        exclude_dictionary = super().exclude_dictionary(**kwargs)
+        exclude_dictionary['invitation_only'] = True
+        exclude_dictionary['catalog_visibility'] = 'none'
+        return exclude_dictionary


### PR DESCRIPTION
## Description

The intention here is to remove invitation-only courses and the courses that shouldn't show in the catalog from search results.

This is achieved by :
- Including the `invitation-only` and `catalog-visibilty` fields in the indexed data
- Creating a custom SearchFilterGenerator to exclude results based on these fields

## Testing Instructions

**Sandbox**: [LMS](https://se-4682.opencraft.hosting/)

The sandbox has these features enabled:
`COURSES_ARE_BROWSABLE`
`ENABLE_COURSE_DISCOVERY`
`ENABLE_SEPARATE_ARCHIVED_COURSES`

It also has four courses with the following names, with their "invitation" and "catalog" settings matching their titles:
`Test - Doesn't show in Catalog - Needs Invitation`
`Test - Doesn't show in Catalog - Doesn't need Invitation`
`Test - Shows in Catalog - Needs Invitation`
`Test - Shows in Catalog - Doesn't need invitation`

By using the search term "test" in the course discovery page, you should only see the `Test - Shows in Catalog - Doesn't need invitation` course.

## Reviewers
- [ ] @nizarmah 