### PR TITLE
[SE-5561] Fix setuptools version conflict

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1080,3 +1080,8 @@ xss-utils==0.2.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
+
+# TODO: @gabor-boros - remove this line when we upgrade to Maple. For more information:
+# https://tasks.opencraft.com/browse/SE-4860
+setuptools<59.7.0,>=59.1.1
+


### PR DESCRIPTION
## Description

Opening any unit in Studio results in this error:
```python


Apr 29 13:01:09 edxapp-demoopencrafthosting-appserver-109 [service_variant=cms][django.request][env:sandbox] ERROR [edxapp-demoopencrafthosting-appserver-109  1725] [user 6] [ip 94.125.122.82] [log.py:222] - Inter
--
nal Server Error: /container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@d91b9e5d8bc64d57a1332d06bf2f2193
Traceback (most recent call last):
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
response = get_response(request)
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
response = self.process_exception_by_middleware(e, request)
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/usr/lib/python3.8/contextlib.py", line 75, in inner
return func(*args, **kwds)
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 563, in wrapper
return wrapped(*args, **kwargs)
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/http.py", line 40, in inner
return func(request, *args, **kwargs)
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/contrib/auth/decorators.py", line 21, in _wrapped_view
return view_func(request, *args, **kwargs)
File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/component.py", line 122, in container_handler
component_templates = get_component_templates(course)
File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/component.py", line 367, in get_component_templates
component_display_name = xblock_type_display_name(component)
File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/helpers.py", line 143, in xblock_type_display_name
component_class = XBlock.load_class(category, select=settings.XBLOCK_SELECT_FUNCTION)
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/xblock/plugin.py", line 115, in load_class
PLUGIN_CACHE[key] = cls._load_class_entry_point(selected_entry_point)
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/xblock/plugin.py", line 70, in _load_class_entry_point
class_ = entry_point.load()
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2446, in load
self.require(*args, **kwargs)
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2469, in require
items = working_set.resolve(reqs, env, installer, extras=self.extras)
File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/pkg_resources/__init__.py", line 775, in resolve
raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (setuptools 50.3.2 (/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages), Requirement.parse('setuptools<59.7.0,>=59.1.1'), {'celery'})
Apr 29 13:01:09 edxapp-demoopencrafthosting-appserver-109 [service_variant=cms][openedx.core.djangoapps.cors_csrf.helpers][env:sandbox] INFO [edxapp-demoopencrafthosting-appserver-109  1725] [user 6]
```

## Tickets

- [SE-5561](https://tasks.opencraft.com/browse/SE-5561)

## Testing instructions

1. [This page](https://studio.demo.opencraft.hosting/container/block-v1:Oppia+CS-OPP+2021-Opp+type@vertical+block@5299e82a581b46e58b6bdbb6d80b9ee8) should work. 

## Post-merge steps

1. Set `edx-platform` version to `opencraft-release/lilac.2` for [this Ocim instance](https://manage.opencraft.com/instance/830/).