### PR TITLE
feat: enable discussions for all users

### DIFF
--- a/lms/djangoapps/discussion/toggles.py
+++ b/lms/djangoapps/discussion/toggles.py
@@ -14,6 +14,17 @@ WAFFLE_FLAG_NAMESPACE = "discussions"
 # .. toggle_target_removal_date: 2022-03-05
 ENABLE_DISCUSSIONS_MFE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_discussions_mfe', __name__)
 
+# .. toggle_name: discussions.enable_discussions_mfe_for_everyone
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to use the new MFE experience for discussions in the course tab and in-context
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_creation_date: 2021-04-21
+# .. toggle_target_removal_date: 2022-03-05
+ENABLE_DISCUSSIONS_MFE_FOR_EVERYONE = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE, 'enable_discussions_mfe_for_everyone', __name__
+)
+
 # .. toggle_name: discussions.enable_new_structure_discussions
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False


### PR DESCRIPTION
## Description

Allow any user that's enrolled in a course to view the discussion forum.

## Testing instructions

The changes have been deployed to https://es1.kgdocluster.opencraft.hosting/. Create a new account and enroll into any course. You should be able to view the new discussion experience.

- [Deployed config](https://gitlab.com/opencraft/devstacks/keith/grove-do/-/blob/main/instances/es1/config.yml)
- [Deployed requirements](https://gitlab.com/opencraft/devstacks/keith/grove-do/-/blob/main/instances/es1/requirements.txt)