### PR TITLE
backport: reset a Randomized Content Block via AJAX

### DIFF
--- a/common/lib/xmodule/xmodule/assets/library_content/public/js/library_content_reset.js
+++ b/common/lib/xmodule/xmodule/assets/library_content/public/js/library_content_reset.js
@@ -4,8 +4,14 @@ function LibraryContentReset(runtime, element) {
     e.preventDefault();
     $.post({
       url: runtime.handlerUrl(element, 'reset_selected_children'),
-      success() {
-        location.reload();
+      success(data) {
+        edx.HtmlUtils.setHtml(element, edx.HtmlUtils.HTML(data));
+        // Rebind the reset button for the block
+        XBlock.initializeBlock(element);
+        // Render the new set of problems (XBlocks)
+        $(".xblock", element).each(function(i, child) {
+          XBlock.initializeBlock(child);
+        });
       },
     });
   });

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -375,7 +375,7 @@ class LibraryContentBlock(
                 block.save()
 
         self.selected = []
-        return Response()
+        return Response(json.dumps(self.student_view({}).content))
 
     def _get_selected_child_blocks(self):
         """


### PR DESCRIPTION
This backports [edx#29728](https://github.com/openedx/edx-platform/pull/29728) to the echo branch.