### PR TITLE
fix: xblock-poll's celery tasks were not registered (#28019)

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2280,6 +2280,12 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ################################# CELERY ######################################
 
+CELERY_IMPORTS = (
+    # Since xblock-poll is not a Django app, and XBlocks don't get auto-imported
+    # by celery workers, its tasks will not get auto-discovered:
+    'poll.tasks',
+)
+
 # Celery beat configuration
 
 CELERYBEAT_SCHEDULER = 'celery.beat:PersistentScheduler'


### PR DESCRIPTION
Pulled from https://github.com/edx/edx-platform/pull/28019

(cherry picked from commit e2a867e97564aeffbf47a0532da21cfeee2b0deb)

**Testing instructions**

TBD

**Reviewer**

- [ ] @eLRuLL 

