### PR TITLE
[BB-4813] Add signal for activating enrollments

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1355,6 +1355,7 @@ class CourseEnrollment(models.Model):
         if activation_changed:
             if self.is_active:
                 self.emit_event(EVENT_NAME_ENROLLMENT_ACTIVATED)
+                self.send_signal(EVENT_NAME_ENROLLMENT_ACTIVATED)
             else:
                 UNENROLL_DONE.send(sender=None, course_enrollment=self, skip_refund=skip_refund)
                 self.emit_event(EVENT_NAME_ENROLLMENT_DEACTIVATED)


### PR DESCRIPTION
While there's a signal for enrolling and deactivating users, no such signal is emitted when the enrollment is updated with `is_active=True`