### PR TITLE
Implement feature flag to disable students un-enrollment [BB-4951]

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -451,6 +451,19 @@ FEATURES = {
     # .. toggle_creation_date: 2021-03-05
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/26106
     'ENABLE_HELP_LINK': True,
+
+    # .. toggle_name: FEATURES['DISABLE_UNENROLLMENT']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable disable self-unenrollments via REST API.
+    #   This also hides the "Unenroll" button on the Learner Dashboard.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-10-11
+    # .. toggle_target_removal_date: None
+    # .. toggle_warnings: For consistency in user experience, keep the value in sync with the setting of the same name
+    #   in the LMS and CMS
+    # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
+    'DISABLE_UNENROLLMENT': False,
 }
 
 ENABLE_JASMINE = False

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -455,13 +455,13 @@ FEATURES = {
     # .. toggle_name: FEATURES['DISABLE_UNENROLLMENT']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Set to True to enable disable self-unenrollments via REST API.
+    # .. toggle_description: Set to True to disable self-unenrollments via REST API.
     #   This also hides the "Unenroll" button on the Learner Dashboard.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2021-10-11
     # .. toggle_target_removal_date: None
     # .. toggle_warnings: For consistency in user experience, keep the value in sync with the setting of the same name
-    #   in the LMS and CMS
+    #   in the LMS and CMS.
     # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
     'DISABLE_UNENROLLMENT': False,
 }

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -351,6 +351,14 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
         resp = self._change_enrollment('unenroll', course_id="edx/")
         assert resp.status_code == 400
 
+    @patch.dict(settings.FEATURES, {'DISABLE_UNENROLLMENT': True})
+    def test_unenroll_disable_unenrollment(self):
+        """
+        Tests that a user cannot unenroll when unenrollment has been disabled
+        """
+        resp = self._change_enrollment('unenroll')
+        assert resp.status_code == 400
+
     def test_enrollment_limit(self):
         """
         Assert that in a course with max student limit set to 1, we can enroll staff and instructor along with

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -352,12 +352,20 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
         assert resp.status_code == 400
 
     @patch.dict(settings.FEATURES, {'DISABLE_UNENROLLMENT': True})
-    def test_unenroll_disable_unenrollment(self):
+    def test_unenroll_when_unenrollment_disabled(self):
         """
-        Tests that a user cannot unenroll when unenrollment has been disabled
+        Tests that a user cannot unenroll when unenrollment has been disabled.
         """
+        # Enroll the student in the course
+        CourseEnrollment.enroll(self.user, self.course.id, mode="honor")
+
+        # Attempt to unenroll
         resp = self._change_enrollment('unenroll')
         assert resp.status_code == 400
+
+        # Verify that user is still enrolled
+        is_enrolled = CourseEnrollment.is_enrolled(self.user, self.course.id)
+        assert is_enrolled
 
     def test_enrollment_limit(self):
         """

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -514,7 +514,10 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     empty_dashboard_message = configuration_helpers.get_value(
         'EMPTY_DASHBOARD_MESSAGE', None
     )
-    disable_unenrollment = settings.FEATURES.get('DISABLE_UNENROLLMENT', False)
+    disable_unenrollment = configuration_helpers.get_value(
+        'DISABLE_UNENROLLMENT',
+        settings.FEATURES.get('DISABLE_UNENROLLMENT', False)
+    )
 
     disable_course_limit = request and 'course_limit' in request.GET
     course_limit = get_dashboard_course_limit() if not disable_course_limit else None

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -514,6 +514,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     empty_dashboard_message = configuration_helpers.get_value(
         'EMPTY_DASHBOARD_MESSAGE', None
     )
+    disable_unenrollment = settings.FEATURES.get('DISABLE_UNENROLLMENT', False)
 
     disable_course_limit = request and 'course_limit' in request.GET
     course_limit = get_dashboard_course_limit() if not disable_course_limit else None
