### PR TITLE
fix: preview mode navigation previous button (that uses legacy UI)

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.js
@@ -364,7 +364,7 @@
 
             if ((direction === 'next') && (this.position >= this.contents.length)) {
                 targetUrl = this.nextUrl;
-            } else if ((direction === 'previous')) {
+            } else if ((direction === 'previous') && (this.position === 1 || this.contents.length === 0)) {
                 targetUrl = this.prevUrl;
             }
 


### PR DESCRIPTION
## Description
Legacy UI: Previous button should use prev_url if it in first position. In studio UI, it should always use prev_url. To make this possible we checking length of contents which is always zero for studio and more than 0 for legacy UI.

Cherry picks https://github.com/openedx/edx-platform/pull/31193

## Supporting information

`Private ref`: [Jira: BB-6820](https://tasks.opencraft.com/browse/BB-6820)

## Testing instructions

- Test `next` and `previous` buttons in lms preview UI
