### PR TITLE
Fix: Allow delete course content in Studio only for admin users

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1339,8 +1339,8 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
                 xblock_info['staff_only_message'] = False
 
             xblock_info['show_delete_button'] = True
-            if user is not None and PREVENT_STAFF_STRUCTURE_DELETION.is_enabled():
-                xblock_info['show_delete_button'] = user.has_perm(DELETE_COURSE_CONTENT, xblock)
+            if PREVENT_STAFF_STRUCTURE_DELETION.is_enabled():
+                xblock_info['show_delete_button'] = user.has_perm(DELETE_COURSE_CONTENT, xblock) if user is not None else False
 
             xblock_info['has_partition_group_components'] = has_children_visible_to_specific_partition_groups(
                 xblock

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -3371,11 +3371,11 @@ class TestXBlockPublishingInfo(ItemTest):
         xblock_info = self._get_xblock_info(chapter.location)
         self._verify_visibility_state(xblock_info, VisibilityState.live)
 
-    def test_staff_show_delte_button(self):
+    def test_staff_show_delete_button(self):
         """
         Test delete button is *not visible* to user with CourseStaffRole
         """
-        # add user as course staff
+        # Add user as course staff
         CourseStaffRole(self.course_key).add_users(self.user)
 
         # Get xblock outline
@@ -3386,13 +3386,66 @@ class TestXBlockPublishingInfo(ItemTest):
             include_children_predicate=lambda xblock: not xblock.category == 'vertical',
             user=self.user
         )
+        self.assertTrue(xblock_info['show_delete_button'])
+
+    def test_staff_show_delete_button_with_waffle(self):
+        """
+        Test delete button is *not visible* to user with CourseStaffRole and
+        PREVENT_STAFF_STRUCTURE_DELETION waffle set
+        """
+        # Add user as course staff
+        CourseStaffRole(self.course_key).add_users(self.user)
+
+        with override_waffle_flag(PREVENT_STAFF_STRUCTURE_DELETION, active=True):
+            # Get xblock outline
+            xblock_info = create_xblock_info(
+                self.course,
+                include_child_info=True,
+                course_outline=True,
+                include_children_predicate=lambda xblock: not xblock.category == 'vertical',
+                user=self.user
+            )
+
+        self.assertFalse(xblock_info['show_delete_button'])
+
+    def test_no_user_show_delete_button(self):
+        """
+        Test delete button is *visible* when user attribute is not set on
+        xblock. This happens with ajax requests.
+        """
+        # Get xblock outline
+        xblock_info = create_xblock_info(
+            self.course,
+            include_child_info=True,
+            course_outline=True,
+            include_children_predicate=lambda xblock: not xblock.category == 'vertical',
+            user=None
+        )
+        self.assertTrue(xblock_info['show_delete_button'])
+
+    def test_no_user_show_delete_button_with_waffle(self):
+        """
+        Test delete button is *visible* when user attribute is not set on
+        xblock (this happens with ajax requests) and PREVENT_STAFF_STRUCTURE_DELETION waffle set.
+        """
+
+        with override_waffle_flag(PREVENT_STAFF_STRUCTURE_DELETION, active=True):
+            # Get xblock outline
+            xblock_info = create_xblock_info(
+                self.course,
+                include_child_info=True,
+                course_outline=True,
+                include_children_predicate=lambda xblock: not xblock.category == 'vertical',
+                user=None
+            )
+
         self.assertFalse(xblock_info['show_delete_button'])
 
     def test_instructor_show_delete_button(self):
         """
-        Test delete button is *visible* to user with CourseCreatorRole only
+        Test delete button is *visible* to user with CourseInstructorRole only
         """
-        # add user as course instructor
+        # Add user as course instructor
         CourseInstructorRole(self.course_key).add_users(self.user)
 
         # Get xblock outline


### PR DESCRIPTION
## Description
Fix a couple of minor issues with [SE-4482](https://github.com/open-craft/edx-platform/pull/360). Specifically the delete icon would reappear when the visibility of a section was changed.

## Supporting information
JIRA Ticket: [SE-4482](https://tasks.opencraft.com/browse/SE-4482)

## Testing instructions
- Login on `https://studio.pr440.sandbox.stage.opencraft.hosting/`.
- Enable PREVENT_STAFF_STRUCTURE_DELETION waffle flag from `https://studio.pr440.sandbox.stage.opencraft.hosting/admin`
-  Go to the setting > Course team of the  *Demonstration Course* 
-  Add `verified@example.com` as the staff for the course
-  Login from the `verified@example.com` on the studio page
-  `verified@example.com` should not be able to see the delete button on the course outline page.
- Change the visibility of a section like [here](https://drive.google.com/file/d/1DZs0CPLMJ16sL0ebXz2G6bwnJ0ftFn1j/view?us)
- The delete button should not reappear

- Additionally: confirm whether the business logic is correct for the course creator, instructor and staff roles.

## Reviewers

- [ ] @nizarmah
