### PR TITLE
feat[nutmeg]: allow using all components of LibraryContentBlock [BB-7062]

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -162,7 +162,7 @@ class LibraryContentBlock(
     )
     max_count = Integer(
         display_name=_("Count"),
-        help=_("Enter the number of components to display to each student."),
+        help=_("Enter the number of components to display to each student. Set it to -1 to display all components."),
         default=1,
         scope=Scope.settings,
     )
@@ -339,7 +339,11 @@ class LibraryContentBlock(
         actual BlockUsageLocators, it is necessary to use self.children,
         because the block_ids alone do not specify the block type.
         """
-        block_keys = self.make_selection(self.selected, self.children, self.max_count, "random")  # pylint: disable=no-member
+        max_count = self.max_count
+        if max_count < 0:
+            max_count = len(self.children)
+
+        block_keys = self.make_selection(self.selected, self.children, max_count, "random")  # pylint: disable=no-member
 
         # Publish events for analytics purposes:
         lib_tools = self.runtime.service(self, 'library_tools')
@@ -435,9 +439,13 @@ class LibraryContentBlock(
         if is_root:
             # User has clicked the "View" link. Show a preview of all possible children:
             if self.children:  # pylint: disable=no-member
+                max_count = self.max_count
+                if max_count < 0:
+                    max_count = len(self.children)
+
                 fragment.add_content(self.runtime.service(self, 'mako').render_template(
                     "library-block-author-preview-header.html", {
-                        'max_count': self.max_count,
+                        'max_count': max_count,
                         'display_name': self.display_name or self.url_name,
                     }))
                 context['can_edit_visibility'] = False

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -280,18 +280,21 @@ class LibraryContentBlockTestMixin:
         assert result.summary
         assert StudioValidationMessage.WARNING == result.summary.type
         assert 'only 4 matching problems' in result.summary.text
+        assert len(self.lc_block.selected_children()) == 4
 
         # Add some capa problems so we can check problem type validation messages
         self.lc_block.max_count = 1
         self._create_capa_problems()
         self.lc_block.refresh_children()
         assert self.lc_block.validate()
+        assert len(self.lc_block.selected_children()) == 1
 
         # Existing problem type should pass validation
         self.lc_block.max_count = 1
         self.lc_block.capa_type = 'multiplechoiceresponse'
         self.lc_block.refresh_children()
         assert self.lc_block.validate()
+        assert len(self.lc_block.selected_children()) == 1
 
         # ... unless requested more blocks than exists in library
         self.lc_block.max_count = 10
@@ -303,6 +306,7 @@ class LibraryContentBlockTestMixin:
         assert result.summary
         assert StudioValidationMessage.WARNING == result.summary.type
         assert 'only 1 matching problem' in result.summary.text
+        assert len(self.lc_block.selected_children()) == 1
 
         # Missing problem type should always fail validation
         self.lc_block.max_count = 1
@@ -314,6 +318,14 @@ class LibraryContentBlockTestMixin:
         assert result.summary
         assert StudioValidationMessage.WARNING == result.summary.type
         assert 'no matching problem types' in result.summary.text
+        assert len(self.lc_block.selected_children()) == 0
+
+        # -1 selects all blocks from the library.
+        self.lc_block.max_count = -1
+        self.lc_block.capa_type = ANY_CAPA_TYPE_VALUE
+        self.lc_block.refresh_children()
+        assert self.lc_block.validate()
+        assert len(self.lc_block.selected_children()) == len(self.lc_block.children)
 
     def test_capa_type_filtering(self):
         """
@@ -388,6 +400,8 @@ class LibraryContentBlockTestMixin:
         (True, 8),
         # User resets selected children without reset button on content block
         (False, 8),
+        # User resets selected children with reset button on content block when all library blocks should be selected.
+        (True, -1),
     )
     @ddt.unpack
     def test_reset_selected_children_capa_blocks(self, allow_resetting_children, max_count):

--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -85,6 +85,8 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 selected = []
                 mode = block_structure.get_xblock_field(block_key, 'mode')
                 max_count = block_structure.get_xblock_field(block_key, 'max_count')
+                if max_count < 0:
+                    max_count = len(library_children)
 
                 # Retrieve "selected" json from LMS MySQL database.
                 state_dict = get_student_module_as_dict(usage_info.user, usage_info.course_key, block_key)


### PR DESCRIPTION
This backports https://github.com/openedx/edx-platform/pull/31788 to Nutmeg.

Setting max_count to a negative value resulted in raising an unhandled ValueError. Currently, it selects all children of the LibraryContentBlock.