### PR TITLE
feat: Add retrieve object_tags REST API

### DIFF
--- a/openedx/features/content_tagging/api.py
+++ b/openedx/features/content_tagging/api.py
@@ -101,20 +101,16 @@ def get_taxonomies_for_org(
 
 
 def get_content_tags(
-    object_id: str, taxonomy: Taxonomy = None, valid_only=True
+    object_id: str, taxonomy_id: str = None
 ) -> Iterator[ContentObjectTag]:
     """
     Generates a list of content tags for a given object.
 
     Pass taxonomy to limit the returned object_tags to a specific taxonomy.
-
-    Pass valid_only=False when displaying tags to content authors, so they can see invalid tags too.
-    Invalid tags will (probably) be hidden from learners.
     """
     for object_tag in oel_tagging.get_object_tags(
         object_id=object_id,
-        taxonomy=taxonomy,
-        valid_only=valid_only,
+        taxonomy_id=taxonomy_id,
     ):
         yield ContentObjectTag.cast(object_tag)
 

--- a/openedx/features/content_tagging/rest_api/v1/urls.py
+++ b/openedx/features/content_tagging/rest_api/v1/urls.py
@@ -6,10 +6,13 @@ from rest_framework.routers import DefaultRouter
 
 from django.urls.conf import path, include
 
+from openedx_tagging.core.tagging.rest_api.v1 import views as oel_tagging_views
+
 from . import views
 
 router = DefaultRouter()
 router.register("taxonomies", views.TaxonomyOrgView, basename="taxonomy")
+router.register("object_tags", oel_tagging_views.ObjectTagView, basename="object_tag")
 
 urlpatterns = [
     path('', include(router.urls))

--- a/openedx/features/content_tagging/tests/test_api.py
+++ b/openedx/features/content_tagging/tests/test_api.py
@@ -189,14 +189,12 @@ class TestAPITaxonomy(TestTaxonomyMixin, TestCase):
         object_tag_attr,
     ):
         taxonomy_id = getattr(self, taxonomy_attr).id
-        taxonomy = api.get_taxonomy(taxonomy_id)
         object_tag = getattr(self, object_tag_attr)
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             valid_tags = list(
                 api.get_content_tags(
-                    taxonomy=taxonomy,
+                    taxonomy_id=taxonomy_id,
                     object_id=object_tag.object_id,
-                    valid_only=True,
                 )
             )
         assert len(valid_tags) == 1
@@ -219,14 +217,12 @@ class TestAPITaxonomy(TestTaxonomyMixin, TestCase):
         object_tag_attr,
     ):
         taxonomy_id = getattr(self, taxonomy_attr).id
-        taxonomy = api.get_taxonomy(taxonomy_id)
         object_tag = getattr(self, object_tag_attr)
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             valid_tags = list(
                 api.get_content_tags(
-                    taxonomy=taxonomy,
+                    taxonomy_id=taxonomy_id,
                     object_id=object_tag.object_id,
-                    valid_only=False,
                 )
             )
         assert len(valid_tags) == 1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -43,6 +43,7 @@ attrs==23.1.0
     #   lti-consumer-xblock
     #   openedx-blockstore
     #   openedx-events
+    #   openedx-learning
     #   referencing
 babel==2.11.0
     # via
@@ -98,6 +99,7 @@ celery==5.3.1
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
+    #   openedx-learning
 certifi==2023.7.22
     # via
     #   -r requirements/edx/paver.txt
@@ -766,7 +768,7 @@ openedx-filters==1.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning==0.1.2
+openedx-learning==0.1.5
     # via -r requirements/edx/kernel.in
 openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -92,6 +92,7 @@ attrs==23.1.0
     #   lti-consumer-xblock
     #   openedx-blockstore
     #   openedx-events
+    #   openedx-learning
     #   referencing
 babel==2.11.0
     # via
@@ -175,6 +176,7 @@ celery==5.3.1
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
+    #   openedx-learning
 certifi==2023.7.22
     # via
     #   -r requirements/edx/doc.txt
@@ -1297,7 +1299,7 @@ openedx-filters==1.5.0
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
     #   lti-consumer-xblock
-openedx-learning==0.1.2
+openedx-learning==0.1.5
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -60,6 +60,7 @@ attrs==23.1.0
     #   lti-consumer-xblock
     #   openedx-blockstore
     #   openedx-events
+    #   openedx-learning
     #   referencing
 babel==2.11.0
     # via
@@ -125,6 +126,7 @@ celery==5.3.1
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
+    #   openedx-learning
 certifi==2023.7.22
     # via
     #   -r requirements/edx/base.txt
@@ -907,7 +909,7 @@ openedx-filters==1.5.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.1.2
+openedx-learning==0.1.5
     # via -r requirements/edx/base.txt
 openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -66,6 +66,7 @@ attrs==23.1.0
     #   lti-consumer-xblock
     #   openedx-blockstore
     #   openedx-events
+    #   openedx-learning
     #   referencing
 babel==2.11.0
     # via
@@ -131,6 +132,7 @@ celery==5.3.1
     #   edx-celeryutils
     #   edx-enterprise
     #   event-tracking
+    #   openedx-learning
 certifi==2023.7.22
     # via
     #   -r requirements/edx/base.txt
@@ -976,7 +978,7 @@ openedx-filters==1.5.0
     # via
     #   -r requirements/edx/base.txt
     #   lti-consumer-xblock
-openedx-learning==0.1.2
+openedx-learning==0.1.5
     # via -r requirements/edx/base.txt
 openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
## Description

This PR exposes the retrieve object tag REST API endpoint from oel_tagging.

## Supporting Information

- Depends on https://github.com/openedx/openedx-learning/pull/68

## Testing Instructions

- Run your local devstack,
- Make have https://github.com/openedx/openedx-learning/pull/68 installed locally, to do that:
    - clone the branch to your DEV_STACK/src
    - uninstall your existing openedx-learning package:
        - `make lms-shel`
        - `pip uninstall openedx-learning`
    - install the branch you cloned: 
        - `make lms-shell`
        - `cd /edx/src`
        - `pip install -e openedx-learning`
   - Check that the endpoint page works:
       - `http://localhost:18000/api/content_tagging/v1/object_tags/`

---
Private Ref: [FAL-3452](https://tasks.opencraft.com/browse/FAL-3452)