### PR TITLE
[SE-4473] Implement progress bar

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.js
@@ -426,6 +426,8 @@
                     }
                 });
             }
+            // Reload progress bar
+            this.$('#progress-frame').attr('src', this.$('#progress-frame').attr('src'));
         };
 
         Sequence.prototype.mark_active = function(position) {

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from functools import reduce
 
 import six
+from django.conf import settings
 from django.contrib.auth.models import User
 from lxml import etree
 from opaque_keys.edx.keys import UsageKey
@@ -493,6 +494,9 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
 
         fragment = Fragment()
         params = self._get_render_metadata(context, display_items, prereq_met, prereq_meta_info, banner_text, view, fragment)
+        if settings.FEATURES.get('SHOW_PROGRESS_BAR', False):
+            parent_block_id = self.get_parent().scope_ids.usage_id.block_id
+            params['chapter_completion_aggregator_url'] = settings.COMPLETION_AGGREGATOR_URL + '/' + six.text_type(self.course_id) + '/' + parent_block_id + '/'
         fragment.add_content(self.system.render_template("seq_module.html", params))
 
         self._capture_full_seq_item_metrics(display_items)

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -496,7 +496,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         params = self._get_render_metadata(context, display_items, prereq_met, prereq_meta_info, banner_text, view, fragment)
         if settings.FEATURES.get('SHOW_PROGRESS_BAR', False):
             parent_block_id = self.get_parent().scope_ids.usage_id.block_id
-            params['chapter_completion_aggregator_url'] = settings.COMPLETION_AGGREGATOR_URL + '/' + six.text_type(self.course_id) + '/' + parent_block_id + '/'
+            params['chapter_completion_aggregator_url'] = '/'.join([settings.COMPLETION_AGGREGATOR_URL, str(self.course_id), parent_block_id]) + '/'
         fragment.add_content(self.system.render_template("seq_module.html", params))
 
         self._capture_full_seq_item_metrics(display_items)

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -494,7 +494,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
 
         fragment = Fragment()
         params = self._get_render_metadata(context, display_items, prereq_met, prereq_meta_info, banner_text, view, fragment)
-        if settings.FEATURES.get('SHOW_PROGRESS_BAR', False):
+        if settings.FEATURES.get('SHOW_PROGRESS_BAR', False) and getattr(settings, 'COMPLETION_AGGREGATOR_URL', ''):
             parent_block_id = self.get_parent().scope_ids.usage_id.block_id
             params['chapter_completion_aggregator_url'] = '/'.join([settings.COMPLETION_AGGREGATOR_URL, str(self.course_id), parent_block_id]) + '/'
         fragment.add_content(self.system.render_template("seq_module.html", params))

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -201,7 +201,7 @@ ${HTML(fragment.foot_html())}
                         </div>
                         % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False):
                           <div class="container">
-                            <iframe style="border: none; height: 50px; position: relative; top: 10px;" src="${completion_aggregator_url}/${course.id}/">
+                            <iframe style="border: none; height: 50px; position: relative; top: 10px; width: -webkit-fill-available" src="${completion_aggregator_url}/${course.id}/">
                             </iframe>
                           </div>
                         % endif

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -21,6 +21,8 @@ from openedx.features.course_experience import course_home_page_title, DISABLE_C
    settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
    (course.enable_proctored_exams or course.enable_timed_exams)
    )
+
+   completion_aggregator_url = settings.COMPLETION_AGGREGATOR_URL if settings.FEATURES.get("SHOW_PROGRESS_BAR", False) else ""
 %>
 
 % if display_reset_dates_banner:
@@ -197,6 +199,12 @@ ${HTML(fragment.foot_html())}
                             % endif
                             <span class="nav-item nav-item-sequence">${sequence_title}</span>
                         </div>
+                        % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False):
+                          <div class="container">
+                            <iframe style="border: none; height: 50px; position: relative; top: 10px;" src="${completion_aggregator_url}/${course.id}/">
+                            </iframe>
+                          </div>
+                        % endif
                     </div>
                 </nav>
             </div>

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -1,5 +1,8 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import pgettext, ugettext as _ %>
+<%!
+ from django.utils.translation import pgettext, ugettext as _
+ from django.conf import settings 
+%>
 
 <div id="sequence_${element_id}" class="sequence" data-id="${item_id}"
      data-position="${position}" data-ajax-url="${ajax_url}"
@@ -110,6 +113,11 @@
     ${gated_sequence_fragment | n, decode.utf8}
   % else:
   <div class="sr-is-focusable" tabindex="-1"></div>
+  % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False):
+    <div class="progress-container">
+      <iframe id="progress-frame" style="border: none; width: 100%; height: 70px;" src="${chapter_completion_aggregator_url}"></iframe>
+    </div>
+  % endif
 
   % for idx, item in enumerate(items):
   <div id="seq_contents_${idx}"


### PR DESCRIPTION
**Description:** 
This PR implements the changes needed to show course progress bar on the courseware page. There are two progress bars that will be displayed: One at the course level and the other one at section/chapter level.

**JIRA:** [SE-4473](https://tasks.opencraft.com/browse/SE-4473)

**Testing instructions:**

1. Setup your devstack with this branch.
2. Set the feature flag `SHOW_PROGRESS_BAR` to true under `FEATURES` in lms.yml and studio.yml.
3. Add the `COMPLETION_AGGREGATOR_URL` setting in lms.yml as shown below:
```
COMPLETION_AGGREGATOR_URL: /completion-aggregator/progress_bar
```
4. Ensure completion tracking is enabled.
5. Pip install completion-aggregator django app containing https://github.com/open-craft/openedx-completion-aggregator/pull/89.
6. Start new course in LMS and verify that both progress bars are visible and updates correctly.

**Reviewers:**
- [ ] @gabor-boros  