### PR TITLE
fix: eSHE Instructor should be able to see forum members and enrollments [BB-7841]

### DIFF
--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -29,6 +29,8 @@ EMAIL = 'instructor.email'
 RESCORE_EXAMS = 'instructor.rescore_exams'
 VIEW_REGISTRATION = 'instructor.view_registration'
 VIEW_DASHBOARD = 'instructor.dashboard'
+VIEW_ENROLLMENTS = 'instructor.view_enrollments'
+VIEW_FORUM_MEMBERS = 'instructor.view_forum_members'
 
 
 perms[ALLOW_STUDENT_TO_BYPASS_ENTRANCE_EXAM] = HasAccessRule('staff')
@@ -66,3 +68,5 @@ perms[VIEW_DASHBOARD] = \
         'instructor',
         'data_researcher'
 ) | HasAccessRule('staff') | HasAccessRule('instructor')
+perms[VIEW_ENROLLMENTS] = HasAccessRule('staff')
+perms[VIEW_FORUM_MEMBERS] = HasAccessRule('staff')

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1659,7 +1659,7 @@ def get_anon_ids(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.CAN_ENROLL)
+@require_course_permission(permissions.VIEW_ENROLLMENTS)
 @require_post_params(
     unique_student_identifier="email or username of student for whom to get enrollment status"
 )
@@ -2609,7 +2609,7 @@ def problem_grade_report(request, course_id):
 @require_POST
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
-@require_course_permission(permissions.CAN_ENROLL)
+@require_course_permission(permissions.VIEW_FORUM_MEMBERS)
 @require_post_params('rolename')
 def list_forum_members(request, course_id):
     """


### PR DESCRIPTION
## Description

Consider [this diff](https://github.com/open-craft/edx-platform/commit/5d160c2ecd91e58276dccfd84ca32fb689f46e5e#diff-119bae82c371c32ae47e25d78423c5001a44e951e23492f31d3febe7d9c008f6R47-R53). We've modified `CAN_ENROLL` permission in a way that eSHE Instructors don't have it, but eSHE Instructor + Staff have.

However, the same permission is used to control two other endpoints that shouldn't be forbidden to eSHE Instructor. One of them, `get_student_enrollment_status`, is used for this instructor view:
![image](https://github.com/open-craft/edx-platform/assets/18251194/4b24d7f5-c7e6-43f2-9d8f-41fe62b9a637)

So this PR fixes these two endpoints for eSHE Instructors by introducing two new permissions, specific to these endpoints, with the same access level as before.

## Testing instructions

1. Switch your devstack to the `0x29a/bb7841/fix-permissions` branch from the `git@github.com:open-craft/edx-platform.git` repo.
2. Enable the eSHE Instructor role by setting [this](https://github.com/open-craft/edx-platform/blob/opencraft-release/palm.1/lms/envs/common.py#L1060) to `True`. 
3. Open two browser tabs, one of them should be anonymous.
4. In one tab log in as staff, in the other register as `eshe_instructor@example.com`.
5. As a staff, give `eshe_instructor@example.com` the `eSHE Instructor` course team role (that can be done in the Instructor Dashboard).
6. Now, verify that `eshe_instructor@example.com` can view enrollment status of `staff@example.com`.