@@ -794,6 +795,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
         # TODO START: clean up as part of REVEM-199 (START)
         'course_info': get_dashboard_course_info(user, course_enrollments),
         # TODO START: clean up as part of REVEM-199 (END)
+        'disable_unenrollment': disable_unenrollment,
     }
 
     context_from_plugins = get_plugins_view_context(

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -516,7 +516,7 @@ def student_dashboard(request):  # lint-amnesty, pylint: disable=too-many-statem
     )
     disable_unenrollment = configuration_helpers.get_value(
         'DISABLE_UNENROLLMENT',
-        settings.FEATURES.get('DISABLE_UNENROLLMENT', False)
+        settings.FEATURES.get('DISABLE_UNENROLLMENT')
     )
 
     disable_course_limit = request and 'course_limit' in request.GET

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -375,6 +375,9 @@ def change_enrollment(request, check_access=True):
         # Otherwise, there is only one mode available (the default)
         return HttpResponse()
     elif action == "unenroll":
+        if settings.FEATURES.get('DISABLE_UNENROLLMENT', False):
+            return HttpResponseBadRequest(_("Unenrollment is currently disabled"))
+
         enrollment = CourseEnrollment.get_enrollment(user, course_id)
         if not enrollment:
             return HttpResponseBadRequest(_("You are not enrolled in this course"))

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -375,7 +375,7 @@ def change_enrollment(request, check_access=True):
         # Otherwise, there is only one mode available (the default)
         return HttpResponse()
     elif action == "unenroll":
-        if settings.FEATURES.get('DISABLE_UNENROLLMENT', False):
+        if settings.FEATURES.get('DISABLE_UNENROLLMENT'):
             return HttpResponseBadRequest(_("Unenrollment is currently disabled"))
 
         enrollment = CourseEnrollment.get_enrollment(user, course_id)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -917,6 +917,18 @@ FEATURES = {
     # .. toggle_warnings: None
     # .. toggle_tickets: 'https://openedx.atlassian.net/browse/OSPR-5290'
     'ENABLE_BULK_USER_RETIREMENT': False,
+
+    # .. toggle_name: FEATURES['DISABLE_UNENROLLMENT']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable the disabling of course unenrollment through REST API. 
+    #   This is disabled by default.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-10-11
+    # .. toggle_target_removal_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
+    'DISABLE_UNENROLLMENT': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -922,7 +922,7 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Set to True to disable self-unenrollments via REST API. 
-    #   This also hides the "Unenroll" button on the learner dashboard.
+    #   This also hides the "Unenroll" button on the Learner Dashboard.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2021-10-11
     # .. toggle_target_removal_date: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -921,12 +921,13 @@ FEATURES = {
     # .. toggle_name: FEATURES['DISABLE_UNENROLLMENT']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Set to True to enable the disabling of course unenrollment through REST API. 
-    #   This is disabled by default.
+    # .. toggle_description: Set to True to disable self-unenrollments via REST API. 
+    #   This also hides the "Unenroll" button on the learner dashboard.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2021-10-11
     # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
+    # .. toggle_warnings: For consistency in user experience, keep the value in sync with the setting of the same name
+    #   in the LMS and CMS.
     # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
     'DISABLE_UNENROLLMENT': False,
 }

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -211,7 +211,7 @@ from common.djangoapps.student.models import CourseEnrollment
                 # checks if we can unenroll based on the value of unfulfilled_entitlement
                 can_unenroll_unfulfilled_entitlement = cert_status.get('can_unenroll') if not unfulfilled_entitlement else False
                 # compares the three different parameters by which we can unenroll 
