### PR TITLE
fix: fix redirect unauthenticated users to login middleware for TPA [BB-5090]

### DIFF
--- a/openedx/core/djangoapps/user_authn/middleware.py
+++ b/openedx/core/djangoapps/user_authn/middleware.py
@@ -17,7 +17,8 @@ class RedirectUnauthenticatedToLoginMiddleware:
     register pages.
 
     If redirects, passes the requested url to login as 'next' query string
-    parameter.
+    parameter. If the original url has a 'tpa_hint' query parameter, the
+    parameter is passed to login without being escaped.
 
     To enable the middleware, ENABLE_REDIRECT_UNAUTHENTICATED_USERS_TO_LOGIN
     setting has to be set to True.
@@ -55,6 +56,11 @@ class RedirectUnauthenticatedToLoginMiddleware:
         Generates query string for redirect.
         """
         # calling copy to get mutable QueryDict
-        query = QueryDict().copy()
-        query['next'] = request.get_full_path()
-        return query.urlencode()
+        request_query = request.GET.copy()
+        redirect_query = QueryDict().copy()
+
+        if 'tpa_hint' in request_query:
+            redirect_query.setlist('tpa_hint', request_query.pop('tpa_hint'))
+        redirect_query['next'] = request.path + '?' + request_query.urlencode()
+
+        return redirect_query.urlencode()

--- a/openedx/core/djangoapps/user_authn/tests/test_middlewares.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_middlewares.py
@@ -141,3 +141,15 @@ class RedirectUnauthenticatedToLoginMiddlewareTests(TestCase):
         response = self.middleware(request)
 
         self.assertEqual(response, self.mock_response)
+
+    @ddt.data(*RedirectUnauthenticatedToLoginMiddleware.WHITELIST)
+    def test_does_not_redirect_unauthenticated_user_if_path_in_whitelist(self, whitelisted_url):
+        """
+        Middleware doesn't redirect if requested path is whitelisted.
+        """
+        request = RequestFactory().get(whitelisted_url + 'test')
+        request.user = AnonymousUserFactory.create()
+
+        response = self.middleware(request)
+
+        self.assertEqual(response, self.mock_response)

--- a/openedx/core/djangoapps/user_authn/tests/test_middlewares.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_middlewares.py
@@ -73,6 +73,27 @@ class RedirectUnauthenticatedToLoginMiddlewareTests(TestCase):
         self.assertIn('next', query)
         self.assertEqual(query['next'], '/dashboard?test=123')
 
+    def test_passes_tpa_hint_parameter_to_login(self):
+        """
+        Middleware passes 'tpa_hint' query parameter to login.
+
+        When redirecting, if the original url has 'tpa_hint' query string
+        parameter, the middleware does not pass the parameter throug the 'next'
+        query string parameter, doesn't escape it, and passes it to login as
+        normal query string parameter.
+        """
+        request = RequestFactory().get('/dashboard?tpa_hint=test-tpa&test=123')
+        request.user = AnonymousUserFactory.create()
+
+        response = self.middleware(request)
+
+        self.assertNotEqual(response, self.mock_response)
+        query = QueryDict(urlparse(response.url).query)
+        self.assertIn('next', query)
+        self.assertEqual(query['next'], '/dashboard?test=123')
+        self.assertIn('tpa_hint', query)
+        self.assertEqual(query['tpa_hint'], 'test-tpa')
+
     def test_does_not_redirect_if_user_is_authenticated(self):
         """
         Middleware doesn't redirect authenticated users.


### PR DESCRIPTION
## Description
This PR fixes issues which `RedirectUnauthenticatedToLoginMiddleware` causes when enabled together with [hinted sign in](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_advanced_features.html#hinted-sign-in) and third part authentication.

## Useful links
[BB-5090](https://tasks.opencraft.com/browse/BB-5090)
[comment that describes the issue](https://tasks.opencraft.com/browse/BB-5090?focusedCommentId=230367&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-230367)
[Hinted Sign In](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_advanced_features.html#hinted-sign-in)