### PR TITLE
[BB-5329] Added date configuration to Schedule & Details settings page

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1146,6 +1146,12 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
 
             course_authoring_microfrontend_url = get_proctored_exam_settings_url(course_module)
 
+            date_placeholder_format = configuration_helpers.get_value_for_org(
+                course_module.location.org,
+                'SCHEDULE_DETAIL_FORMAT',
+                settings.FEATURES.get('SCHEDULE_DETAIL_FORMAT', 'mm/dd/yyyy')
+            ).upper()
+
             settings_context = {
                 'context_course': course_module,
                 'course_locator': course_key,
@@ -1170,6 +1176,7 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
                 'enable_extended_course_details': enable_extended_course_details,
                 'upgrade_deadline': upgrade_deadline,
                 'course_authoring_microfrontend_url': course_authoring_microfrontend_url,
+                'date_placeholder_format': date_placeholder_format,
             }
             if is_prerequisite_courses_enabled():
                 courses, in_process_course_actions = get_courses_accessible_to_user(request)

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -464,6 +464,14 @@ FEATURES = {
     #   in the LMS and CMS.
     # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/429'
     'DISABLE_UNENROLLMENT': False,
+
+    # .. toggle_name: FEATURES['SCHEDULE_DETAIL_FORMAT']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: 'MM/DD/YYYY'
+    # .. toggle_description: Configure dates to show up in various formats.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-02-05
+    'SCHEDULE_DETAIL_FORMAT': 'MM/DD/YYYY',
 }
 
 ENABLE_JASMINE = False

