### PR TITLE
feat!: update Drag and Drop v2 XBlock to prevent XSS vulnerabilities (Nutmeg backport)

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -168,3 +168,4 @@ XBlock                              # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
+xblock-drag-and-drop-v2             # Drag and Drop XBlock

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1120,8 +1120,8 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
-    # via -r requirements/edx/github.in
+xblock-drag-and-drop-v2==3.0.0
+    # via -r requirements/edx/base.in
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/github.in
 xblock-utils==3.0.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1617,7 +1617,7 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
+xblock-drag-and-drop-v2==3.0.0
     # via -r requirements/edx/testing.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -71,7 +71,6 @@ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc32118
 # Third Party XBlocks
 
 git+https://github.com/open-craft/xblock-poll@v1.12.0#egg=xblock-poll==1.12.0
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5#egg=xblock-drag-and-drop-v2==2.3.5
 
 # Temporary for testing edx-django-utils upgrade
 git+https://github.com/edx/edx-django-utils.git@robrap/ARCHBOM-2054-move-cookie-monitoring-middleware#egg=edx_django_utils

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1490,7 +1490,7 @@ xblock==1.6.1
     #   xblock-google-drive
     #   xblock-poll
     #   xblock-utils
-xblock-drag-and-drop-v2 @ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.5
+xblock-drag-and-drop-v2==3.0.0
     # via -r requirements/edx/base.txt
 xblock-poll @ git+https://github.com/open-craft/xblock-poll@v1.12.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
BREAKING CHANGE: disallowed HTML tags (e.g. <script>) will no longer be rendered in LMS and Studio.

This cherry-picks https://github.com/openedx/edx-platform/pull/31354 to the common Nutmeg branch.