### PR TITLE
[SE-4650] feat: Add course-wide custom scripts

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1019,6 +1019,19 @@ class CourseFields(object):
         ),
         scope=Scope.settings, default=False
     )
+
+    course_wide_js = List(
+        display_name=_("Course-wide Custom JS"),
+        help=_('Enter Javascript resource URLs you want to be loaded globally throughout the course pages.'),
+        scope=Scope.settings,
+    )
+
+    course_wide_css = List(
+        display_name=_("Course-wide Custom CSS"),
+        help=_('Enter CSS resource URLs you want to be loaded globally throughout the course pages.'),
+        scope=Scope.settings,
+    )
+
     other_course_settings = Dict(
         display_name=_("Other Course Settings"),
         help=_(

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -446,6 +446,7 @@ class CoursewareIndex(View):
             'sequence_title': None,
             'disable_accordion': not DISABLE_COURSE_OUTLINE_PAGE_FLAG.is_enabled(self.course.id),
             'show_search': show_search,
+            'render_course_wide_assets': True,
         }
         courseware_context.update(
             get_experiment_user_metadata_context(

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1693,6 +1693,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
             'is_learning_mfe': is_request_from_learning_mfe(request),
             'is_mobile_app': is_request_from_mobile_app(request),
             'reset_deadlines_url': reverse(RESET_COURSE_DEADLINES_NAME),
+            'render_course_wide_assets': True,
         }
         return render_to_response('courseware/courseware-chromeless.html', context)
 

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -168,6 +168,11 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
     </script>
 % endif
 
+  % if course and course is not UNDEFINED and render_course_wide_assets:
+  % for css in course.course_wide_css:
+    <link rel="stylesheet" href="${css}" type="text/css">
+  % endfor
+  % endif
 </head>
 
 <body class="${static.dir_rtl()} <%block name='bodyclass'/> lang_${LANGUAGE_CODE}">
@@ -211,6 +216,13 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
   <script type="text/javascript" src="${static.url('js/header/header.js')}"></script>
   <%static:optional_include_mako file="body-extra.html" is_theming_enabled="True" />
   <script type="text/javascript" src="${static.url('js/src/jquery_extend_patch.js')}"></script>
+  <div id="lean_overlay"></div>
+
+  % if course and course is not UNDEFINED and render_course_wide_assets:
+  % for js in course.course_wide_js:
+  <script type="text/javascript" src="${js}"></script>
+  % endfor
+  % endif
 </body>
 </html>
 

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -20,6 +20,12 @@
   {% block headextra %}{% endblock %}
   {% render_block "css" %}
 
+  {% if request.course and request.render_course_wide_assets %}
+  {% for css in request.course.course_wide_css %}
+  <link rel="stylesheet" href="{{css}}" type="text/css">
+  {% endfor %}
+  {% endif %}
+
   {% optional_include "head-extra.html"|microsite_template_path %}
 
   <meta name="path_prefix" content="{{EDX_ROOT_URL}}">
@@ -46,6 +52,12 @@
     {% javascript 'base_application' %}
 
     {% render_block "js" %}
+
+    {% if request.course and request.render_course_wide_assets %}
+    {% for js in request.course.course_wide_js %}
+    <script type="text/javascript" src="{{js}}"></script>
+    {% endfor %}
+    {% endif %}
 </body>
 </html>
 


### PR DESCRIPTION
Cherry-pick of https://github.com/edx/edx-platform/pull/28411

Imlements OEP-15 by adding two fields to the course settings:
- Course-wide Custom JS
- Course-wide Custom CSS
The resources defined in these fields will be rendered in all course pages.

Rebase b6cb629849..0578e1c4c6 onto b6cb629849:
- Add course-wide resources to API for MFE use
- Revert "Add course-wide resources to API for MFE use" reverts commit 53648dcf0afe3cd171c9dc2eb5e56b871b2bcfb2

Signed-off-by: Gabor Boros <gabor.brs@gmail.com>

## Testing instructions

1. go to [this page](https://esme-readspeaker.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40edx_introduction)
2. Validate the "listen button" on the right of the course page
3. Click the button and check it starts reading the text