### PR TITLE
temp: Add configuration option to redirect to external site when TPA account is unlinked

### DIFF
--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -213,6 +213,7 @@
             saveError: function(error) {
                 var errorCode;
                 var msg;
+                var redirectURL;
                 if (error.status === 0) {
                     msg = gettext('An error has occurred. Check your Internet connection and try again.');
                 } else if (error.status === 500) {
@@ -242,6 +243,7 @@
                 } else if (error.responseJSON !== undefined) {
                     msg = error.responseJSON.value;
                     errorCode = error.responseJSON.error_code;
+                    redirectURL = error.responseJSON.redirect_url;
                 } else {
                     msg = gettext('An unexpected error has occurred.');
                 }
@@ -262,6 +264,9 @@
                     if (!this.hideAuthWarnings) {
                         this.clearFormErrors();
                         this.renderThirdPartyAuthWarning();
+                    }
+                    if (redirectURL){
+                        window.location.href = redirectURL;
                     }
                 } else {
                     this.renderErrors(this.defaultFormErrorsTitle, this.errors);


### PR DESCRIPTION
**Testing instructions**

1. Add the dummy OAuth provider 
2. Try logging in using the dummy oauth provider
3. You will see an error message about an unlinked TPA account, asking you to log in. 
4. Check out this branch
5. Add a site config variable called `OC_REDIRECT_ON_TPA_UNLINKED_ACCOUNT` with the URL to redirect to. 
6. Clear cookies or us a fresh browser session, and try logging in with the dummy provider again. 
7. You should be redirected to the URl set above. 

`Private-ref`: [BB-7394](https://tasks.opencraft.com/browse/BB-7394)