### PR TITLE
feat: redirect unauthenticated users to login page [BB-5090] [BB-5351]

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -16,6 +16,7 @@
 <%!
 import six
 from lms.djangoapps.branding import api as branding_api
+from django.http import QueryDict
 from django.urls import reverse
 from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext as _
@@ -31,6 +32,41 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
 <!--[if lte IE 9]><html class="ie ie9 lte9" lang="${LANGUAGE_CODE}"><![endif]-->
 <!--[if !IE]><!--><html lang="${LANGUAGE_CODE}"><!--<![endif]-->
 <head dir="${static.dir_rtl()}">
+
+<%
+def is_authentication_page():
+  """
+  Checks if the page loaded is an authentication page.
+  """
+  return (
+    request.path.startswith('/login') or
+    request.path.startswith('/register')
+  )
+
+def should_auto_login_user():
+  """
+  Checks if user should be auto-logged
+  """
+  return (
+    (not is_authentication_page()) and
+    (not user.is_authenticated)
+  )
+
+def get_login_page():
+  """
+  Gets login page url, with ?next redirection to previous requested page
+  """
+  # calling copy to get mutable QueryDict
+  query = QueryDict().copy()
+  query['next'] = request.get_full_path()
+  return request.build_absolute_uri('/login?' + query.urlencode())
+%>
+
+    % if should_auto_login_user():
+      <style>html{display:none;}</style>
+      <meta http-equiv="refresh" content="0.0;url=${get_login_page()}">
+    % endif
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
### Description
Prevent any unauthenticated users from being able to view LMS content, by redirecting them to the login page.

Implemented through changes to the theme, so that only the requests that would return a page with some content would get affected by this change. There has been an attempt at implementing it through a middleware (see BB-5090), however, it was interfering with admin panel, API endpoints and other urls.

### Tickets:
[BB-5090](https://tasks.opencraft.com/browse/BB-5090)
[BB-5351](https://tasks.opencraft.com/browse/BB-5351)