### PR TITLE
Revert "[FAL-2030] Updates kombu package to support multi-tenant redi…

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -412,7 +412,6 @@ BROKER_USE_SSL = ENV_TOKENS.get('CELERY_BROKER_USE_SSL', False)
 BROKER_TRANSPORT_OPTIONS = {
     'fanout_patterns': True,
     'fanout_prefix': True,
-    **ENV_TOKENS.get('CELERY_BROKER_TRANSPORT_OPTIONS', {})
 }
 
 # Message expiry time in seconds

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -548,7 +548,6 @@ BROKER_USE_SSL = ENV_TOKENS.get('CELERY_BROKER_USE_SSL', False)
 BROKER_TRANSPORT_OPTIONS = {
     'fanout_patterns': True,
     'fanout_prefix': True,
-    **ENV_TOKENS.get('CELERY_BROKER_TRANSPORT_OPTIONS', {})
 }
 
 # Block Structures

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,13 +8,6 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# kombu needs additional functionality to support multi-tenant redis
-# This branch backports the following PRs to kombu 4.6.11, because celery 4.4.7 has requirement kombu<4.7,>=4.6.10
-# https://github.com/celery/kombu/pull/1351
-# https://github.com/celery/kombu/pull/1349
-# https://github.com/celery/kombu/pull/1376
-git+https://github.com/open-craft/kombu.git@v4.6.11.1#egg=kombu==4.6.11.1
-
 # celery 5.0 has dropped python3.5 support.
 celery<5.0
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -141,7 +141,7 @@ jmespath==0.10.0          # via boto3, botocore
 joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, nltk
 jsondiff==1.2.0           # via edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-celeryutils, edx-enterprise, edx-proctoring, edx-submissions, ora2
-git+https://github.com/open-craft/kombu.git@v4.6.11.1#egg=kombu==4.6.11.1 # via -c requirements/edx/../constraints.txt
+kombu==4.6.11             # via celery
 laboratory==1.0.2         # via -r requirements/edx/base.in
 lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, lti-consumer-xblock, ora2
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -169,7 +169,7 @@ joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requi
 jsondiff==1.2.0           # via -r requirements/edx/testing.txt, edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-celeryutils, edx-enterprise, edx-proctoring, edx-submissions, ora2
 jsonschema==3.2.0         # via sphinxcontrib-openapi
-git+https://github.com/open-craft/kombu.git@v4.6.11.1#egg=kombu==4.6.11.1 # via -c requirements/edx/../constraints.txt
+kombu==4.6.11             # via -r requirements/edx/testing.txt, celery
 laboratory==1.0.2         # via -r requirements/edx/testing.txt
 lazy-object-proxy==1.4.3  # via -r requirements/edx/testing.txt, astroid
 lazy==1.4                 # via -r requirements/edx/testing.txt, acid-xblock, bok-choy, lti-consumer-xblock, ora2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -163,7 +163,7 @@ jmespath==0.10.0          # via -r requirements/edx/base.txt, boto3, botocore
 joblib==0.14.1            # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, nltk
 jsondiff==1.2.0           # via -r requirements/edx/base.txt, edx-enterprise
 jsonfield2==3.0.3         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-celeryutils, edx-enterprise, edx-proctoring, edx-submissions, ora2
-git+https://github.com/open-craft/kombu.git@v4.6.11.1#egg=kombu==4.6.11.1 # via -c requirements/edx/../constraints.txt
+kombu==4.6.11             # via -r requirements/edx/base.txt, celery
 laboratory==1.0.2         # via -r requirements/edx/base.txt
 lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via -r requirements/edx/base.txt, acid-xblock, bok-choy, lti-consumer-xblock, ora2


### PR DESCRIPTION
…s authentication (#397)"

This reverts commit 04dbfa3610d23adac0050eea4b315d0d57bd9fe4.

## Description

The reason behind reverting the change is explained [here](https://github.com/edx/edx-platform/pull/28020#pullrequestreview-753038789).

In short, the celery workers are timing out, terminating, and restarting whenever used. This is also causing app servers to fail provisioning when attempting to import the demo course.

## Testing instructions

* Provision an app server for an instance using `opencraft-release/koa.3`. Make sure it has the 04dbfa3610d23adac0050eea4b315d0d57bd9fe4.
The app server should fail to provision by timing out at `TASK [demo : import demo course]`.
* Provision a new app server for the same instance using `nizar/revert-fal-2030`.
The app server should successfully provision. 