### PR TITLE
fix: handle missing COMPLETION_AGGREGATOR_URL setting

### DIFF
--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -199,7 +199,7 @@ ${HTML(fragment.foot_html())}
                             % endif
                             <span class="nav-item nav-item-sequence">${sequence_title}</span>
                         </div>
-                        % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False) and completion_aggregator_url != "":
+                        % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False) and completion_aggregator_url:
                           <div class="container">
                             <iframe style="border: none; height: 50px; position: relative; top: 10px; width: -webkit-fill-available" src="${completion_aggregator_url}/${course.id}/">
                             </iframe>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -22,7 +22,7 @@ from openedx.features.course_experience import course_home_page_title, DISABLE_C
    (course.enable_proctored_exams or course.enable_timed_exams)
    )
 
-   completion_aggregator_url = settings.COMPLETION_AGGREGATOR_URL if settings.FEATURES.get("SHOW_PROGRESS_BAR", False) else ""
+   completion_aggregator_url = getattr(settings, "COMPLETION_AGGREGATOR_URL", "")
 %>
 
 % if display_reset_dates_banner:
@@ -199,7 +199,7 @@ ${HTML(fragment.foot_html())}
                             % endif
                             <span class="nav-item nav-item-sequence">${sequence_title}</span>
                         </div>
-                        % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False):
+                        % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False) and completion_aggregator_url != "":
                           <div class="container">
                             <iframe style="border: none; height: 50px; position: relative; top: 10px; width: -webkit-fill-available" src="${completion_aggregator_url}/${course.id}/">
                             </iframe>

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
  from django.utils.translation import pgettext, ugettext as _
- from django.conf import settings 
+ from django.conf import settings
 %>
 
 <div id="sequence_${element_id}" class="sequence" data-id="${item_id}"
@@ -117,7 +117,7 @@
     ${gated_sequence_paywall | n, decode.utf8}
   % else:
   <div class="sr-is-focusable" tabindex="-1"></div>
-  % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False):
+  % if settings.FEATURES.get("SHOW_PROGRESS_BAR", False) and getattr(settings, 'COMPLETION_AGGREGATOR_URL', ''):
     <div class="progress-container">
       <iframe id="progress-frame" style="border: none; width: 100%; height: 70px;" src="${chapter_completion_aggregator_url}"></iframe>
     </div>


### PR DESCRIPTION
## Description

When the feature `SHOW_PROGRESS_BAR` is set to True and the `COMPLETION_AGGREGATOR_URL` setting is not setup, lms raises template error `Undefined`.

This PR handles such a case by checking for `COMPLETION_AGGREGATOR_URL` as well as `SHOW_PROGRESS_BAR` setting in templates.

## Supporting information
JIRA: [BB-6140](https://tasks.opencraft.com/browse/BB-6140)

## Error raised

```logs
edx.devstack-lilac.master.lms     | 2022-04-22 11:59:58,669 ERROR 8567 [root] [user None] [ip None] signals.py:22 - Uncaught exception from None
edx.devstack-lilac.master.lms     | Traceback (most recent call last):
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
edx.devstack-lilac.master.lms     |     response = get_response(request)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
edx.devstack-lilac.master.lms     |     response = self.process_exception_by_middleware(e, request)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
edx.devstack-lilac.master.lms     |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
edx.devstack-lilac.master.lms     |     return self.dispatch(request, *args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
edx.devstack-lilac.master.lms     |     return bound_method(*args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/generic/base.py", line 97, in dispatch
edx.devstack-lilac.master.lms     |     return handler(request, *args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
edx.devstack-lilac.master.lms     |     return bound_method(*args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 142, in _wrapped_view
edx.devstack-lilac.master.lms     |     response = view_func(request, *args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
edx.devstack-lilac.master.lms     |     return bound_method(*args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/cache.py", line 31, in _cache_controlled
edx.devstack-lilac.master.lms     |     response = viewfunc(request, *args, **kw)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
edx.devstack-lilac.master.lms     |     return bound_method(*args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/common/djangoapps/util/views.py", line 43, in inner
edx.devstack-lilac.master.lms     |     response = view_func(request, *args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 45, in _wrapper
edx.devstack-lilac.master.lms     |     return bound_method(*args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/openedx/features/enterprise_support/api.py", line 365, in inner
edx.devstack-lilac.master.lms     |     return view_func(request, course_id, *args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 153, in get
edx.devstack-lilac.master.lms     |     return CourseTabView.handle_exceptions(request, self.course_key, self.course, exception)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 151, in get
edx.devstack-lilac.master.lms     |     return self.render(request)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 257, in render
edx.devstack-lilac.master.lms     |     return render_to_response('courseware/courseware.html', self._create_courseware_context(request))
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 493, in _create_courseware_context
edx.devstack-lilac.master.lms     |     courseware_context['fragment'] = self.section.render(self.view, section_context)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/xblock/core.py", line 199, in render
edx.devstack-lilac.master.lms     |     return self.runtime.render(self, view, context)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 2032, in render
edx.devstack-lilac.master.lms     |     return self.__getattr__('render')(block, view_name, context)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1477, in render
edx.devstack-lilac.master.lms     |     return super().render(block, view_name, context=context)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/xblock/runtime.py", line 826, in render
edx.devstack-lilac.master.lms     |     frag = view_fn(context)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 430, in student_view
edx.devstack-lilac.master.lms     |     return self._student_or_public_view(context, prereq_met, prereq_meta_info, banner_text)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 551, in _student_or_public_view
edx.devstack-lilac.master.lms     |     fragment.add_content(self.system.render_template("seq_module.html", params))
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/shortcuts.py", line 182, in render_to_string
edx.devstack-lilac.master.lms     |     return template.render(dictionary, request)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/template.py", line 82, in render
edx.devstack-lilac.master.lms     |     return self.mako_template.render_unicode(**context_dictionary)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/template.py", line 478, in render_unicode
edx.devstack-lilac.master.lms     |     return runtime._render(
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 878, in _render
edx.devstack-lilac.master.lms     |     _render_context(
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 920, in _render_context
edx.devstack-lilac.master.lms     |     _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 947, in _exec_template
edx.devstack-lilac.master.lms     |     callable_(context, *args, **kwargs)
edx.devstack-lilac.master.lms     |   File "/tmp/mako_lms/7fa50c86c772c2affd8b5a04d05a85da/seq_module.html.py", line 149, in render_body
edx.devstack-lilac.master.lms     |     __M_writer(filters.html_escape(filters.decode.utf8(chapter_completion_aggregator_url)))
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/filters.py", line 79, in decode
edx.devstack-lilac.master.lms     |     return decode(str(x))
edx.devstack-lilac.master.lms     |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/mako/runtime.py", line 230, in __str__
edx.devstack-lilac.master.lms     |     raise NameError("Undefined")
edx.devstack-lilac.master.lms     | NameError: Undefined

```

## Testing instructions
1. Setup your devstack with this branch.
2. Set the feature flag SHOW_PROGRESS_BAR to true under FEATURES in lms.yml and studio.yml.
3. Do not add the COMPLETION_AGGREGATOR_URL setting in lms.yml
4. Start new course in LMS and verify that no error is raised.