### PR TITLE
feat[nutmeg]: add new endpoint for cloning course [BB-7106]

### DIFF
--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from cms.djangoapps.contentstore.views.course import _accessible_courses_iter, get_course_and_check_access
 
 from ..serializers.course_runs import (
+    CourseCloneSerializer,
     CourseRunCreateSerializer,
     CourseRunImageSerializer,
     CourseRunRerunSerializer,
@@ -93,3 +94,10 @@ class CourseRunViewSet(viewsets.GenericViewSet):  # lint-amnesty, pylint: disabl
         new_course_run = serializer.save()
         serializer = self.get_serializer(new_course_run)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=['post'])
+    def clone(self, request, *args, **kwargs):  # lint-amnesty, pylint: disable=missing-function-docstring, unused-argument
+        serializer = CourseCloneSerializer(data=request.data, context=self.get_serializer_context())
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response({"message": "Course cloned successfully."}, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
This backports [openedx#31794](https://github.com/openedx/edx-platform/pull/31794) to Nutmeg.

Adds a new studio endpoint for the existing clone_course method, so that external applications can call it using the following API:
```
/api/v1/course_runs/clone/
```
And passing the source_course_id (of an existing course) and destination_course_id (of a non-existing course) in the request data, like below:
```
{
    "source_course_id": "course-v1:edX+DemoX+Demo_Course",
    "destination_course_id": "course-v1:new+TestX+Demo_Course_Clone",
}
```

See parent PR for testing instructions.