### PR TITLE
[SE-4891] Cherry pick: feat: add `optional-exposed` extra field type to registration form

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3374,7 +3374,8 @@ LOGIN_REDIRECT_WHITELIST = []
 #   'terms_of_service': 'hidden', 'city': 'hidden', 'country': 'hidden'}
 # .. setting_description: The signup form may contain extra fields that are presented to every user. For every field, we
 #   can specifiy whether it should be "required": to display the field, and make it mandatory; "optional": to display
-#   the field, and make it non-mandatory; "hidden": to not display the field.
+#   the optional field as part of a toggled input field list; "optional-exposed": to display the optional fields among
+#   the required fields, and make it non-mandatory; "hidden": to not display the field.
 #   When the terms of service are not visible and agreement to the honor code is required (the default), the signup page
 #   includes a paragraph that links to the honor code page (defined my MKTG_URLS["HONOR"]). This page might not be
 #   available for all Open edX platforms. In such cases, the "honor_code" registration field should be "hidden".

--- a/lms/static/js/spec/student_account/register_spec.js
+++ b/lms/static/js/spec/student_account/register_spec.js
@@ -88,6 +88,7 @@
                                 defaultValue: '',
                                 type: 'email',
                                 required: true,
+                                exposed: true,
                                 instructions: 'Enter your email.',
                                 restrictions: {}
                             },
@@ -98,6 +99,7 @@
                                 defaultValue: '',
                                 type: 'text',
                                 required: true,
+                                exposed: true,
                                 instructions: 'Enter your email.',
                                 restrictions: {}
                             },
@@ -108,6 +110,7 @@
                                 defaultValue: '',
                                 type: 'text',
                                 required: true,
+                                exposed: true,
                                 instructions: 'Enter your username.',
                                 restrictions: {}
                             },
@@ -118,6 +121,7 @@
                                 defaultValue: '',
                                 type: 'text',
                                 required: true,
+                                exposed: true,
                                 instructions: 'Enter your username.',
                                 restrictions: {}
                             },
@@ -128,6 +132,7 @@
                                 defaultValue: '',
                                 type: 'password',
                                 required: true,
+                                exposed: true,
                                 instructions: 'Enter your password.',
                                 restrictions: {}
                             },
@@ -144,6 +149,7 @@
                                     {value: 'b', name: "Bachelor's degree"}
                                 ],
                                 required: false,
+                                exposed: false,
                                 instructions: 'Select your education level.',
                                 restrictions: {}
                             },
@@ -160,6 +166,7 @@
                                     {value: 'o', name: 'Other'}
                                 ],
                                 required: false,
+                                exposed: false,
                                 instructions: 'Select your gender.',
                                 restrictions: {}
                             },
@@ -176,6 +183,7 @@
                                     {value: 2014, name: '2014'}
                                 ],
                                 required: false,
+                                exposed: false,
                                 instructions: 'Select your year of birth.',
                                 restrictions: {}
                             },
@@ -186,6 +194,7 @@
                                 defaultValue: '',
                                 type: 'textarea',
                                 required: false,
+                                exposed: false,
                                 instructions: 'Enter your mailing address.',
                                 restrictions: {}
                             },
@@ -196,6 +205,7 @@
                                 defaultValue: '',
                                 type: 'textarea',
                                 required: false,
+                                exposed: false,
                                 instructions: "If you'd like, tell us why you're interested in edX.",
                                 restrictions: {}
                             },
@@ -206,11 +216,12 @@
                                 defaultValue: '',
                                 type: 'checkbox',
                                 required: true,
+                                exposed: true,
                                 instructions: '',
                                 restrictions: {},
                                 supplementalLink: '/honor',
                                 supplementalText: 'Review the Terms of Service and Honor Code'
