### PR TITLE
feat: add custom html templates for components [bb-5885]

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1970,6 +1970,12 @@ DEFAULT_SITE_THEME = None
 # .. toggle_creation_date: 2016-06-30
 ENABLE_COMPREHENSIVE_THEMING = False
 
+# .. setting_name: CUSTOM_RESOURCE_TEMPLATES_DIRECTORY
+# .. setting_default: None
+# .. setting_description: Path to existing directory containing resource templates.
+#   "CUSTOM_RESOURCE_TEMPLATES_DIRECTORY" : null
+CUSTOM_RESOURCE_TEMPLATES_DIRECTORY = []
+
 ############################ Global Database Configuration #####################
 
 DATABASE_ROUTERS = [

--- a/common/lib/xmodule/xmodule/tests/test_resource_templates.py
+++ b/common/lib/xmodule/xmodule/tests/test_resource_templates.py
@@ -1,11 +1,13 @@
 """
 Tests for xmodule.x_module.ResourceTemplates
 """
-
-
+import pathlib
 import unittest
 
 from xmodule.x_module import ResourceTemplates
+from django.test import override_settings
+
+CUSTOM_RESOURCE_TEMPLATES_DIRECTORY = pathlib.Path(__file__).parent.parent / "templates/"
 
 
 class ResourceTemplatesTests(unittest.TestCase):
@@ -27,6 +29,20 @@ class ResourceTemplatesTests(unittest.TestCase):
 
     def test_get_template(self):
         assert TestClass.get_template('latex_html.yaml')['template_id'] == 'latex_html.yaml'
+
+    @override_settings(CUSTOM_RESOURCE_TEMPLATES_DIRECTORY=CUSTOM_RESOURCE_TEMPLATES_DIRECTORY)
+    def test_get_custom_template(self):
+        assert TestClassResourceTemplate.get_template('latex_html.yaml')['template_id'] == 'latex_html.yaml'
+
+    @override_settings(CUSTOM_RESOURCE_TEMPLATES_DIRECTORY=CUSTOM_RESOURCE_TEMPLATES_DIRECTORY)
+    def test_custom_templates(self):
+        expected = {
+            'latex_html.yaml',
+            'zooming_image.yaml',
+            'announcement.yaml',
+            'anon_user_id.yaml'}
+        got = {t['template_id'] for t in TestClassResourceTemplate.templates()}
+        assert expected == got
 
 
 class TestClass(ResourceTemplates):
@@ -55,3 +71,14 @@ class TestClass2(TestClass):
     @classmethod
     def get_template_dir(cls):
         return 'foo'
+
+
+class TestClassResourceTemplate(ResourceTemplates):
+    """
+    Like TestClass, but `template_packages` contains a module that doesn't
+    have any templates.
+
+    See `TestClass`.
+    """
+    template_packages = ['capa.checker']
+    template_dir_name = 'test'

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -10,11 +10,12 @@ from functools import partial
 import yaml
 from contracts import contract, new_contract
 from django.utils.encoding import python_2_unicode_compatible
+from django.conf import settings
 from lazy import lazy
 from lxml import etree
 from opaque_keys.edx.asides import AsideDefinitionKeyV2, AsideUsageKeyV2
 from opaque_keys.edx.keys import UsageKey
-from pkg_resources import resource_exists, resource_isdir, resource_listdir, resource_string
+from pkg_resources import resource_exists, resource_isdir, resource_listdir, resource_string, resource_filename
 from web_fragments.fragment import Fragment
 from webob import Response
 from webob.multidict import MultiDict
@@ -1039,6 +1040,35 @@ class ResourceTemplates:
     template_packages = [__name__]
 
     @classmethod
+    def _load_template(cls, template_path, template_id):
+        """
+        Reads an loads the yaml content provided in the template_path and
+        return the content as a dictionary.
+        """
+        if not os.path.exists(template_path):
+            return None
+
+        with open(template_path) as file_object:
+            template = yaml.safe_load(file_object)
+            template['template_id'] = template_id
+            return template
+
+    @classmethod
+    def _load_templates_in_dir(cls, dirpath):
+        """
+        Lists every resource template found in the provided dirpath.
+        """
+        templates = []
+        for template_file in os.listdir(dirpath):
+            if not template_file.endswith('.yaml'):
+                log.warning("Skipping unknown template file %s", template_file)
+                continue
+
+            template = cls._load_template(os.path.join(dirpath, template_file), template_file)
+            templates.append(template)
+        return templates
+
+    @classmethod
     def templates(cls):
         """
         Returns a list of dictionary field: value objects that describe possible templates that can be used
@@ -1047,21 +1077,21 @@ class ResourceTemplates:
         Expects a class attribute template_dir_name that defines the directory
         inside the 'templates' resource directory to pull templates from
         """
-        templates = []
+        templates = {}
         dirname = cls.get_template_dir()
         if dirname is not None:
             for pkg in cls.template_packages:
                 if not resource_isdir(pkg, dirname):
                     continue
-                for template_file in resource_listdir(pkg, dirname):
-                    if not template_file.endswith('.yaml'):
-                        log.warning("Skipping unknown template file %s", template_file)
-                        continue
-                    template_content = resource_string(pkg, os.path.join(dirname, template_file))
-                    template = yaml.safe_load(template_content)
-                    template['template_id'] = template_file
-                    templates.append(template)
-        return templates
+                for template in cls._load_templates_in_dir(resource_filename(pkg, dirname)):
+                    templates[template['template_id']] = template
+
+        custom_template_dir = cls.get_custom_template_dir()
+        if custom_template_dir is not None:
+            for template in cls._load_templates_in_dir(custom_template_dir):
+                templates[template['template_id']] = template
+
+        return list(templates.values())
 
     @classmethod
     def get_template_dir(cls):  # lint-amnesty, pylint: disable=missing-function-docstring
@@ -1079,21 +1109,48 @@ class ResourceTemplates:
             return None
 
     @classmethod
+    def get_custom_template_dir(cls):
+        """
+        If settings.CUSTOM_RESOURCE_TEMPLATES_DIRECTORY is defined, check if it has a
+        subdirectory named as the class's template_dir_name and return the full path.
+        """
+        template_dir_name = getattr(cls, 'template_dir_name', None)
+
+        if template_dir_name is None:
+            return
+
+        resource_dir = settings.CUSTOM_RESOURCE_TEMPLATES_DIRECTORY
+
+        if not resource_dir:
+            return None
+
+        template_dir_path = os.path.join(resource_dir, template_dir_name)
+
+        if os.path.exists(template_dir_path):
+            return template_dir_path
+        return None
+
+    @classmethod
     def get_template(cls, template_id):
         """
         Get a single template by the given id (which is the file name identifying it w/in the class's
         template_dir_name)
-
         """
         dirname = cls.get_template_dir()
         if dirname is not None:
             path = os.path.join(dirname, template_id)
             for pkg in cls.template_packages:
                 if resource_exists(pkg, path):
-                    template_content = resource_string(pkg, path)
-                    template = yaml.safe_load(template_content)
-                    template['template_id'] = template_id
-                    return template
+                    abs_path = resource_filename(pkg, path)
+                    return cls._load_template(abs_path, template_id)
+
+        custom_template_dir = cls.get_custom_template_dir()
+
+        if custom_template_dir is not None:
+            abs_path = os.path.join(custom_template_dir, template_id)
+            return cls._load_template(abs_path, template_id)
+
+        return None
 
 
 class XModuleDescriptorToXBlockMixin:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4293,6 +4293,12 @@ DEFAULT_SITE_THEME = None
 # .. toggle_creation_date: 2016-06-30
 ENABLE_COMPREHENSIVE_THEMING = False
 
+# .. setting_name: CUSTOM_RESOURCE_TEMPLATES_DIRECTORY
+# .. setting_default: None
+# .. setting_description: Path to existing directory containing resource templates.
+#   "CUSTOM_RESOURCE_TEMPLATES_DIRECTORY" : null
+CUSTOM_RESOURCE_TEMPLATES_DIRECTORY = []
+
 # API access management
 API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 API_ACCESS_FROM_EMAIL = 'api-requests@example.com'


### PR DESCRIPTION
This PR contains cherry-picked changes from https://github.com/openedx/edx-platform/pull/30108/files. Duplicating the description below.

## Description

At Opencraft, we have clients that want to be able to add custom HTML templates that show up while creating course components in Studio.

Currently, there's no way to achieve this besides forking `edx-platform` and adding the `yaml` files to `common/lib/xmodule/xmodule/templates/`

This PR allows operators to set a custom directory where templates can be additionally loaded from.

- Checks if `settings.CUSTOM_RESOURCE_TEMPLATES_DIRECTORY` exists.
- If so, load the `yaml` files with the same logic as in the `xmodule/templates` directory.

## Supporting information

- Configuration PR: https://github.com/openedx/configuration/pull/6706
- Custom Client Branch: https://github.com/open-craft/edx-platform/pull/453
- Task: https://tasks.opencraft.com/browse/BB-5885
- Sandbox: https://studio.pr30108.sandbox.opencraft.hosting [Sandbox]

## Testing instructions

- Update the setting `settings.CUSTOM_RESOURCE_TEMPLATES_DIRECTORY` to a valid path.
- In that directory create an `html` directory.
- Copy a template from `common/lib/xmodule/xmodule/templates/html` to the above directory with a different filename.
- In the Studio, edit a Unit. Under the **Text** component you should see your new template list (on the Sandbox I've added many).

## Deadline

4 April 2022