### PR TITLE
[BB-5195] feat: disable allowed enrollment if enrollment closed

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -819,6 +819,13 @@ def user_post_save_callback(sender, **kwargs):
                         cea.save()
                     continue
 
+                # Skip auto enrollment of user if enrollment is not open for the course
+                # We are checking this here instead of passing check_access=True to CourseEnrollment.enroll()
+                # as we want to skip course full check.
+                if CourseEnrollment.is_enrollment_closed(user, CourseOverview.get_from_id(cea.course_id)):
+                    log.info(f'Skipping auto enrollment of user as enrollment for course {cea.course_id} has ended')
+                    continue
+
                 enrollment = CourseEnrollment.enroll(user, cea.course_id)
 
                 manual_enrollment_audit = ManualEnrollmentAudit.get_manual_enrollment_by_email(user.email)

--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -14,6 +14,7 @@ from common.djangoapps.student.models import CourseEnrollmentAllowed
 from common.djangoapps.student.tests.factories import CourseEnrollmentAllowedFactory, UserFactory
 from common.djangoapps.student.tests.tests import UserSettingsEventTestMixin
 
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 
 class TestUserProfileEvents(UserSettingsEventTestMixin, TestCase):
     """
@@ -163,6 +164,10 @@ class TestUserEvents(UserSettingsEventTestMixin, TestCase):
         Test that when a user's email changes, the user is enrolled in pending courses.
         """
         pending_enrollment = CourseEnrollmentAllowedFactory(auto_enroll=True)  # lint-amnesty, pylint: disable=unused-variable
+
+        # Create a CourseOverview for the enrollment course
+        course_overview = CourseOverviewFactory.create(id=pending_enrollment.course_id)
+        course_overview.save()
 
         # the e-mail will change to test@edx.org (from something else)
         assert self.user.email != 'test@edx.org'

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -8,9 +8,10 @@ import pytz
 from crum import set_current_request
 from django.contrib.auth.models import AnonymousUser, User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core.cache import cache
+from django.conf import settings
 from django.db.models import signals  # pylint: disable=unused-import
 from django.db.models.functions import Lower
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from edx_toggles.toggles.testutils import override_waffle_flag
 from freezegun import freeze_time
 from opaque_keys.edx.keys import CourseKey
