### PR TITLE
chore: bump ora2

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -133,7 +133,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-events>=3.1.0               # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 optimizely-sdk                      # Optimizely full stack SDK for Python
-ora2>=4.5.0
+ora2>=5.1.1
 outcome-surveys                     # edx-platform plugin to send and track segment events needed for surveys
 openedx-django-wiki
 openedx-blockstore

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -133,7 +133,7 @@ openedx-calc                        # Library supporting mathematical calculatio
 openedx-events>=3.1.0               # Open edX Events from Hooks Extension Framework (OEP-50)
 openedx-filters                     # Open edX Filters from Hooks Extension Framework (OEP-50)
 optimizely-sdk                      # Optimizely full stack SDK for Python
-ora2>=5.1.1
+ora2==5.1.1
 outcome-surveys                     # edx-platform plugin to send and track segment events needed for surveys
 openedx-django-wiki
 openedx-blockstore

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -778,7 +778,7 @@ openedx-filters==1.2.0
     #   lti-consumer-xblock
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.in
-ora2==5.2.5
+ora2==5.1.1
     # via -r requirements/edx/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -778,7 +778,7 @@ openedx-filters==1.2.0
     #   lti-consumer-xblock
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.in
-ora2==5.0.0
+ora2==5.2.5
     # via -r requirements/edx/base.in
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1037,7 +1037,7 @@ openedx-filters==1.2.0
     #   lti-consumer-xblock
 optimizely-sdk==4.1.1
     # via -r requirements/edx/testing.txt
-ora2==5.2.5
+ora2==5.1.1
     # via -r requirements/edx/testing.txt
 oscrypto==1.3.0
     # via

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1037,7 +1037,7 @@ openedx-filters==1.2.0
     #   lti-consumer-xblock
 optimizely-sdk==4.1.1
     # via -r requirements/edx/testing.txt
-ora2==5.0.0
+ora2==5.2.5
     # via -r requirements/edx/testing.txt
 oscrypto==1.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -984,7 +984,7 @@ openedx-filters==1.2.0
     #   lti-consumer-xblock
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.0.0
+ora2==5.2.5
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -984,7 +984,7 @@ openedx-filters==1.2.0
     #   lti-consumer-xblock
 optimizely-sdk==4.1.1
     # via -r requirements/edx/base.txt
-ora2==5.2.5
+ora2==5.1.1
     # via -r requirements/edx/base.txt
 oscrypto==1.3.0
     # via


### PR DESCRIPTION
This PR bumps ora2 to a version that supports the me-south-1 AWS region.

## Testing

1. Try submitting a file in [the development environment](https://apps.lms.dev.eshe.edpl.us/learning/course/course-v1:ASU+CS101+2023/block-v1:ASU+CS101+2023+type@sequential+block@cbfa6ca94fc44eaf94c2a63215112dd5/block-v1:ASU+CS101+2023+type@vertical+block@083e1b735440424e91a29b897a2c3694) where this has been deployed.
2. Ensure the file is uploaded correctly.