### PR TITLE
cherry-pick: feat: allow switching anonymous user ID hashing algorithm from shake to md5 [BB-6533]

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -502,6 +502,17 @@ FEATURES = {
     # .. toggle_warnings: For consistency in user-experience, keep the value in sync with the setting of the same name
     #   in the LMS and CMS.
     'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': False,
+
+    # .. toggle_name: FEATURES['ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to enable the legacy MD5 hashing algorithm to generate anonymous user id
+    #   instead of the newer SHAKE128 hashing algorithm
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-08-08
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
+    'ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID': False,
 }
 
 ENABLE_JASMINE = False

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -230,12 +230,22 @@ def anonymous_id_for_user(user, course_id, save='DEPRECATED'):
         # function: Rotate at will, since the hashes are stored and
         # will not change.
         # include the secret key as a salt, and to make the ids unique across different LMS installs.
-        hasher = hashlib.shake_128()
+        legacy_hash_enabled = settings.FEATURES.get('ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID', False)
+        if legacy_hash_enabled:
+            # Use legacy MD5 algorithm if flag enabled
+            hasher = hashlib.md5()
+        else:
+            hasher = hashlib.shake_128()
+
         hasher.update(settings.SECRET_KEY.encode('utf8'))
         hasher.update(str(user.id).encode('utf8'))
         if course_id:
             hasher.update(str(course_id).encode('utf-8'))
-        anonymous_user_id = hasher.hexdigest(16)  # pylint: disable=too-many-function-args
+
+        if legacy_hash_enabled:
+            anonymous_user_id = hasher.hexdigest()
+        else:
+            anonymous_user_id = hasher.hexdigest(16)  # pylint: disable=too-many-function-args
 
         try:
             AnonymousUserId.objects.create(

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -1057,6 +1057,17 @@ class AnonymousLookupTable(ModuleStoreTestCase):
             assert anonymous_id != new_anonymous_id
             assert self.user == user_by_anonymous_id(new_anonymous_id)
 
+    def test_enable_legacy_hash_flag(self):
+        """Test that different anonymous id returned if ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID enabled."""
+        CourseEnrollment.enroll(self.user, self.course.id)
+        anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+        with patch.dict(settings.FEATURES, ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID=True):
+            # Recreate user object to clear cached anonymous id.
+            self.user = User.objects.get(pk=self.user.id)
+            AnonymousUserId.objects.filter(user=self.user).filter(course_id=self.course.id).delete()
+            new_anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+            assert anonymous_id != new_anonymous_id
+
 
 @skip_unless_lms
 @patch('openedx.core.djangoapps.programs.utils.get_programs')

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -973,6 +973,17 @@ FEATURES = {
     # .. toggle_warnings: For consistency in user-experience, keep the value in sync with the setting of the same name
     #   in the LMS and CMS.
     'MARK_LIBRARY_CONTENT_BLOCK_COMPLETE_ON_VIEW': False,
+
+    # .. toggle_name: FEATURES['ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to enable the legacy MD5 hashing algorithm to generate anonymous user id
+    #   instead of the newer SHAKE128 hashing algorithm
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-08-08
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
+    'ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API


### PR DESCRIPTION
This cherry-picks https://github.com/openedx/edx-platform/pull/30832 to the common Maple branch.

The conflicts were trivial - only in `lms/envs/common.py` and `cms/envs/common.py`, so I'll merge this once the CI passes, as I've already reviewed an upstream PR.