@@ -36,6 +37,7 @@ from lms.djangoapps.courseware.toggles import (
     REDIRECT_TO_COURSEWARE_MICROFRONTEND
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.schedules.models import Schedule
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -677,6 +679,42 @@ class TestUserPostSaveCallback(SharedModuleStoreTestCase):
         assert actual_course_enrollment.mode == 'audit'
         assert actual_student.is_active is True
         assert actual_cea.user == student
+
+    @ddt.data(False, True)
+    def test_auto_enrollment_if_course_enrollment_closed(self, feature_enabled):
+        """
+        Test the following scenarios
+
+        1. Invited students who register when enrollment is closed are not enrolled if
+        DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED is True
+
+        2. Invited students who register when enrollment is closed are enrolled if
+        DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED is False
+        """
+
+        def register_and_enroll_student():
+            student = self._set_up_invited_student(
+                course=self.course,
+                active=False,
+                enrolled=False
+            )
+            student.is_active = True
+            # trigger the post_save callback
+            student.save()
+            return CourseEnrollment.get_enrollment(student, self.course.id)
+
+        # Set enrollment end date to a past date so that enrollment is ended
+        enrollment_end = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=2)
+        course_overview = CourseOverviewFactory.create(id=self.course.id, enrollment_end=enrollment_end)
+        course_overview.save()
+
+        if feature_enabled:
+            with override_settings(
+                FEATURES={**settings.FEATURES, 'DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED': True}
+            ):
+                assert register_and_enroll_student() is None
+        else:
+            assert register_and_enroll_student() is not None
 
     def test_verified_student_not_downgraded_when_changing_email(self):
         """

--- a/common/lib/xmodule/xmodule/course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/course_metadata_utils.py
@@ -110,6 +110,20 @@ def has_course_ended(end_date):
     return datetime.now(utc) > end_date if end_date is not None else False
 
 
+def is_enrollment_open(enrollment_start_date, enrollment_end_date):
+    """
+    Given a course's enrollment start and end datetime, returns if enrollment is open
+
+    Arguments:
+        enrollment_start_date (datetime): The enrollment start datetime of the course.
+        enrollment_end_date (datetime): The enrollment end datetime of the course.
+    """
+    now = datetime.now(utc)
+    enrollment_start_date = enrollment_start_date or datetime.min.replace(tzinfo=utc)
+    enrollment_end_date = enrollment_end_date or datetime.max.replace(tzinfo=utc)
+    return enrollment_start_date < now < enrollment_end_date
+
+
 def course_starts_within(start_date, look_ahead_days):
     """
     Given a course's start datetime and look ahead days, returns True if

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1225,6 +1225,12 @@ class CourseBlock(
     def has_started(self):
         return course_metadata_utils.has_course_started(self.start)
 
+    def is_enrollment_open(self):
+        """
+        Returns True if course enrollment is open
+        """
+        return course_metadata_utils.is_enrollment_open(self.enrollment_start, self.enrollment_end)
+
     @property
     def grader(self):
         return grader_from_conf(self.raw_grader)

--- a/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
@@ -21,6 +21,7 @@ from xmodule.course_metadata_utils import (
     has_course_ended,
     has_course_started,
     may_certify_for_course,
+    is_enrollment_open,
     number_for_course_location
 )
 from xmodule.modulestore.tests.utils import (
@@ -59,7 +60,21 @@ class CourseMetadataUtilsTestCase(TestCase):
                     user_id=-3,  # -3 refers to a "testing user"
                     fields={
                         "start": _LAST_MONTH,
-                        "end": _LAST_WEEK
+                        "end": _LAST_WEEK,
+                        "enrollment_start": _LAST_MONTH,
+                        "enrollment_end": _LAST_WEEK
+                    }
+                )
+            with mixed_store.default_store('mongo'):
+                self.demo_course_enrollment_end = mixed_store.create_course(
+                    org="edX",
+                    course="DemoX.2",
+                    run="Fall_2014_1",
+                    user_id=-3,  # -3 refers to a "testing user"
+                    fields={
+                        "start": _LAST_MONTH,
+                        "end": _LAST_WEEK,
+                        "enrollment_end": _LAST_WEEK
                     }
                 )
             with mixed_store.default_store('split'):
@@ -70,7 +85,20 @@ class CourseMetadataUtilsTestCase(TestCase):
                     user_id=-3,  # -3 refers to a "testing user"
                     fields={
                         "start": _NEXT_WEEK,
-                        "display_name": "Intro to <div>html</div>"
+                        "display_name": "Intro to <div>html</div>",
+                        "enrollment_start": _NEXT_WEEK,
+                    }
+                )
+            with mixed_store.default_store('split'):
+                self.html_course_enrollment_start = mixed_store.create_course(
+                    org="UniversityX",
+                    course="CS-204",
+                    run="Y2097",
+                    user_id=-3,  # -3 refers to a "testing user"
+                    fields={
+                        "start": _LAST_WEEK,
+                        "display_name": "Intro to <div>html</div>",
+                        "enrollment_start": _LAST_WEEK,
                     }
                 )
 
