### PR TITLE
feat: Add toggle to allow redirecting to courseware after enrollment

### DIFF
--- a/common/djangoapps/student/toggles.py
+++ b/common/djangoapps/student/toggles.py
@@ -1,0 +1,24 @@
+"""
+Toggles for Dashboard page.
+"""
+from edx_toggles.toggles import WaffleSwitch
+
+# Namespace for student waffle flags.
+WAFFLE_FLAG_NAMESPACE = 'student'
+
+# Waffle flag to enable control redirecting after enrolment.
+# .. toggle_name: student.redirect_to_courseware_after_enrollment
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Redirect to courseware after enrollment instead of dashboard.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2023-02-06
+# .. toggle_target_removal_date: None
+# .. toggle_warning: None
+REDIRECT_TO_COURSEWARE_AFTER_ENROLLMENT = WaffleSwitch(
+    f'{WAFFLE_FLAG_NAMESPACE}.redirect_to_courseware_after_enrollment', __name__
+)
+
+
+def should_redirect_to_courseware_after_enrollment():
+    return REDIRECT_TO_COURSEWARE_AFTER_ENROLLMENT.is_enabled()

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -39,6 +39,7 @@ from pytz import UTC
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.permissions import IsAuthenticated
 
+from common.djangoapps.student.toggles import should_redirect_to_courseware_after_enrollment
 from common.djangoapps.track import views as track_views
 from lms.djangoapps.bulk_email.models import Optout
 from common.djangoapps.course_modes.models import CourseMode
@@ -400,8 +401,10 @@ def change_enrollment(request, check_access=True):
                 reverse("course_modes_choose", kwargs={'course_id': str(course_id)})
             )
 
-        # Otherwise, there is only one mode available (the default)
-        return HttpResponse()
+        if should_redirect_to_courseware_after_enrollment():
+            return HttpResponse(reverse('courseware', args=[str(course_id)]))
+        else:
+            return HttpResponse()
     elif action == "unenroll":
         if configuration_helpers.get_value(
             "DISABLE_UNENROLLMENT",


### PR DESCRIPTION
This change adds a new waffle switch to redirect a student to courseware after enrolment instead of the dashboard.

cherrypick of: https://github.com/openedx/edx-platform/pull/31715