-                can_unenroll =  can_unenroll_partner_managed_enrollment or can_unenroll_unfulfilled_entitlement and (not disable_unenrollment)
+                can_unenroll = (can_unenroll_partner_managed_enrollment or can_unenroll_unfulfilled_entitlement) and not disable_unenrollment
                 credit_status = credit_statuses.get(session_id)
                 course_mode_info = all_course_modes.get(session_id)
                 is_paid_course = True if entitlement else (session_id in enrolled_courses_either_paid)

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -205,8 +205,13 @@ from common.djangoapps.student.models import CourseEnrollment
                 show_courseware_link = show_courseware_links_for.get(session_id, False)
                 cert_status = cert_statuses.get(session_id)
                 can_refund_entitlement = entitlement and entitlement.is_entitlement_refundable()
-                partner_managed_enrollment = enrollment.mode == 'masters'
-                can_unenroll = (False if partner_managed_enrollment else (not cert_status)) or (cert_status.get('can_unenroll') if not unfulfilled_entitlement else False) and (not disable_unenrollment)
+                partner_managed_enrollment = enrollment.mode == 'masters' 
+                # checks if we can unenroll based on the value of partner_managed_enrollment
+                can_unenroll_partner_managed_enrollment = False if partner_managed_enrollment else (not cert_status)
+                # checks if we can unenroll based on the value of unfulfilled_entitlement
+                can_unenroll_unfulfilled_entitlement = cert_status.get('can_unenroll') if not unfulfilled_entitlement else False
+                # compares the three different parameters by which we can unenroll 
+                can_unenroll =  can_unenroll_partner_managed_enrollment or can_unenroll_unfulfilled_entitlement and (not disable_unenrollment)
                 credit_status = credit_statuses.get(session_id)
                 course_mode_info = all_course_modes.get(session_id)
                 is_paid_course = True if entitlement else (session_id in enrolled_courses_either_paid)

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -206,7 +206,7 @@ from common.djangoapps.student.models import CourseEnrollment
                 cert_status = cert_statuses.get(session_id)
                 can_refund_entitlement = entitlement and entitlement.is_entitlement_refundable()
                 partner_managed_enrollment = enrollment.mode == 'masters'
-                can_unenroll = False if partner_managed_enrollment else (not cert_status) or cert_status.get('can_unenroll') if not unfulfilled_entitlement else False
+                can_unenroll = (False if partner_managed_enrollment else (not cert_status)) or (cert_status.get('can_unenroll') if not unfulfilled_entitlement else False) and (not disable_unenrollment)
                 credit_status = credit_statuses.get(session_id)
                 course_mode_info = all_course_modes.get(session_id)
                 is_paid_course = True if entitlement else (session_id in enrolled_courses_either_paid)

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -244,7 +244,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 ## and/or if they have selected a course run and email_settings are enabled
                 ## as these are the only actions currently available
                 % if entitlement and (can_refund_entitlement or show_email_settings):
-                    <%include file='_dashboard_entitlement_actions.html' args='course_overview=course_overview,entitlement=entitlement,dashboard_index=dashboard_index, can_refund_entitlement=can_refund_entitlement, show_email_settings=show_email_settings'/>
+                    <%include file='_dashboard_entitlement_actions.html' args='course_overview=course_overview,entitlement=entitlement,dashboard_index=dashboard_index, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, show_email_settings=show_email_settings'/>
                 % elif not entitlement:
                     <div class="wrapper-action-more" data-course-key="${enrollment.course_id}">
                       <button type="button" class="action action-more" id="actions-dropdown-link-${dashboard_index}" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-${dashboard_index}" data-course-number="${course_overview.number}" data-course-name="${course_overview.display_name_with_default}" data-dashboard-index="${dashboard_index}">

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -244,7 +244,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 ## and/or if they have selected a course run and email_settings are enabled
                 ## as these are the only actions currently available
                 % if entitlement and (can_refund_entitlement or show_email_settings):
