### PR TITLE
refactor: [BB-6077] allow setting celery backend in yml

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -102,7 +102,7 @@ BROKER_POOL_LIMIT = 0
 BROKER_CONNECTION_TIMEOUT = 1
 
 # For the Result Store, use the django cache named 'celery'
-CELERY_RESULT_BACKEND = 'django-cache'
+CELERY_RESULT_BACKEND = ENV_TOKENS.get('CELERY_RESULT_BACKEND', 'django-cache')
 
 # When the broker is behind an ELB, use a heartbeat to refresh the
 # connection and to detect if it has been dropped.

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -110,7 +110,7 @@ BROKER_POOL_LIMIT = 0
 BROKER_CONNECTION_TIMEOUT = 1
 
 # For the Result Store, use the django cache named 'celery'
-CELERY_RESULT_BACKEND = 'django-cache'
+CELERY_RESULT_BACKEND = ENV_TOKENS.get('CELERY_RESULT_BACKEND', 'django-cache')
 
 # When the broker is behind an ELB, use a heartbeat to refresh the
 # connection and to detect if it has been dropped.


### PR DESCRIPTION
Cherry pick of: https://github.com/openedx/edx-platform/pull/30244

### Description

Currently, the `CELERY_RESULT_BACKEND` is hard coded to use `django-cache`.

This PR allows to setup `CELERY_RESULT_BACKEND` via `ENV_TOKENS`.

To use django ORM as celery backend, one can set `CELERY_RESULT_BACKEND` to `django-db` as described in [docs](https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html#django-celery-results-using-the-django-orm-cache-as-a-result-backend).