### PR TITLE
[BB-6041] Convert compliance warning back to html

### DIFF
--- a/openedx/core/djangoapps/password_policy/forms.py
+++ b/openedx/core/djangoapps/password_policy/forms.py
@@ -6,6 +6,7 @@ from django.contrib.admin.forms import AdminAuthenticationForm
 from django.forms import ValidationError
 
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
+from openedx.core.djangolib.markup import HTML
 
 
 class PasswordPolicyAwareAdminAuthForm(AdminAuthenticationForm):
@@ -24,9 +25,9 @@ class PasswordPolicyAwareAdminAuthForm(AdminAuthenticationForm):
                 password_policy_compliance.enforce_compliance_on_login(self.user_cache, cleaned_data['password'])
             except password_policy_compliance.NonCompliantPasswordWarning as e:
                 # Allow login, but warn the user that they will be required to reset their password soon.
-                messages.warning(self.request, str(e))
+                messages.warning(self.request, HTML(str(e)))
             except password_policy_compliance.NonCompliantPasswordException as e:
                 # Prevent the login attempt.
-                raise ValidationError(str(e))  # lint-amnesty, pylint: disable=raise-missing-from
+                raise ValidationError(HTML(str(e)))  # lint-amnesty, pylint: disable=raise-missing-from
 
         return cleaned_data

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -149,7 +149,7 @@ def _enforce_password_policy_compliance(request, user):  # lint-amnesty, pylint:
         password_policy_compliance.enforce_compliance_on_login(user, request.POST.get('password'))
     except password_policy_compliance.NonCompliantPasswordWarning as e:
         # Allow login, but warn the user that they will be required to reset their password soon.
-        PageLevelMessages.register_warning_message(request, str(e))
+        PageLevelMessages.register_warning_message(request, HTML(str(e)))
     except password_policy_compliance.NonCompliantPasswordException as e:
         AUDIT_LOG.info("Password reset initiated for email %s.", user.email)
         send_password_reset_email_for_user(user, request)


### PR DESCRIPTION
This PR converts the password compliance warning message back to HTML. It was converted to string as part of additional security but that resulted in HTML attributes not being applied while displaying the warning message.

**Jira tickets:** [BB-6041](https://tasks.opencraft.com/browse/BB-6041)


**Screenshots**

Before fix:
![esme-password-warning](https://user-images.githubusercontent.com/13742492/160233531-e406e301-0059-4b4f-a48d-ed460814a365.png)


After fix:
![esme-stage-warning-after-fix](https://user-images.githubusercontent.com/13742492/160233541-2d607b9e-6a47-4e8a-a136-1d7efb6d030a.png)


**Testing Instructions:**
The fix is already deployed to Esme staging so it can be verified there. The minimum password length has been set to 20.
1. Register/login with password less than the minimum length requirement.
2. After login, verify that the warning message is shown correctly.

**Reviewers:**

- [ ] @DubeySandeep 
