### PR TITLE
revert: Remove CSS that hides the signatures on custom certificates

### DIFF
--- a/lms/static/certificates/sass/_components.scss
+++ b/lms/static/certificates/sass/_components.scss
@@ -497,6 +497,12 @@
     .accomplishment-type {
       margin-top: 0;
     }
+
+    // hide the fancy
+    .accomplishment-signatories .signatory-signature,
+    .accomplishment-type-symbol {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
### Description
This reverts "Remove CSS that hides the signatures on custom certificates"

### Testing Instructions

1. Checkout this branch
2. Install the ASU-YTP theme
3. Setup the certificate
4. Check the [certificate](http://localhost:18000/certificates/course/course-v1:edX+DemoX+Demo_Course?preview=verified), and see the signature is shown since theme is overwriting this 