-                    <%include file='_dashboard_entitlement_actions.html' args='course_overview=course_overview,entitlement=entitlement,dashboard_index=dashboard_index, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, show_email_settings=show_email_settings'/>
+                    <%include file='_dashboard_entitlement_actions.html' args='course_overview=course_overview,entitlement=entitlement,dashboard_index=dashboard_index, can_refund_entitlement=can_refund_entitlement, show_email_settings=show_email_settings'/>
                 % elif not entitlement:
                     <div class="wrapper-action-more" data-course-key="${enrollment.course_id}">
                       <button type="button" class="action action-more" id="actions-dropdown-link-${dashboard_index}" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-${dashboard_index}" data-course-number="${course_overview.number}" data-course-name="${course_overview.display_name_with_default}" data-dashboard-index="${dashboard_index}">

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -241,11 +241,11 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 % endif
 
                 ## We should only show the gear dropdown if the user is able to refund/unenroll from their entitlement
-                ## and/or if they have selected a course run and email_settings are enabled
+                ## and/or if they have selected a course run, unenrollment is not disabled, and email_settings are enabled
                 ## as these are the only actions currently available
                 % if entitlement and (can_refund_entitlement or show_email_settings):
                     <%include file='_dashboard_entitlement_actions.html' args='course_overview=course_overview,entitlement=entitlement,dashboard_index=dashboard_index, can_refund_entitlement=can_refund_entitlement, show_email_settings=show_email_settings'/>
-                % elif not entitlement:
+                % elif not entitlement and (can_unenroll or partner_managed_enrollment or show_email_settings):
                     <div class="wrapper-action-more" data-course-key="${enrollment.course_id}">
                       <button type="button" class="action action-more" id="actions-dropdown-link-${dashboard_index}" aria-haspopup="true" aria-expanded="false" aria-controls="actions-dropdown-${dashboard_index}" data-course-number="${course_overview.number}" data-course-name="${course_overview.display_name_with_default}" data-dashboard-index="${dashboard_index}">
                         <span class="sr">${_('Course options for')}</span>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -256,21 +256,21 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                       </button>
                       <div class="actions-dropdown" id="actions-dropdown-${dashboard_index}" tabindex="-1">
                         <ul class="actions-dropdown-list" id="actions-dropdown-list-${dashboard_index}" aria-label="${_('Available Actions')}" role="menu">
-                          % if can_unenroll:
-                            <li class="actions-item" id="actions-item-unenroll-${dashboard_index}" role="menuitem">
-                              <% course_refund_url = reverse('course_run_refund_status', args=[six.text_type(course_overview.id)]) %>
-                                  <a href="#unenroll-modal" class="action action-unenroll" rel="leanModal"
-                                    data-course-id="${course_overview.id}"
-                                    data-course-number="${course_overview.number}"
-                                    data-course-name="${course_overview.display_name_with_default}"
-                                    data-dashboard-index="${dashboard_index}"
-                                    data-course-refund-url="${course_refund_url}"
-                                    data-course-is-paid-course="${is_paid_course}"
-                                    data-course-cert-name-long="${cert_name_long}"
-                                    data-course-enrollment-mode="${enrollment.mode}">
-                                    ${_('Unenroll')}
-                                  </a>
-                            </li>
+                        % if can_unenroll:
+                          <li class="actions-item" id="actions-item-unenroll-${dashboard_index}" role="menuitem">
+                            <% course_refund_url = reverse('course_run_refund_status', args=[six.text_type(course_overview.id)]) %>
+                                <a href="#unenroll-modal" class="action action-unenroll" rel="leanModal"
+                                  data-course-id="${course_overview.id}"
+                                  data-course-number="${course_overview.number}"
+                                  data-course-name="${course_overview.display_name_with_default}"
+                                  data-dashboard-index="${dashboard_index}"
+                                  data-course-refund-url="${course_refund_url}"
+                                  data-course-is-paid-course="${is_paid_course}"
+                                  data-course-cert-name-long="${cert_name_long}"
+                                  data-course-enrollment-mode="${enrollment.mode}">
+                                  ${_('Unenroll')}
+                                </a>
+                          </li>
                         % elif partner_managed_enrollment:
                           <li class="actions-item" id="actions-item-enrolled-by-partner-${dashboard_index}" role="menuitem">
                             <a class="action action-message action-unenroll-managed-enrollment">

