### PR TITLE
[SE-4888] Cherry-pick Fix use a registration field order when using a registration extension

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -348,6 +348,11 @@ class RegistrationFormFactory(object):
             handler = getattr(self, "_add_{field_name}_field".format(field_name=field_name))
             self.field_handlers[field_name] = handler
 
+        custom_form = get_registration_extension_form()
+        if custom_form:
+            custom_form_field_names = [field_name for field_name, field in custom_form.fields.items()]
+            valid_fields.extend(custom_form_field_names)
+
         field_order = configuration_helpers.get_value('REGISTRATION_FIELD_ORDER')
         if not field_order:
             field_order = settings.REGISTRATION_FIELD_ORDER or valid_fields
@@ -355,7 +360,8 @@ class RegistrationFormFactory(object):
         # if not append missing fields at end of field order
         if set(valid_fields) != set(field_order):
             difference = set(valid_fields).difference(set(field_order))
-            field_order.extend(difference)
+            # sort the additional fields so we have could have a deterministic result when presenting them
+            field_order.extend(sorted(difference))
 
         self.field_order = field_order
 
@@ -379,57 +385,57 @@ class RegistrationFormFactory(object):
 
         # Custom form fields can be added via the form set in settings.REGISTRATION_EXTENSION_FORM
         custom_form = get_registration_extension_form()
-
         if custom_form:
-            # Default fields are always required
-            for field_name in self.DEFAULT_FIELDS:
-                self.field_handlers[field_name](form_desc, required=True)
-
-            for field_name, field in custom_form.fields.items():
-                restrictions = {}
-                if getattr(field, 'max_length', None):
-                    restrictions['max_length'] = field.max_length
-                if getattr(field, 'min_length', None):
-                    restrictions['min_length'] = field.min_length
-                field_options = getattr(
-                    getattr(custom_form, 'Meta', None), 'serialization_options', {}
-                ).get(field_name, {})
-                field_type = field_options.get('field_type', FormDescription.FIELD_TYPE_MAP.get(field.__class__))
-                if not field_type:
-                    raise ImproperlyConfigured(
-                        u"Field type '{}' not recognized for registration extension field '{}'.".format(
-                            field_type,
-                            field_name
-                        )
-                    )
-                form_desc.add_field(
-                    field_name, label=field.label,
-                    default=field_options.get('default'),
-                    field_type=field_options.get('field_type', FormDescription.FIELD_TYPE_MAP.get(field.__class__)),
-                    placeholder=field.initial, instructions=field.help_text, required=field.required,
-                    restrictions=restrictions,
-                    options=getattr(field, 'choices', None), error_messages=field.error_messages,
-                    include_default_option=field_options.get('include_default_option'),
-                )
-
-            # Extra fields configured in Django settings
-            # may be required, optional, or hidden
-            for field_name in self.EXTRA_FIELDS:
-                if self._is_field_visible(field_name):
-                    self.field_handlers[field_name](
-                        form_desc,
-                        required=self._is_field_required(field_name)
-                    )
+            custom_form_field_names = [field_name for field_name, field in custom_form.fields.items()]
         else:
-            # Go through the fields in the fields order and add them if they are required or visible
-            for field_name in self.field_order:
-                if field_name in self.DEFAULT_FIELDS:
-                    self.field_handlers[field_name](form_desc, required=True)
-                elif self._is_field_visible(field_name):
-                    self.field_handlers[field_name](
-                        form_desc,
-                        required=self._is_field_required(field_name)
-                    )
+            custom_form_field_names = []
+
+        # Go through the fields in the fields order and add them if they are required or visible
+        for field_name in self.field_order:
+            if field_name in self.DEFAULT_FIELDS:
+                self.field_handlers[field_name](form_desc, required=True)
+            elif self._is_field_visible(field_name) and self.field_handlers.get(field_name):
+                self.field_handlers[field_name](
+                    form_desc,
+                    required=self._is_field_required(field_name)
+                )
+            elif field_name in custom_form_field_names:
+                for custom_field_name, field in custom_form.fields.items():
+                    if field_name == custom_field_name:
+                        restrictions = {}
+                        if getattr(field, 'max_length', None):
+                            restrictions['max_length'] = field.max_length
+                        if getattr(field, 'min_length', None):
+                            restrictions['min_length'] = field.min_length
+                        field_options = getattr(
+                            getattr(custom_form, 'Meta', None), 'serialization_options', {}
+                        ).get(field_name, {})
+                        field_type = field_options.get(
+                            'field_type',
+                            FormDescription.FIELD_TYPE_MAP.get(field.__class__))
+                        if not field_type:
+                            raise ImproperlyConfigured(
+                                u"Field type '{}' not recognized for registration extension field '{}'.".format(
+                                    field_type,
+                                    field_name
+                                )
+                            )
+                        if self._is_field_visible(field_name) or field.required:
+                            form_desc.add_field(
+                                field_name,
+                                label=field.label,
+                                default=field_options.get('default'),
+                                field_type=field_options.get(
+                                    'field_type',
+                                    FormDescription.FIELD_TYPE_MAP.get(field.__class__)),
+                                placeholder=field.initial,
+                                instructions=field.help_text,
+                                required=(self._is_field_required(field_name) or field.required),
+                                restrictions=restrictions,
+                                options=getattr(field, 'choices', None), error_messages=field.error_messages,
+                                include_default_option=field_options.get('include_default_option'),
+                            )
+
         # remove confirm_email form v1 registration form
         if is_api_v1(request):
             for index, field in enumerate(form_desc.fields):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -529,18 +529,18 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
             }
         )
 
