### PR TITLE
revert: revert hide discussion tab change

### DIFF
--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -355,8 +355,6 @@ def get_course_tab_list(user, course):
     course_tab_list = []
     must_complete_ee = not user_can_skip_entrance_exam(user, course)
     for tab in xmodule_tab_list:
-        if tab.tab_id == 'discussion':
-            continue
         if must_complete_ee:
             # Hide all of the tabs except for 'Courseware'
             # Rename 'Courseware' tab to 'Entrance Exam'

--- a/lms/djangoapps/discussion/urls.py
+++ b/lms/djangoapps/discussion/urls.py
@@ -17,5 +17,5 @@ urlpatterns = [
         views.DiscussionBoardFragmentView.as_view(),
         name='discussion_board_fragment_view'
     ),
-    #url(r'', views.forum_form_discussion, name='forum_form_discussion'),
+    re_path('', views.forum_form_discussion, name='forum_form_discussion'),
 ]


### PR DESCRIPTION
## Description

Reverts commit 6ffea760ce4a1c983f6328f5cbcf9d639721ba95

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

OpenCraft internal ticket : [BB-7147](https://tasks.opencraft.com/browse/BB-7147)