### PR TITLE
fix: update lti-consumer-xblock to 2.10.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -19,7 +19,7 @@
 -e openedx/core/lib/xblock_builtin/xblock_discussion  # via -r requirements/edx/local.in
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive  # via -r requirements/edx/github.in
 -e common/lib/xmodule  # via -r requirements/edx/local.in
--e git+https://github.com/open-craft/xblock-lti-consumer.git@a512a7cac78ca5365cc13a491d486d9ac4fb439c#egg=lti-consumer #via -r requirements/edx/base.in
+-e git+https://github.com/open-craft/xblock-lti-consumer.git@2.10.1-opencraft#egg=lti-consumer #via -r requirements/edx/base.in
 amqp==2.6.1               # via kombu
 analytics-python==1.2.9   # via -r requirements/edx/base.in
 aniso8601==8.0.0          # via edx-tincan-py35

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -19,7 +19,7 @@
 -e openedx/core/lib/xblock_builtin/xblock_discussion  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive  # via -r requirements/edx/testing.txt
 -e common/lib/xmodule  # via -r requirements/edx/testing.txt
--e git+https://github.com/open-craft/xblock-lti-consumer.git@a512a7cac78ca5365cc13a491d486d9ac4fb439c#egg=lti-consumer #via -r requirements/edx/base.in
+-e git+https://github.com/open-craft/xblock-lti-consumer.git@2.10.1-opencraft#egg=lti-consumer #via -r requirements/edx/base.in
 alabaster==0.7.12         # via sphinx
 amqp==2.6.1               # via -r requirements/edx/testing.txt, kombu
 analytics-python==1.2.9   # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -19,7 +19,7 @@
 -e openedx/core/lib/xblock_builtin/xblock_discussion  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive  # via -r requirements/edx/base.txt
 -e common/lib/xmodule  # via -r requirements/edx/base.txt
--e git+https://github.com/open-craft/xblock-lti-consumer.git@a512a7cac78ca5365cc13a491d486d9ac4fb439c#egg=lti-consumer #via -r requirements/edx/base.in
+-e git+https://github.com/open-craft/xblock-lti-consumer.git@2.10.1-opencraft#egg=lti-consumer #via -r requirements/edx/base.in
 amqp==2.6.1               # via -r requirements/edx/base.txt, kombu
 analytics-python==1.2.9   # via -r requirements/edx/base.txt
 aniso8601==8.0.0          # via -r requirements/edx/base.txt, edx-tincan-py35


### PR DESCRIPTION
### Description

The previous lti-consumer-xblock commit hash was pointing to a code drift branch which was backporting https://github.com/edx/xblock-lti-consumer/pull/150 to tag `2.4.0`

Unfortunately, `config_id` duplicate errors started showing for one of the clients. Accordingly, we had to update the xblock to the latest version which inculded that fix and still supported koa (`2.10.1`).

However, https://github.com/edx/xblock-lti-consumer/pull/150 was not merged until tag `3.0.3`. Thefore, we created a custom tag, `2.10.1-opencraft` which includes the backported change on top of tag `2.10.1`

### Important Links

* **Jira Ticket**: SE-4851
* **Sandbox**:
    * LMS: https://pr400.sandbox.stage.opencraft.hosting/
    * Studio: https://studio.pr400.sandbox.stage.opencraft.hosting/

### Testing Instructions

* [Compare `2.4.0-opencraft` against `2.4.0`](https://github.com/open-craft/xblock-lti-consumer/compare/2.4.0...open-craft:2.4.0-opencraft)
* [Compare `2.10.1-opencraft` against `2.10.1`](https://github.com/open-craft/xblock-lti-consumer/compare/2.10.1...open-craft:2.10.1-opencraft)
* Verify that only the additional code drift exists
* Test the LTI Consumer XBlock on the Sandbox Instance