### PR TITLE
Backport missing showRegisterLinks initializations to Palm

### DIFF
--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -76,7 +76,7 @@
                 this.supportURL = options.support_link;
                 this.passwordResetSupportUrl = options.password_reset_support_link;
                 this.createAccountOption = options.account_creation_allowed && options.register_links_allowed;
-                    this.showRegisterLinks = options.register_links_allowed
+                this.showRegisterLinks = options.register_links_allowed;
                 this.hideAuthWarnings = options.hide_auth_warnings || false;
                 this.pipelineUserDetails = options.third_party_auth.pipeline_user_details;
                 this.enterpriseName = options.enterprise_name || '';
@@ -162,7 +162,8 @@
                         supportURL: this.supportURL,
                         passwordResetSupportUrl: this.passwordResetSupportUrl,
                         createAccountOption: this.createAccountOption,
-                        showRegisterLinks: this.showRegisterLinks,hideAuthWarnings: this.hideAuthWarnings,
+                        showRegisterLinks: this.showRegisterLinks,
+                        hideAuthWarnings: this.hideAuthWarnings,
                         pipelineUserDetails: this.pipelineUserDetails,
                         enterpriseName: this.enterpriseName,
                         enterpriseSlugLoginURL: this.enterpriseSlugLoginURL,
@@ -188,8 +189,8 @@
                     this.subview.passwordHelp = new PasswordResetView({
                         fields: data.fields,
                         model: this.resetModel,
-                    showRegisterLinks: this.showRegisterLinks
-                        });
+                        showRegisterLinks: this.showRegisterLinks
+                    });
 
                     // Listen for 'password-email-sent' event to toggle sub-views
                     this.listenTo(this.subview.passwordHelp, 'password-email-sent', this.passwordEmailSent);
@@ -213,8 +214,8 @@
                         hideAuthWarnings: this.hideAuthWarnings,
                         is_require_third_party_auth_enabled: this.is_require_third_party_auth_enabled,
                         enableCoppaCompliance: this.enable_coppa_compliance,
-                    showRegisterLinks: this.showRegisterLinks
-                        });
+                        showRegisterLinks: this.showRegisterLinks
+                    });
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.
                     this.listenTo(this.subview.register, 'auth-complete', this.authComplete);

--- a/lms/static/js/student_account/views/FormView.js
+++ b/lms/static/js/student_account/views/FormView.js
@@ -32,10 +32,14 @@
             optionalStr: gettext('(optional)'),
             submitButton: '',
             isEnterpriseEnable: false,
+            showRegisterLinks: true,
 
             initialize: function(data) {
                 this.model = data.model;
-                this.showRegisterLinks = data.showRegisterLinks;
+                this.showRegisterLinks = (
+                    typeof data.showRegisterLinks !== 'undefined'
+                ) ? data.showRegisterLinks : this.showRegisterLinks;
+
                 this.preRender(data);
 
                 this.tpl = $(this.tpl).html();

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -52,7 +52,9 @@
                 this.supportURL = data.supportURL;
                 this.passwordResetSupportUrl = data.passwordResetSupportUrl;
                 this.createAccountOption = data.createAccountOption;
-                this.showRegisterLinks = data.showRegisterLinks;
+                this.showRegisterLinks = (
+                    typeof data.showRegisterLinks !== 'undefined'
+                ) ? data.showRegisterLinks : this.showRegisterLinks;
                 this.accountActivationMessages = data.accountActivationMessages;
                 this.accountRecoveryMessages = data.accountRecoveryMessages;
                 this.hideAuthWarnings = data.hideAuthWarnings;

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -89,7 +89,8 @@
                         optionalStr: fields[i].name === 'marketing_emails_opt_in' ? '' : this.optionalStr,
                         supplementalText: fields[i].supplementalText || '',
                         supplementalLink: fields[i].supplementalLink || '',
-                    showRegisterLinks: this.showRegisterLinks})));
+                        showRegisterLinks: this.showRegisterLinks
+                    })));
                 }
                 html.push('</div>');
                 return html;


### PR DESCRIPTION
## Description

Backport of https://github.com/openedx/edx-platform/pull/32783, includes missing initializations in JS files that were causing JS tests to fail.

(cherry picked from commit 3025ab5fe6f6f53d6af5b36681355efafa37c74b) (cherry picked from commit 2ee57b7d59ed53fa928f9b19127038b4cf0b4620)

## Supporting information

`Private-ref`: [BB-7694](https://tasks.opencraft.com/browse/BB-7694)

## Testing instructions

1. Set the `SHOW_REGISTRATION_LINKS` flag to `False` in both lms and cms
2. Check LMS: http://localhost:18000/ has no register button at the top
3. Check LMS: http://localhost:18000/register still works does work
4. Check LMS: http://localhost:18000/login doesn't show links to the registration form
5. Check CMS (studio): http://localhost:18010/ doesn't show links to register an account