@@ -155,6 +183,18 @@ class CourseMetadataUtilsTestCase(TestCase):
             FunctionTest(has_course_ended, [
                 TestScenario((self.demo_course.end,), True),
                 TestScenario((self.html_course.end,), False),
+            ]),
+            FunctionTest(is_enrollment_open, [
+                TestScenario((self.demo_course.enrollment_start, self.demo_course.enrollment_end,), False),
+                TestScenario((
+                    self.demo_course_enrollment_end.enrollment_start,
+                    self.demo_course_enrollment_end.enrollment_end
+                ), False),
+                TestScenario((self.html_course.enrollment_start, self.html_course.enrollment_end,), False),
+                TestScenario((
+                    self.html_course_enrollment_start.enrollment_start,
+                    self.html_course_enrollment_start.enrollment_end,
+                ), True),
             ]),
             FunctionTest(course_start_date_is_default, [
                 TestScenario((test_datetime, advertised_start_parsable), False),

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -58,7 +58,16 @@ class DummySystem(ImportSystem):  # lint-amnesty, pylint: disable=abstract-metho
         )
 
 
-def get_dummy_course(start, announcement=None, is_new=None, advertised_start=None, end=None, certs='end'):
+def get_dummy_course(
+    start,
+    announcement=None,
+    is_new=None,
+    advertised_start=None,
+    end=None,
+    certs='end',
+    enrollment_start=None,
+    enrollment_end=None
+):
     """Get a dummy course"""
 
     system = DummySystem(load_error_modules=True)
@@ -93,6 +102,8 @@ def get_dummy_course(start, announcement=None, is_new=None, advertised_start=Non
         advertised_start=advertised_start,
         end=end,
         certs=certs,
+        enrollment_start=enrollment_start,
+        enrollment_end=enrollment_end,
     )
 
     return system.process_xml(start_xml)
@@ -372,6 +383,7 @@ class SelfPacedTestCase(unittest.TestCase):
         assert not self.course.self_paced
 
 
+@ddt.ddt
 class CourseBlockTestCase(unittest.TestCase):
     """
     Tests for a select few functions from CourseBlock.
@@ -418,6 +430,23 @@ class CourseBlockTestCase(unittest.TestCase):
         """
         expected_certificate_available_date = self.course.end + timedelta(days=2)
         assert expected_certificate_available_date == self.course.certificate_available_date
+
+    @ddt.data(
+        (_LAST_WEEK, None, True),
+        (None, _NEXT_WEEK, True),
+        (_LAST_WEEK, _NEXT_WEEK, True),
+        (_LAST_WEEK, _LAST_WEEK, False),
+        (_NEXT_WEEK, _NEXT_WEEK, False)
+    )
+    @ddt.unpack
+    def test_is_enrollment_open(self, enrollment_start_date, enrollment_end_date, enrollment_open):
+        """
+        Test CourseBlock.is_enrollment_open.
+        """
+        self.course.enrollment_start = enrollment_start_date
+        self.course.enrollment_end = enrollment_end_date
+
+        assert self.course.is_enrollment_open() is enrollment_open
 
 
 class ProctoringProviderTestCase(unittest.TestCase):

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -13,13 +13,11 @@ Note: The access control logic in this file does NOT check for enrollment in
 
 
 import logging
-from datetime import datetime
 
 from django.conf import settings  # pylint: disable=unused-import
 from django.contrib.auth.models import AnonymousUser
 from edx_django_utils.monitoring import function_trace
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from pytz import UTC
 from xblock.core import XBlock
 
 from lms.djangoapps.courseware.access_response import (
@@ -253,32 +251,42 @@ def _can_enroll_courselike(user, courselike):
     # which actually points to a CourseKey. Sigh.
     course_key = courselike.id
 
+    course_enrollment_open = courselike.is_enrollment_open()
+
+    user_has_staff_access = _has_staff_access_to_descriptor(user, courselike, course_key)
+
     # If the user appears in CourseEnrollmentAllowed paired with the given course key,
     # they may enroll, except if the CEA has already been used by a different user.
     # Note that as dictated by the legacy database schema, the filter call includes
     # a `course_id` kwarg which requires a CourseKey.
     if user is not None and user.is_authenticated:
         cea = CourseEnrollmentAllowed.objects.filter(email=user.email, course_id=course_key).first()
-        if cea and cea.valid_for_user(user):
-            return ACCESS_GRANTED
-        elif cea:
-            debug("Deny: CEA was already consumed by a different user {} and can't be used again by {}".format(
-                cea.user.id,
-                user.id,
-            ))
-            return ACCESS_DENIED
+        if cea:
+            # DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED flag is used to disable enrollment for user invited
+            # to a course if user is registering when the course enrollment is closed
+            if (
+                settings.FEATURES.get('DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED') and
+                not course_enrollment_open and
+                not user_has_staff_access
+            ):
+                return ACCESS_DENIED
+            elif cea.valid_for_user(user):
+                return ACCESS_GRANTED
+            else:
+                debug("Deny: CEA was already consumed by a different user {} and can't be used again by {}".format(
+                    cea.user.id,
+                    user.id,
+                ))
+                return ACCESS_DENIED
 
-    if _has_staff_access_to_descriptor(user, courselike, course_key):
+    if user_has_staff_access:
         return ACCESS_GRANTED
 
     if courselike.invitation_only:
         debug("Deny: invitation only")
         return ACCESS_DENIED
 
-    now = datetime.now(UTC)
-    enrollment_start = courselike.enrollment_start or datetime.min.replace(tzinfo=UTC)
-    enrollment_end = courselike.enrollment_end or datetime.max.replace(tzinfo=UTC)
-    if enrollment_start < now < enrollment_end:
+    if course_enrollment_open:
         debug("Allow: in enrollment period")
         return ACCESS_GRANTED
 

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -11,9 +11,11 @@ import pytest
 import ddt
 import pytz
 from ccx_keys.locator import CCXLocator
+from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
 from django.urls import reverse
 from milestones.tests.utils import MilestonesTestCaseMixin
 from opaque_keys.edx.locator import CourseLocator
@@ -31,6 +33,7 @@ from lms.djangoapps.courseware.tests.factories import (
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from common.djangoapps.student.models import CourseEnrollment
@@ -463,10 +466,11 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         # Non-staff can enroll if authenticated and specifically allowed for that course
         # even outside the open enrollment period
         user = UserFactory.create()
-        course = Mock(
-            enrollment_start=tomorrow, enrollment_end=tomorrow,
-            id=CourseLocator('edX', 'test', '2012_Fall'), enrollment_domain=''
-        )
+        course = CourseOverviewFactory.create(id=CourseLocator('edX', 'test', '2012_Fall'))
+        course.enrollment_start = tomorrow
+        course.enrollment_end = tomorrow
+        course.enrollment_domain = ''
+        course.save()
         CourseEnrollmentAllowedFactory(email=user.email, course_id=course.id)
         assert access._has_access_course(user, 'enroll', course)
 
@@ -476,29 +480,61 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
 
         # Non-staff cannot enroll if it is between the start and end dates and invitation only
         # and not specifically allowed
-        course = Mock(
-            enrollment_start=yesterday, enrollment_end=tomorrow,
-            id=CourseLocator('edX', 'test', '2012_Fall'), enrollment_domain='',
-            invitation_only=True
-        )
+        course.enrollment_start = yesterday
+        course.enrollment_end = tomorrow
+        course.invitation_only = True
+        course.save()
         user = UserFactory.create()
         assert not access._has_access_course(user, 'enroll', course)
 
         # Non-staff can enroll if it is between the start and end dates and not invitation only
-        course = Mock(
-            enrollment_start=yesterday, enrollment_end=tomorrow,
-            id=CourseLocator('edX', 'test', '2012_Fall'), enrollment_domain='',
-            invitation_only=False
-        )
+        course.invitation_only = False
+        course.save()
         assert access._has_access_course(user, 'enroll', course)
 
         # Non-staff cannot enroll outside the open enrollment period if not specifically allowed
-        course = Mock(
-            enrollment_start=tomorrow, enrollment_end=tomorrow,
-            id=CourseLocator('edX', 'test', '2012_Fall'), enrollment_domain='',
-            invitation_only=False
-        )
+        course.enrollment_start = tomorrow
+        course.enrollment_end = tomorrow
+        course.invitation_only = False
+        course.save()
         assert not access._has_access_course(user, 'enroll', course)
+
+    @override_settings(FEATURES={**settings.FEATURES, 'DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED': True})
+    def test__has_access_course_with_disable_allowed_enrollment_flag(self):
+        yesterday = datetime.datetime.now(pytz.utc) - datetime.timedelta(days=1)
+        tomorrow = datetime.datetime.now(pytz.utc) + datetime.timedelta(days=1)
+
+        # Non-staff user invited to course, cannot enroll outside the open enrollment period
+        # if DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED is True
+        user = UserFactory.create()
+        course = CourseOverviewFactory.create(id=CourseLocator('edX', 'test', '2012_Fall'))
+        course.enrollment_start = tomorrow
+        course.enrollment_end = tomorrow
+        course.enrollment_domain = ''
+        course.save()
+        CourseEnrollmentAllowedFactory(email=user.email, course_id=course.id)
+        assert not access._has_access_course(user, 'enroll', course)
+
+        # Staff can always enroll even outside the open enrollment period
+        user = StaffFactory.create(course_key=course.id)
+        assert access._has_access_course(user, 'enroll', course)
+
+        # Non-staff cannot enroll outside the open enrollment period if not specifically allowed
+        user = UserFactory.create()
+        assert not access._has_access_course(user, 'enroll', course)
+
+        # Non-staff cannot enroll if it is between the start and end dates and invitation only
+        # and not specifically allowed
+        course.enrollment_start = yesterday
+        course.enrollment_end = tomorrow
+        course.invitation_only = True
+        course.save()
+        assert not access._has_access_course(user, 'enroll', course)
+
+        # Non-staff can enroll if it is between the start and end dates and not invitation only
+        course.invitation_only = False
+        course.save()
+        assert access._has_access_course(user, 'enroll', course)
 
     def test__user_passed_as_none(self):
         """Ensure has_access handles a user being passed as null"""

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -966,6 +966,16 @@ FEATURES = {
     # .. toggle_warnings: For consistency in user-experience, keep the value in sync with the setting of the same name
     #   in the LMS and CMS.
     'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': False,
+
+    # .. toggle_name: FEATURES['DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to disable enrollment for user invited to a course
+    # .. if user is registering before enrollment start date or after enrollment end date
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-06-06
+    # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/29538'
+    'DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -508,6 +508,12 @@ class CourseOverview(TimeStampedModel):
         """
         return course_metadata_utils.has_course_ended(self.end)
 
+    def is_enrollment_open(self):
+        """
+        Returns True if course enrollment is open
+        """
+        return course_metadata_utils.is_enrollment_open(self.enrollment_start, self.enrollment_end)
+
     def has_marketing_url(self):
         """
         Returns whether the course has marketing url.

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -142,6 +142,7 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
             ('has_ended', ()),
             ('has_started', ()),
             ('may_certify', ()),
+            ('is_enrollment_open', ()),
         ]
         for method_name, method_args in methods_to_test:
             course_value = getattr(course, method_name)(*method_args)


### PR DESCRIPTION
## Description

Cherrypick of commit be34c0d from openedx/edx-platform#29538

This PR seeks to address the following scenario:

1. Non-registered user is enrolled in a course
2. Course enrollment ends
3. User registers after course enrollment has ended
4. User in enrolled to the course anyways

This PR introduces a feature flag "DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED" which when set to True, the newly registered user is not automatically enrolled to the course if the enrollment has ended.

Impacted user roles : Learner

## Supporting information



## Testing instructions

1. Set the "DISABLE_ALLOWED_ENROLLMENT_IF_ENROLLMENT_CLOSED" flag to true
2. As a staff user, enroll an email-id to a course and set auto-enroll to true.
3. From the studio settings, set the course enrollment end date to a past date, so that the enrollment ends.
4. Register to the lms, using the email-id enrolled above.
5. Check that the user is NOT enrolled to the course