-                            }
+                            },
                         ]
                     };
                 var createRegisterView = function(that, formFields) {
@@ -500,6 +511,29 @@
 
                 // Form button should be disabled on success.
                     expect(view.$submitButton).toHaveAttr('disabled');
+                });
+
+                it('shows optional exposed fields', function() {
+                    var formFields = FORM_DESCRIPTION.fields
+                    formFields.push({
+                        placeholder: '',
+                        name: 'exposed_custom_optional_field',
+                        label: 'Exposed custom optional field.',
+                        defaultValue: '',
+                        type: 'checkbox',
+                        required: false,
+                        exposed: true,
+                        instructions: 'Check this field if you would like to.',
+                        restrictions: {}
+                    })
+
+                    createRegisterView(this, formFields);
+                    var elementClasses = view.$('.exposed-optional-fields').attr('class');
+                    var elementChildren = view.$('.exposed-optional-fields .form-field')
+                    // Expect the exposed optional fields container does not have other
+                    // classes assigned, like .hidden
+                    expect(elementClasses).toEqual('exposed-optional-fields');
+                    expect(elementChildren.length).toEqual(1)
                 });
 
                 it('hides optional fields by default', function() {

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -100,7 +100,8 @@
                         field,
                         len = data.length,
                         requiredFields = [],
-                        optionalFields = [];
+                        optionalFields = [],
+                        exposedOptionalFields = [];
 
                     this.fields = data;
 
@@ -122,12 +123,18 @@
                                 // input elements that are visible on the page.
                                 this.hasOptionalFields = true;
                             }
-                            optionalFields.push(field);
+
+                            if (field.exposed) {
+                                exposedOptionalFields.push(field);
+                            } else {
+                                optionalFields.push(field);
+                            }
                         }
                     }
 
                     html = this.renderFields(requiredFields, 'required-fields');
 
+                    html.push.apply(html, this.renderFields(exposedOptionalFields, 'exposed-optional-fields'));
                     html.push.apply(html, this.renderFields(optionalFields, 'optional-fields'));
 
                     this.render(html.join(''));
@@ -247,6 +254,14 @@
                         window.analytics.track('edx.bi.user.register.optional_fields_selected');
                         $('.optional-fields').toggleClass('hidden');
                     });
+
+                    // Since the honor TOS text has a composed css selector, it is more future proof
+                    // to insert the not toggled optional fields before .honor_tos_combined's parent
+                    // that is the container for the honor TOS text and checkbox.
+                    // xss-lint: disable=javascript-jquery-insert-into-target
+                    $('.exposed-optional-fields').insertBefore(
+                        $('.honor_tos_combined').parent()
+                    );
 
                     // We are swapping the order of these elements here because the honor code agreement
                     // is a required checkbox field and the optional fields toggle is a cosmetic

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -135,7 +135,7 @@ class FormDescription:
 
     def add_field(
             self, name, label="", field_type="text", default="",
-            placeholder="", instructions="", required=True, restrictions=None,
+            placeholder="", instructions="", exposed=None, required=True, restrictions=None,
             options=None, include_default_option=False, error_messages=None,
             supplementalLink="", supplementalText=""
     ):
@@ -158,6 +158,9 @@ class FormDescription:
 
             instructions (unicode): Short instructions for using the field
                 (e.g. "This is the email address you used when you registered.")
+
+            exposed (boolean): Whether the field is shown if not required.
+                If the field is not set, the field will be visible if it's required.
 
             required (boolean): Whether the field is required or optional.
 
@@ -195,6 +198,9 @@ class FormDescription:
             )
             raise InvalidFieldError(msg)
 
