### PR TITLE
chore: backport TinyMCE upgrade to echo branch v2 [BB-6151]

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -177,7 +177,7 @@ module.exports = Merge.smart({
                 // https://github.com/webpack/webpack/issues/304#issuecomment-272150177
                 // (I've tried every other suggestion solution on that page, this
                 // was the only one that worked.)
-                /\/sinon\.js|codemirror-compressed\.js|hls\.js|tinymce\.full\.min\.js/
+                /\/sinon\.js|codemirror-compressed\.js|hls\.js|tinymce.js/
             ],
             rules: [
                 {
@@ -381,7 +381,7 @@ module.exports = Merge.smart({
                 'jquery.timepicker': 'timepicker/jquery.timepicker',
                 'backbone.associations': 'backbone-associations/backbone-associations-min',
                 squire: 'Squire',
-                tinymce: 'tinymce.full.min',
+                tinymce: 'tinymce',
 
                 // See sinon/webpack interaction weirdness:
                 // https://github.com/webpack/webpack/issues/304#issuecomment-272150177


### PR DESCRIPTION
This adds a fix after #472, which backported https://github.com/openedx/edx-platform/pull/30335.