### PR TITLE
fix: loading of underscore and other text assets over CDN

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -353,6 +353,11 @@
             'jquery_extend_patch': {
                 deps: ['jquery']
             }
+        },
+        config: {
+          text: {
+            useXhr: () => true
+          }
         }
     });
 }).call(this, require, define);

--- a/lms/static/lms/js/require-config.js
+++ b/lms/static/lms/js/require-config.js
@@ -226,6 +226,11 @@
             'hls': {
                 exports: 'Hls'
             }
+        },
+        config: {
+          text: {
+            useXhr: () => true
+          }
         }
     });
 }).call(this, require || RequireJS.require, define || RequireJS.define);


### PR DESCRIPTION
**Backport of https://github.com/openedx/edx-platform/pull/33124**

The text plugin for requirejs is used to load text assets such as .underscore files. To avoid CORS issues when loading such assets from a different domain, such as a when a CDN is in use, this plugin loads such assets as .js files by adding a script tag.

What this means in practice is that if you configure the platform to serve static assets from a CDN, it will try to load `file.underscore.js` instead of `file.underscore`. We can override this behaviour by providing a `useXhr` function for the text plugin configuration. The plugin will use this function to determine whether to use XHR or the script tag approach.

In this change we are asking it to always use XHR since the concerns about CORS raised by the plugins documentation don't apply here.

ref: https://github.com/requirejs/text/blob/3f9d4c19b3a1a3c6f35650c5788cbea1db93197a/README.md#xhr-restrictions