+        if exposed is None:
+            exposed = required
+
         field_dict = {
             "name": name,
             "label": label,
@@ -202,6 +208,7 @@ class FormDescription:
             "defaultValue": default,
             "placeholder": placeholder,
             "instructions": instructions,
+            "exposed": exposed,
             "required": required,
             "restrictions": {},
             "errorMessages": {},
@@ -268,6 +275,7 @@ class FormDescription:
                     "label": "Cheese or Wine?",
                     "defaultValue": "cheese",
                     "type": "select",
+                    "exposed": True,
                     "required": True,
                     "placeholder": "",
                     "instructions": "",
@@ -283,6 +291,7 @@ class FormDescription:
                     "label": "comments",
                     "defaultValue": "",
                     "type": "text",
+                    "exposed": False,
                     "required": False,
                     "placeholder": "Any comments?",
                     "instructions": "Please enter additional comments here."

--- a/openedx/core/djangoapps/user_api/tests/test_helpers.py
+++ b/openedx/core/djangoapps/user_api/tests/test_helpers.py
@@ -96,6 +96,7 @@ class FormDescriptionTest(TestCase):
             placeholder="placeholder",
             instructions="instructions",
             required=True,
+            exposed=True,
             restrictions={
                 "min_length": 2,
                 "max_length": 10
@@ -111,8 +112,8 @@ class FormDescriptionTest(TestCase):
                json.dumps({'method': 'post',
                            'submit_url': '/submit',
                            'fields': [{'name': 'name', 'label': 'label', 'type': 'text', 'defaultValue': 'default',
-                                       'placeholder': 'placeholder', 'instructions': 'instructions', 'required': True,
-                                       'restrictions': {'min_length': 2, 'max_length': 10},
+                                       'placeholder': 'placeholder', 'instructions': 'instructions', 'exposed': True,
+                                       'required': True, 'restrictions': {'min_length': 2, 'max_length': 10},
                                        'errorMessages': {'required': 'You must provide a value!'},
                                        'supplementalLink': '', 'supplementalText': '',
                                        'loginIssueSupportLink': 'https://support.example.com/login-issue-help.html'}]})

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -350,6 +350,11 @@ class RegistrationFormFactory:
             handler = getattr(self, f"_add_{field_name}_field")
             self.field_handlers[field_name] = handler
 
+        custom_form = get_registration_extension_form()
+        if custom_form:
+            custom_form_field_names = [field_name for field_name, field in custom_form.fields.items()]
+            valid_fields.extend(custom_form_field_names)
+
         field_order = configuration_helpers.get_value('REGISTRATION_FIELD_ORDER')
         if not field_order:
             field_order = settings.REGISTRATION_FIELD_ORDER or valid_fields
@@ -357,7 +362,8 @@ class RegistrationFormFactory:
         # if not append missing fields at end of field order
         if set(valid_fields) != set(field_order):
             difference = set(valid_fields).difference(set(field_order))
-            field_order.extend(difference)
+            # sort the additional fields so we have could have a deterministic result when presenting them
+            field_order.extend(sorted(difference))
 
         self.field_order = field_order
 
@@ -381,57 +387,57 @@ class RegistrationFormFactory:
 
         # Custom form fields can be added via the form set in settings.REGISTRATION_EXTENSION_FORM
         custom_form = get_registration_extension_form()
-
         if custom_form:
-            # Default fields are always required
-            for field_name in self.DEFAULT_FIELDS:
-                self.field_handlers[field_name](form_desc, required=True)
-
-            for field_name, field in custom_form.fields.items():
-                restrictions = {}
-                if getattr(field, 'max_length', None):
-                    restrictions['max_length'] = field.max_length
-                if getattr(field, 'min_length', None):
-                    restrictions['min_length'] = field.min_length
-                field_options = getattr(
-                    getattr(custom_form, 'Meta', None), 'serialization_options', {}
-                ).get(field_name, {})
-                field_type = field_options.get('field_type', FormDescription.FIELD_TYPE_MAP.get(field.__class__))
-                if not field_type:
-                    raise ImproperlyConfigured(
-                        "Field type '{}' not recognized for registration extension field '{}'.".format(
-                            field_type,
-                            field_name
-                        )
-                    )
-                form_desc.add_field(
-                    field_name, label=field.label,
-                    default=field_options.get('default'),
-                    field_type=field_options.get('field_type', FormDescription.FIELD_TYPE_MAP.get(field.__class__)),
-                    placeholder=field.initial, instructions=field.help_text, required=field.required,
-                    restrictions=restrictions,
-                    options=getattr(field, 'choices', None), error_messages=field.error_messages,
-                    include_default_option=field_options.get('include_default_option'),
-                )
-
-            # Extra fields configured in Django settings
-            # may be required, optional, or hidden
-            for field_name in self.EXTRA_FIELDS:
-                if self._is_field_visible(field_name):
-                    self.field_handlers[field_name](
-                        form_desc,
-                        required=self._is_field_required(field_name)
-                    )
+            custom_form_field_names = [field_name for field_name, field in custom_form.fields.items()]
         else:
-            # Go through the fields in the fields order and add them if they are required or visible
-            for field_name in self.field_order:
-                if field_name in self.DEFAULT_FIELDS:
-                    self.field_handlers[field_name](form_desc, required=True)
-                elif self._is_field_visible(field_name):
-                    self.field_handlers[field_name](
-                        form_desc,
-                        required=self._is_field_required(field_name)
-                    )
+            custom_form_field_names = []
+
+        # Go through the fields in the fields order and add them if they are required or visible
+        for field_name in self.field_order:
+            if field_name in self.DEFAULT_FIELDS:
+                self.field_handlers[field_name](form_desc, required=True)
+            elif self._is_field_visible(field_name) and self.field_handlers.get(field_name):
+                self.field_handlers[field_name](
+                    form_desc,
+                    required=self._is_field_required(field_name)
+                )
+            elif field_name in custom_form_field_names:
+                for custom_field_name, field in custom_form.fields.items():
+                    if field_name == custom_field_name:
+                        restrictions = {}
+                        if getattr(field, 'max_length', None):
+                            restrictions['max_length'] = field.max_length
+                        if getattr(field, 'min_length', None):
+                            restrictions['min_length'] = field.min_length
+                        field_options = getattr(
+                            getattr(custom_form, 'Meta', None), 'serialization_options', {}
+                        ).get(field_name, {})
+                        field_type = field_options.get(
+                            'field_type',
+                            FormDescription.FIELD_TYPE_MAP.get(field.__class__))
+                        if not field_type:
+                            raise ImproperlyConfigured(
+                                u"Field type '{}' not recognized for registration extension field '{}'.".format(
+                                    field_type,
+                                    field_name
+                                )
+                            )
+                        if self._is_field_visible(field_name) or field.required:
+                            form_desc.add_field(
+                                field_name,
+                                label=field.label,
+                                default=field_options.get('default'),
+                                field_type=field_options.get(
+                                    'field_type',
+                                    FormDescription.FIELD_TYPE_MAP.get(field.__class__)),
+                                placeholder=field.initial,
+                                instructions=field.help_text,
+                                required=(self._is_field_required(field_name) or field.required),
+                                restrictions=restrictions,
+                                options=getattr(field, 'choices', None), error_messages=field.error_messages,
+                                include_default_option=field_options.get('include_default_option'),
+                            )
+
         # remove confirm_email form v1 registration form
         if is_api_v1(request):
             for index, field in enumerate(form_desc.fields):

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -318,11 +318,15 @@ class RegistrationFormFactory:
 
     def _is_field_visible(self, field_name):
         """Check whether a field is visible based on Django settings. """
-        return self._extra_fields_setting.get(field_name) in ["required", "optional"]
+        return self._extra_fields_setting.get(field_name) in ["required", "optional", "optional-exposed"]
 
     def _is_field_required(self, field_name):
         """Check whether a field is required based on Django settings. """
         return self._extra_fields_setting.get(field_name) == "required"
+
+    def _is_field_exposed(self, field_name):
+        """Check whether a field is optional and should be toggled. """
+        return self._extra_fields_setting.get(field_name) in ["required", "optional-exposed"]
 
     def __init__(self):
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -987,8 +987,8 @@ class LoginSessionViewTest(ApiTestCase):
         form_desc = json.loads(response.content.decode('utf-8'))
         assert form_desc['method'] == 'post'
         assert form_desc['submit_url'] == reverse('user_api_login_session')
-        assert form_desc['fields'] == [{'name': 'email', 'defaultValue': '', 'type': 'email', 'required': True,
-                                        'label': 'Email', 'placeholder': '',
+        assert form_desc['fields'] == [{'name': 'email', 'defaultValue': '', 'type': 'email', 'exposed': True,
+                                        'required': True, 'label': 'Email', 'placeholder': '',
                                         'instructions': 'The email address you used to register with {platform_name}'
                                         .format(platform_name=settings.PLATFORM_NAME),
                                         'restrictions': {'min_length': EMAIL_MIN_LENGTH,
@@ -1000,6 +1000,7 @@ class LoginSessionViewTest(ApiTestCase):
                                        {'name': 'password',
                                         'defaultValue': '',
                                         'type': 'password',
+                                        'exposed': True,
                                         'required': True,
                                         'label': 'Password',
                                         'placeholder': '',

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -559,15 +559,15 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
             }
         )
 
-        self._assert_reg_field(
+        self._assert_reg_absent_field(
             no_extra_fields_setting,
             {
-                "name": "favorite_editor",
-                "type": "select",
+                "name": u"favorite_editor",
+                "type": u"select",
                 "required": False,
-                "label": "Favorite Editor",
-                "placeholder": "cat",
-                "defaultValue": "vim",
+                "label": u"Favorite Editor",
+                "placeholder": u"cat",
+                "defaultValue": u"vim",
                 "errorMessages": {
                     'required': 'This field is required.',
                     'invalid_choice': 'Select a valid choice. %(value)s is not one of the available choices.',
@@ -1161,6 +1161,7 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
             "honor_code": "required",
             "confirm_email": "required",
         },
+        REGISTRATION_FIELD_ORDER=None,
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
     )
     def test_field_order(self):
@@ -1170,9 +1171,22 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names == ['email', 'name', 'username', 'password', 'favorite_movie', 'favorite_editor',
-                               'city', 'state', 'country', 'gender', 'year_of_birth', 'level_of_education',
-                               'mailing_address', 'goals', 'honor_code']
+        assert field_names == [
+            "email",
+            "name",
+            "username",
+            "password",
+            "city",
+            "state",
+            "country",
+            "gender",
+            "year_of_birth",
+            "level_of_education",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "favorite_movie",
+        ]
 
     @override_settings(
         REGISTRATION_EXTRA_FIELDS={
@@ -1260,9 +1274,23 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names == ['email', 'name', 'username', 'password', 'favorite_movie', 'favorite_editor', 'city',
-                               'state', 'country', 'gender', 'year_of_birth', 'level_of_education',
-                               'mailing_address', 'goals', 'honor_code']
+
+        assert field_names == [
+            "name",
+            "password",
+            "gender",
+            "year_of_birth",
+            "level_of_education",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "city",
+            "country",
+            "email",
+            "favorite_movie",
+            "state",
+            "username",
+        ]
 
     def test_register(self):
         # Create a new registration
@@ -1719,6 +1747,31 @@ class RegistrationViewTestV1(ThirdPartyAuthTestMixin, UserAPITestCase):
 
         self._assert_fields_match(actual_field, expected_field)
 
+    def _assert_reg_absent_field(self, extra_fields_setting, expected_absent_field: str):
+        """
+        Retrieve the registration form description from the server and
+        verify that it not contains the expected absent field.
+
+        Args:
+            extra_fields_setting (dict): Override the Django setting controlling
+                which extra fields are displayed in the form.
+            expected_absent_field (str): The field name we expect to be absent in the form.
+
+        Raises:
+            AssertionError
+        """
+        # Retrieve the registration form description
+        with override_settings(REGISTRATION_EXTRA_FIELDS=extra_fields_setting):
+            response = self.client.get(self.url)
+            self.assertHttpOK(response)
+
+        # Verify that the form description matches what we'd expect
+        form_desc = json.loads(response.content.decode('utf-8'))
+
+        current_present_field_names = [field["name"] for field in form_desc["fields"]]
+        assert expected_absent_field not in current_present_field_names, \
+            "Expected absent field {expected}".format(expected=expected_absent_field)
+
     def _assert_password_field_hidden(self, field_settings):
         self._assert_reg_field(field_settings, {
             "name": "password",
@@ -1787,9 +1840,23 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
 
-        assert field_names == ['email', 'name', 'username', 'password', 'favorite_movie', 'favorite_editor',
-                               'confirm_email', 'city', 'state', 'country', 'gender', 'year_of_birth',
-                               'level_of_education', 'mailing_address', 'goals', 'honor_code']
+        assert field_names == [
+            "name",
+            "confirm_email",
+            "password",
+            "gender",
+            "year_of_birth",
+            "level_of_education",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "city",
+            "country",
+            "email",
+            "favorite_movie",
+            "state",
+            "username",
+        ]
 
     @override_settings(
         REGISTRATION_EXTRA_FIELDS={
@@ -1854,6 +1921,7 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
             "honor_code": "required",
             "confirm_email": "required",
         },
+        REGISTRATION_FIELD_ORDER=None,
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
     )
     def test_field_order(self):
@@ -1863,10 +1931,23 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
         # Verify that all fields render in the correct order
         form_desc = json.loads(response.content.decode('utf-8'))
         field_names = [field["name"] for field in form_desc["fields"]]
-        assert field_names ==\
-               ['email', 'name', 'username', 'password', 'favorite_movie', 'favorite_editor', 'confirm_email',
-                'city', 'state', 'country', 'gender', 'year_of_birth', 'level_of_education', 'mailing_address',
-                'goals', 'honor_code']
+        assert field_names == [
+            "email",
+            "name",
+            "username",
+            "password",
+            "confirm_email",
+            "city",
+            "state",
+            "country",
+            "gender",
+            "year_of_birth",
+            "level_of_education",
+            "mailing_address",
+            "goals",
+            "honor_code",
+            "favorite_movie",
+        ]
 
     def test_registration_form_confirm_email(self):
         self._assert_reg_field(

--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -650,8 +650,8 @@ class PasswordResetViewTest(UserAPITestCase):
         assert form_desc['method'] == 'post'
         assert form_desc['submit_url'] == reverse('password_change_request')
         assert form_desc['fields'] ==\
-               [{'name': 'email', 'defaultValue': '', 'type': 'email', 'required': True,
-                 'label': 'Email', 'placeholder': 'username@domain.com',
+               [{'name': 'email', 'defaultValue': '', 'type': 'email', 'exposed': True,
+                 'required': True, 'label': 'Email', 'placeholder': 'username@domain.com',
                  'instructions': 'The email address you used to register with {platform_name}'
                 .format(platform_name=settings.PLATFORM_NAME),
                  'restrictions': {'min_length': EMAIL_MIN_LENGTH,


### PR DESCRIPTION
## Description

This PR cherry-picks registration form improvements/bug fixes.

1. Defines optional extra fields that are not hidden under the toggle on the registration page
2. Fix use a registration field order when using a registration extension form

## Supporting information

Cherry picked from commit 230795fb07dd32dd8f146a392285bf7bd23db978 and 6f0255bc6030adb977dce300c1c59db439424ff6

## Deadline

None

## Other information

N/A
