### PR TITLE
feat: Add retrieve object_tags REST API

### DIFF
--- a/openedx/features/content_tagging/rest_api/v1/urls.py
+++ b/openedx/features/content_tagging/rest_api/v1/urls.py
@@ -6,10 +6,13 @@ from rest_framework.routers import DefaultRouter
 
 from django.urls.conf import path, include
 
+from openedx_tagging.core.tagging.rest_api.v1 import views as oel_tagging_views
+
 from . import views
 
 router = DefaultRouter()
 router.register("taxonomies", views.TaxonomyOrgView, basename="taxonomy")
+router.register("object_tags", oel_tagging_views.ObjectTagView, basename="object_tag")
 
 urlpatterns = [
     path('', include(router.urls))


### PR DESCRIPTION
## Description

This PR exposes the retrieve object tag REST API endpoint from oel_tagging.

## Supporting Information

- Depends on https://github.com/openedx/openedx-learning/pull/68

## Testing Instructions

- Run your local devstack,
- Make have https://github.com/openedx/openedx-learning/pull/68 installed locally, to do that:
    - clone the branch to your DEV_STACK/src
    - uninstall your existing openedx-learning package:
        - `make lms-shel`
        - `pip uninstall openedx-learning`
    - install the branch you cloned: 
        - `make lms-shell`
        - `cd /edx/src`
        - `pip install -e openedx-learning`
   - Check that the endpoint page works:
       - `http://localhost:18000/api/content_tagging/v1/object_tags/`
