### PR TITLE
fix: eSHE instructors should see their courses [BB-7489]

### DIFF
--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -90,7 +90,7 @@ class RoleCache:
             )
 
     @staticmethod
-    def _get_roles(role):
+    def get_roles(role):
         """
         Return the roles that should have the same permissions as the specified role.
         """
@@ -102,7 +102,7 @@ class RoleCache:
         or a role that inherits from the specified role, course_id and org.
         """
         return any(
-            access_role.role in self._get_roles(role) and
+            access_role.role in self.get_roles(role) and
             access_role.course_id == course_id and
             access_role.org == org
             for access_role in self._roles
@@ -483,11 +483,11 @@ class UserBasedRole:
 
     def courses_with_role(self):
         """
-        Return a django QuerySet for all of the courses with this user x role. You can access
+        Return a django QuerySet for all of the courses with this user x (or derived from x) role. You can access
         any of these properties on each result record:
         * user (will be self.user--thus uninteresting)
         * org
         * course_id
         * role (will be self.role--thus uninteresting)
         """
-        return CourseAccessRole.objects.filter(role=self.role, user=self.user)
+        return CourseAccessRole.objects.filter(role__in=RoleCache.get_roles(self.role), user=self.user)


### PR DESCRIPTION
# Description

Continuation of https://github.com/open-craft/edx-platform/pull/561.

We've discovered that eSHE Instructors don't see their courses on the Studio Home page while have access to courses themselves:
![image](https://github.com/open-craft/edx-platform/assets/18251194/e7511680-c1a7-44e2-be35-cbc6fb1a58db)
![image](https://github.com/open-craft/edx-platform/assets/18251194/77c243dc-9635-4a84-a541-526ecf85fedf)

This PR fixes this by modifying the relevant method.

# Test instructions
1. Add some user as an eSHE Instructor for some course.
2. As this user, open Studio Home: you should see your course.