### PR TITLE
Added metadata field for video xblocks

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_xfields.py
+++ b/common/lib/xmodule/xmodule/video_module/video_xfields.py
@@ -23,6 +23,13 @@ class VideoFields(object):
         scope=Scope.settings
     )
 
+    metadata = String(
+        help=_("Meta data to be embeded in the component"),
+        display_name=_("Metadata"),
+        default="",
+        scope=Scope.settings
+    )
+
     saved_video_position = RelativeTime(
         help=_("Current position in the video."),
         scope=Scope.user_state,


### PR DESCRIPTION
This adds an additional field to video xblocks, a field called metadata, where any information related to the component can be used by admin/course-creators.

**JIRA tickets**: [BB-4651](https://tasks.opencraft.com/browse/BB-4651)

~~**Discussions**: Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.~~

~~**Dependencies**: None~~

**Screenshots**: 

![image](https://user-images.githubusercontent.com/7670449/131246686-614b0d26-2c1a-40f3-8762-08f997ed7c60.png)



**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" if there's no rush, "ASAP" if it's critical, or provide a specific date if there is one.

**Testing instructions**:

1.  This pr is based on Koa.3
2. So make sure to have a koa.3 devstack up and running,
3. In the edx-platform repository pull the branch
4. Run `make dev.restart-devserver.studio`
5. Login to lms at port 18000 and then visit http://localhost:18010
6. Edit the demo course and add another unit, in the new unit add video xblocks
7. Click on Edit on the top and switch to `Advance` tab
8. Here you can add any data

**Author notes and concerns**:

None

**Reviewers**
- [ ]  @shimulch 
