### PR TITLE
fix: update edx-bulk-grades to 0.8.12

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -394,7 +394,7 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.in
 edx-api-doc-tools==1.4.0
     # via -r requirements/edx/base.in
-edx-bulk-grades==0.8.8
+edx-bulk-grades==0.8.12
     # via
     #   -r requirements/edx/base.in
     #   staff-graded-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -491,7 +491,7 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/testing.txt
 edx-api-doc-tools==1.4.0
     # via -r requirements/edx/testing.txt
-edx-bulk-grades==0.8.8
+edx-bulk-grades==0.8.12
     # via
     #   -r requirements/edx/testing.txt
     #   staff-graded-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -472,7 +472,7 @@ edx-analytics-data-api-client==0.17.0
     # via -r requirements/edx/base.txt
 edx-api-doc-tools==1.4.0
     # via -r requirements/edx/base.txt
-edx-bulk-grades==0.8.8
+edx-bulk-grades==0.8.12
     # via
     #   -r requirements/edx/base.txt
     #   staff-graded-xblock


### PR DESCRIPTION
<!--

🌰🌰
🌰🌰🌰🌰         🌰 Note: the Nutmeg master branch has been created.  Please consider whether your change
    🌰🌰🌰🌰     should also be applied to Nutmeg. If so, make another pull request against the
🌰🌰🌰🌰         open-release/nutmeg.master branch, or ping @nedbat for help or questions.
🌰🌰

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Upgrade `edx-bulk-grades` package to include support for multiple user, multiple sections grade override implemented in https://github.com/openedx/edx-bulk-grades/pull/82

## Supporting information

- https://github.com/openedx/edx-bulk-grades/pull/82
- Jira: [BB-6423](https://tasks.opencraft.com/browse/BB-6423)

## Testing

Below steps as quoted in the fix MR:

- Have course that has more than 1 subsection
- Use bulk management to export the grades
- Modify grade on new-override_{subsection-id}
- Import grade using bulk management
- You should see only one of the subsection's grade get override

Change

- Follow the reproduce instruction
- You should see all of the subsection's grade get override

