### PR TITLE
fix: display right-to-left for rtl-languages in mobile

### DIFF
--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -339,10 +339,6 @@
 /*
   Mobile menu styling
 */
-.window-wrap[dir='rtl'] .mobile-menu {
-  @include text-align(right);
-}
-
 .mobile-menu {
   border-top: 1px solid theme-color('primary');
   margin: $baseline*1.25 0 -0.5*$baseline;
@@ -370,7 +366,7 @@
         width: 100%;
         padding: $baseline*0.6 $baseline;
         border-bottom: 1px solid theme-color('light');
-        text-align: left;
+        @include text-align(left);
         cursor: pointer;
 
         &:hover,

--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -339,6 +339,10 @@
 /*
   Mobile menu styling
 */
+.window-wrap[dir='rtl'] .mobile-menu {
+  @include text-align(right);
+}
+
 .mobile-menu {
   border-top: 1px solid theme-color('primary');
   margin: $baseline*1.25 0 -0.5*$baseline;


### PR DESCRIPTION
This will display the RTL languages from right to left. Tested on mobile using Developer Tools on Firefox.

To reproduce the result in this PR, simply run the devstack on `koa.master`, open the Developer Tools on either Firefox or Chrome, select Mobile View from the icon on the top right of the Developer Tools, check the display when the following settings are applied:

```yml
# /edx/etc/lms.yml
LANGUAGE_CODE: ar
```

You can optionally change the theme for more thorough testing, though it's not necessary; By copying a theme [like nelp](https://github.com/nelc/nelp-ecommerce-theme/) to `<devstack_root>/../src` and with the following change:

```yml
# /edx/etc/lms.yml
COMPREHENSIVE_THEME_DIRS:
- '/edx/src'

...
...
...

DEFAULT_SITE_THEME: 'nelp-ecommerce-theme'
```

Then head to http://localhost:18000 and check the changes to see if an RTL language (like Arabic: `ar`) is correctly displayed from right to left or not.