--- a/cms/static/js/utils/date_utils.js
+++ b/cms/static/js/utils/date_utils.js
@@ -145,7 +145,12 @@ function($, date, TriggerChangeEventOnEnter, moment) {
 
         // instrument as date and time pickers
         timefield.timepicker({timeFormat: 'H:i'});
-        datefield.datepicker();
+        var placeholder = datefield.attr('placeholder');
+        if (placeholder == 'DD/MM/YYYY') {
+            datefield.datepicker({dateFormat: 'dd/mm/yy'});
+        } else {
+            datefield.datepicker();
+        }
 
         // Using the change event causes setfield to be triggered twice, but it is necessary
         // to pick up when the date is typed directly in the field.

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -222,7 +222,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-course-start" id="course-start">
               <div class="field date" id="field-course-start-date">
                 <label for="course-start-date">${_("Course Start Date")}</label>
-                <input type="text" class="start-date date start datepicker" id="course-start-date" placeholder="MM/DD/YYYY" autocomplete="off" />
+                <input type="text" class="start-date date start datepicker" id="course-start-date" placeholder="${date_placeholder_format}" autocomplete="off" />
                 <span class="tip tip-stacked">${_("First day the course begins")}</span>
               </div>
 
@@ -236,7 +236,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-course-end" id="course-end">
               <div class="field date" id="field-course-end-date">
                 <label for="course-end-date">${_("Course End Date")}</label>
-                <input type="text" class="end-date date end" id="course-end-date" placeholder="MM/DD/YYYY" autocomplete="off" />
+                <input type="text" class="end-date date end" id="course-end-date" placeholder="${date_placeholder_format}" autocomplete="off" />
                 <span class="tip tip-stacked">${_("Last day your course is active")}</span>
               </div>
 
@@ -253,7 +253,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-certificate-available" id="certificate-available">
               <div class="field date" id="field-certificate-available-date">
                 <label for="certificate-available-date">${_("Certificates Available Date")}</label>
-                <input type="text" class="certificate-available-date date start datepicker" id="certificate-available-date" placeholder="MM/DD/YYYY" autocomplete="off" />
+                <input type="text" class="certificate-available-date date start datepicker" id="certificate-available-date" placeholder="${date_placeholder_format}" autocomplete="off" />
                 <span class="tip tip-stacked">${_("By default, 48 hours after course end date")}</span>
               </div>
             </li>
@@ -264,7 +264,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-enrollment-start" id="enrollment-start">
               <div class="field date" id="field-enrollment-start-date">
                 <label for="course-enrollment-start-date">${_("Enrollment Start Date")}</label>
-                <input type="text" class="start-date date start" id="course-enrollment-start-date" placeholder="MM/DD/YYYY" autocomplete="off" />
+                <input type="text" class="start-date date start" id="course-enrollment-start-date" placeholder="${date_placeholder_format}" autocomplete="off" />
                 <span class="tip tip-stacked">${_("First day students can enroll")}</span>
               </div>
 
@@ -281,7 +281,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-enrollment-end" id="enrollment-end">
               <div class="field date ${enrollment_end_editable_class}" id="field-enrollment-end-date">
                 <label for="course-enrollment-end-date">${_("Enrollment End Date")}</label>
-                <input type="text" class="end-date date end" id="course-enrollment-end-date" placeholder="MM/DD/YYYY" autocomplete="off" ${enrollment_end_readonly} />
+                <input type="text" class="end-date date end" id="course-enrollment-end-date" placeholder="${date_placeholder_format}" autocomplete="off" ${enrollment_end_readonly} />
                 <span class="tip tip-stacked">
                   ${_("Last day students can enroll.")}
                 % if not enrollment_end_editable:
@@ -303,7 +303,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="field-group field-group-upgrade-deadline" id="upgrade-deadline">
               <div class="field date is-not-editable" id="field-upgrade-deadline-date">
                 <label for="course-upgrade-deadline-date">${_("Upgrade Deadline Date")}</label>
-                <input type="text" class="date upgrade-deadline" id="course-upgrade-deadline-date" placeholder="MM/DD/YYYY" autocomplete="off" readonly aria-readonly="true" />
+                <input type="text" class="date upgrade-deadline" id="course-upgrade-deadline-date" placeholder="${date_placeholder_format}" autocomplete="off" readonly aria-readonly="true" />
                 <span class="tip tip-stacked">
                   ${_("Last day students can upgrade to a verified enrollment.")}
                   ${_("Contact your edX partner manager to update these settings.")}


### PR DESCRIPTION
## Description

Adds the ability to configure Schedule & Details settings page with the ability to show `dd/mm/yyyy` format. Default setting maintains existing behavior and doesn't introduce anything new.
Why:
Some areas of the world operate with the day-first: `dd/mm/yyyy` rather than `mm/dd/yyyy`.

**JIRA tickets**: [BB-5329](https://tasks.opencraft.com/browse/BB-5429)

~~**Discussions**: Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.~~

~~**Dependencies**: None~~

**Screenshots**: 

![image](https://user-images.githubusercontent.com/7670449/152991264-d7efea43-d392-4abf-b20c-adb7d3b0cab7.png)


~~**Sandbox URL**: TBD - sandbox is being provisioned.~~

**Merge deadline**: None

## Testing instructions

* Initialize lilac devstack to use branch
* Look at the studio --> course(Demo Course) --> settings --> Schedule and Details
* Go under the Course Schedule section and you will see the date format is MM/DD/YYYY
* Now drop in the studio shell `make dev.shell.studio`
* Edit /edx/etc/studio.yml and under `Features` add `SCHEDULE_DETAIL_FORMAT: 'DD/MM/YYYY'`

``
FEATURES:
    ...
    SCHEDULE_DETAIL_FORMAT: 'DD/MM/YYYY'
    ...
``
* Restart studio `make dev.restart-devserver.studio`
* Now check the page again you will see the date format has changed to `DD/MM/YYYY`

**Author notes and concerns**:

- No change to role(s)
- There is no before or after, as the change includes default configuration to remain consistent with preexisting behavior. 
- https://github.com/open-craft/edx-platform/blob/jbcurtin/bb-5429-date-configuration/cms/envs/common.py#L459

**Reviewers**
- [ ] @farhaanbukhsh 
- [ ] @jbcurtin 