-        self._assert_reg_field(
+        self._assert_reg_absent_field(
             no_extra_fields_setting,
             {
-                u"name": u"favorite_editor",
-                u"type": u"select",
-                u"required": False,
-                u"label": u"Favorite Editor",
-                u"placeholder": u"cat",
-                u"defaultValue": u"vim",
-                u"errorMessages": {
-                    u'required': u'This field is required.',
-                    u'invalid_choice': u'Select a valid choice. %(value)s is not one of the available choices.',
+                "name": u"favorite_editor",
+                "type": u"select",
+                "required": False,
+                "label": u"Favorite Editor",
+                "placeholder": u"cat",
+                "defaultValue": u"vim",
+                "errorMessages": {
+                    'required': 'This field is required.',
+                    'invalid_choice': 'Select a valid choice. %(value)s is not one of the available choices.',
                 }
             }
         )
@@ -1136,6 +1136,7 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
             "honor_code": "required",
             "confirm_email": "required",
         },
+        REGISTRATION_FIELD_ORDER=None,
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
     )
     def test_field_order(self):
@@ -1145,13 +1146,11 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        self.assertEqual(field_names, [
+        assert field_names == [
             "email",
             "name",
             "username",
             "password",
-            "favorite_movie",
-            "favorite_editor",
             "city",
             "state",
             "country",
@@ -1161,7 +1160,8 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
             "mailing_address",
             "goals",
             "honor_code",
-        ])
+            "favorite_movie",
+        ]
 
     @override_settings(
         REGISTRATION_EXTRA_FIELDS={
@@ -1262,24 +1262,23 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        self.assertEqual(field_names, [
-            "email",
-            "name",
-            "username",
-            "password",
-            "favorite_movie",
-            "favorite_editor",
 
-            "city",
-            "state",
-            "country",
+        assert field_names == [
+            "name",
+            "password",
             "gender",
             "year_of_birth",
             "level_of_education",
             "mailing_address",
             "goals",
             "honor_code",
-        ])
+            "city",
+            "country",
+            "email",
+            "favorite_movie",
+            "state",
+            "username",
+        ]
 
     def test_register(self):
         # Create a new registration
@@ -1710,6 +1709,31 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
 
         self._assert_fields_match(actual_field, expected_field)
 
+    def _assert_reg_absent_field(self, extra_fields_setting, expected_absent_field: str):
+        """
+        Retrieve the registration form description from the server and
+        verify that it not contains the expected absent field.
+
+        Args:
+            extra_fields_setting (dict): Override the Django setting controlling
+                which extra fields are displayed in the form.
+            expected_absent_field (str): The field name we expect to be absent in the form.
+
+        Raises:
+            AssertionError
+        """
+        # Retrieve the registration form description
+        with override_settings(REGISTRATION_EXTRA_FIELDS=extra_fields_setting):
+            response = self.client.get(self.url)
+            self.assertHttpOK(response)
+
+        # Verify that the form description matches what we'd expect
+        form_desc = json.loads(response.content.decode('utf-8'))
+
+        current_present_field_names = [field["name"] for field in form_desc["fields"]]
+        assert expected_absent_field not in current_present_field_names, \
+            "Expected absent field {expected}".format(expected=expected_absent_field)
+
     def _assert_password_field_hidden(self, field_settings):
         self._assert_reg_field(field_settings, {
             "name": "password",
@@ -1777,24 +1801,23 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
 
-        self.assertEqual(field_names, [
-            "email",
+        assert field_names == [
             "name",
-            "username",
-            "password",
-            "favorite_movie",
-            "favorite_editor",
             "confirm_email",
-            "city",
-            "state",
-            "country",
+            "password",
             "gender",
             "year_of_birth",
             "level_of_education",
             "mailing_address",
             "goals",
             "honor_code",
-        ])
+            "city",
+            "country",
+            "email",
+            "favorite_movie",
+            "state",
+            "username",
+        ]
 
     @override_settings(
         REGISTRATION_EXTRA_FIELDS={
@@ -1871,6 +1894,7 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
             "honor_code": "required",
             "confirm_email": "required",
         },
+        REGISTRATION_FIELD_ORDER=None,
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
     )
     def test_field_order(self):
@@ -1880,13 +1904,11 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        self.assertEqual(field_names, [
+        assert field_names == [
             "email",
             "name",
             "username",
             "password",
-            "favorite_movie",
-            "favorite_editor",
             "confirm_email",
             "city",
             "state",
@@ -1897,7 +1919,8 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
             "mailing_address",
             "goals",
             "honor_code",
-        ])
+            "favorite_movie",
+        ]
 
     def test_registration_form_confirm_email(self):
         self._assert_reg_field(


### PR DESCRIPTION
This PR cherry-picks https://github.com/edx/edx-platform/pull/26633

## Test instructions

1. Navigate [here](https://esme-staging.opencraft.hosting/register)
2. Validate that the text " I hereby confirm receiving updates on new courses, content and new learning initiatives " follows "Password" field.