--- a/lms/templates/dashboard/_dashboard_entitlement_actions.html
+++ b/lms/templates/dashboard/_dashboard_entitlement_actions.html
@@ -1,4 +1,4 @@
-<%page args="course_overview, entitlement, dashboard_index, can_refund_entitlement, show_email_settings" expression_filter="h"/>
+<%page args="course_overview, entitlement, dashboard_index, can_refund_entitlement, can_unenroll, show_email_settings" expression_filter="h"/>
 
 <%!
 import six
@@ -28,7 +28,7 @@ dropdown_btn_id = "entitlement-actions-dropdown-btn-{}".format(dashboard_index)
 
   <div id="${dropdown_id}" class="entitlement-actions-dropdown" tabindex="-1">
     <ul class="entitlement-actions-dropdown-list" aria-label="${_('Available Actions')}" role="menu">
-      % if can_refund_entitlement:
+      % if can_refund_entitlement and can_unenroll:
         <li class="entitlement-actions-item" role="menuitem">
           ## href, id, rel, and data-model-close-button-selector must be defined for compatibility with lms/static/js/leanModal.js
           ## data-dropdown-selector and data-dropdown-button-selector must be defined for compatibility with lms/static/js/dashboard/dropdown.js

--- a/lms/templates/dashboard/_dashboard_entitlement_actions.html
+++ b/lms/templates/dashboard/_dashboard_entitlement_actions.html
@@ -1,4 +1,4 @@
-<%page args="course_overview, entitlement, dashboard_index, can_refund_entitlement, can_unenroll, show_email_settings" expression_filter="h"/>
+<%page args="course_overview, entitlement, dashboard_index, can_refund_entitlement, show_email_settings" expression_filter="h"/>
 
 <%!
 import six
@@ -28,7 +28,7 @@ dropdown_btn_id = "entitlement-actions-dropdown-btn-{}".format(dashboard_index)
 
   <div id="${dropdown_id}" class="entitlement-actions-dropdown" tabindex="-1">
     <ul class="entitlement-actions-dropdown-list" aria-label="${_('Available Actions')}" role="menu">
-      % if can_refund_entitlement and can_unenroll:
+      % if can_refund_entitlement:
         <li class="entitlement-actions-item" role="menuitem">
           ## href, id, rel, and data-model-close-button-selector must be defined for compatibility with lms/static/js/leanModal.js
           ## data-dropdown-selector and data-dropdown-button-selector must be defined for compatibility with lms/static/js/dashboard/dropdown.js


### PR DESCRIPTION
## Description
This PR Implements a feature flag `DISABLE_UNENROLLMENT` that is used to disable students un-enrollment for all courses. The `Unenrollment` option should be disabled when this feature is set to `True`

## Supporting Information
[BB-4951](https://tasks.opencraft.com/browse/BB-4951)

## Before
<img width="1105" alt="Screenshot 2021-10-08 at 12 46 41" src="https://user-images.githubusercontent.com/30666999/136551569-59dac19d-daaa-4bdd-a9ee-87f3921a402e.png">

## After
<img width="1093" alt="Screenshot 2021-10-08 at 12 21 44" src="https://user-images.githubusercontent.com/30666999/136551621-47ed47d2-6877-457f-bf50-80423b90bc58.png">

## Testing Instructions

- Check out to this branch `tinumide/lilac_disable_unenrollment` in the edx-plaftorm repository on a lilac devstack
- In the lms.yml file add `DISABLE_UNENROLLMENT: true` to Features
- Go to the Lms dashboard at `http://localhost:18000/dashboard` and click on the settings gear of a course
- Confirm that there is no option to unenroll