### PR TITLE
fix: use old-style Course Waffle flag for `RELATIVE_DATES_DISABLE_RESET_FLAG`

### DIFF
--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -87,7 +87,7 @@ RELATIVE_DATES_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'relative_dates', 
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2023-04-27
 # .. toggle_warning: For this toggle to have an effect, the RELATIVE_DATES_FLAG toggle must be enabled, too.
-RELATIVE_DATES_DISABLE_RESET_FLAG = CourseWaffleFlag(f'{WAFFLE_FLAG_NAMESPACE}.relative_dates_disable_reset', __name__)
+RELATIVE_DATES_DISABLE_RESET_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'relative_dates_disable_reset', __name__)
 
 # .. toggle_name: course_experience.calendar_sync
 # .. toggle_implementation: CourseWaffleFlag


### PR DESCRIPTION
This fixes the backport from https://github.com/open-craft/edx-platform/pull/536. It will no longer be needed after Nutmeg.