### PR TITLE
fix(maple): retrieve raw content from TinyMCE editor

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/html/edit_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/html/edit_spec.js
@@ -24,7 +24,7 @@ describe('HTMLEditingDescriptor', function() {
     });
     it('Returns data from Raw Editor if text has not changed', function(done) {
       const visualEditorStub =
-        {getContent() { return 'original visual text' }};
+        {getContent() { return '<p>original visual text</p>' }};
       spyOn(this.descriptor, 'getVisualEditor').and.callFake(() => visualEditorStub);
 
       var self = this;

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -1390,7 +1390,7 @@
       haven't dirtied the Editor. Store the raw content so we can compare it later.
        */
       this.starting_content = visualEditor.getContent({
-        format: "text",
+        format: "raw",
         no_events: 1
       });
       return visualEditor.focus();
@@ -1410,7 +1410,7 @@
       if (this.editor_choice === 'visual') {
         visualEditor = this.getVisualEditor();
         raw_content = visualEditor.getContent({
-          format: "text",
+          format: "raw",
           no_events: 1
         });
         if (this.starting_content !== raw_content) {


### PR DESCRIPTION
This backports https://github.com/openedx/edx-platform/pull/31212 to fix https://github.com/open-craft/edx-platform/pull/493 in Maple.

During the upgrade to TinyMCE v5, we changed the content format to `text`. However, it ignores changes in HTML tags. This reverts the format to `raw`.