### PR TITLE
fix: fetch org list only for course creator granted status and course admin can create new library

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -207,6 +207,10 @@ class TestCourseListing(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 403)
 
     @override_settings(FEATURES={'ENABLE_CREATOR_GROUP': True})
+    @mock.patch(
+        'cms.djangoapps.course_creators.admin.render_to_string',
+        mock.Mock(side_effect=mock_render_to_string, autospec=True)
+    )
     def test_course_creation_when_user_in_org_with_creator_role(self):
         """
         Tests course creation with user having the organization content creation role.
@@ -217,6 +221,9 @@ class TestCourseListing(ModuleStoreTestCase):
             'description': 'Testing Organization Description',
         })
         update_org_role(self.global_admin, OrgContentCreatorRole, self.user, [self.source_course_key.org])
+        self.course_creator_entry.all_organizations = True
+        self.course_creator_entry.state = CourseCreator.GRANTED
+        self.creator_admin.save_model(self.request, self.course_creator_entry, None, True)
         self.assertIn(self.source_course_key.org, get_allowed_organizations(self.user))
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'org': self.source_course_key.org,

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1999,7 +1999,7 @@ def get_organizations(user):
     Returns the list of organizations for which the user is allowed to create courses.
     """
     course_creator = CourseCreator.objects.filter(user=user).first()
-    if not course_creator:
+    if not course_creator or course_creator.state != CourseCreator.GRANTED:
         return []
     elif course_creator.all_organizations:
         organizations = Organization.objects.all().values_list('short_name', flat=True)

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -83,8 +83,9 @@ def user_can_create_library(user, org=None):
         is_course_creator = get_course_creator_status(user) == 'granted'
         has_org_staff_role = OrgStaffRole().get_orgs_for_user(user).exists()
         has_course_staff_role = UserBasedRole(user=user, role=CourseStaffRole.ROLE).courses_with_role().exists()
+        has_course_admin_role = UserBasedRole(user=user, role=CourseInstructorRole.ROLE).courses_with_role().exists()
 
-        return is_course_creator or has_org_staff_role or has_course_staff_role
+        return is_course_creator or has_org_staff_role or has_course_staff_role or has_course_admin_role
     else:
         # EDUCATOR-1924: DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION, if present.
         disable_library_creation = settings.FEATURES.get('DISABLE_LIBRARY_CREATION', None)

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -19,7 +19,7 @@ from organizations.exceptions import InvalidOrganizationException
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, parse_json
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_library_url
 from cms.djangoapps.course_creators.views import add_user_with_status_granted as grant_course_creator_status
-from common.djangoapps.student.roles import LibraryUserRole, CourseStaffRole
+from common.djangoapps.student.roles import LibraryUserRole, CourseStaffRole, CourseInstructorRole
 from xmodule.modulestore.tests.factories import LibraryFactory  # lint-amnesty, pylint: disable=wrong-import-order
 from cms.djangoapps.course_creators.models import CourseCreator
 
@@ -99,6 +99,14 @@ class UnitTestLibraries(CourseTestCase):
         _, nostaff_user = self.create_non_staff_authed_user_client()
         with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
             auth.add_users(self.user, CourseStaffRole(self.course.id), nostaff_user)
+            self.assertEqual(user_can_create_library(nostaff_user), True)
+
+    # When creator groups are enabled, course instructor members can create libraries
+    @mock.patch("cms.djangoapps.contentstore.views.library.LIBRARIES_ENABLED", True)
+    def test_library_creator_status_with_course_instructor_role_for_enabled_creator_group_setting(self):
+        _, nostaff_user = self.create_non_staff_authed_user_client()
+        with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
+            auth.add_users(self.user, CourseInstructorRole(self.course.id), nostaff_user)
             self.assertEqual(user_can_create_library(nostaff_user), True)
 
     @ddt.data(

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -480,9 +480,14 @@ class UnitTestLibraries(CourseTestCase):
                             # Assert that the method returned the expected value
                             self.assertEqual(organizations, [])
                         with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
-                            organizations = get_allowed_organizations_for_libraries(self.user)
-                            # Assert that the method returned the expected value
-                            self.assertEqual(organizations, ['org1', 'org2'])
+                            # Assert that correct org values are returned based on course creator state
+                            for course_creator_state in CourseCreator.STATES:
+                                course_creator.state = course_creator_state
+                                organizations = get_allowed_organizations_for_libraries(self.user)
+                                if course_creator_state != CourseCreator.GRANTED:
+                                    self.assertEqual(organizations, [])
+                                else:
+                                    self.assertEqual(organizations, ['org1', 'org2'])
                     with mock.patch.dict(
                         'django.conf.settings.FEATURES',
                         {"ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES": True}


### PR DESCRIPTION
## Description

This PR fixes two bugs :

1. **fetch org list only for course creator granted status**:
The [get_organizations](https://github.com/open-craft/edx-platform/blob/6e79a5389e9224b452b2f698d4e71b382f3e1e65/cms/djangoapps/contentstore/views/course.py#L1832) is used to fetch a list of orgs which a user is allowed to create courses/libraries for. The course creator status for the user is used here to determine which orgs to display to the user.

However, currently all orgs are fetched for users even with course creator status in `unrequested` or `pending` state. This is a bug which is being fixed with this PR.

2. **Course instrutors cannot create new library even though course staff can**:
Currently course staff has the ability to create new libraries for their respective orgs. But when a course staff user is "promoted" to course instructor/admin role, the user loses this ability. This bug is fixed with the PR too.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

1. **fetch org list only for course creator granted status**:
1. In devstack, set `ENABLE_ORGANIZATION_STAFF_ACCESS_FOR_CONTENT_LIBRARIES` feature flag in Studio to `False`.
2. Create a new user and give that user course staff access for any course.
4. Login to studio as the new user and click on `New Library` button on the studio homepage
5. Click on the org dropdown and verify no orgs are fetched.

2. **Course instrutors cannot create new library even though course staff can**:
1. In devstack, create a new user and give that user course staff access for any course
2. Login to studio as the new user and verify the `New Library` button is visible on the studio homepage.
3. As an admin user, promote the new user to coures instructor/admin role
4. Login to studio as the new user and verify that the `New Library` button is still visible on the studio homepage.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

[BB-7827](https://tasks.opencraft.com/browse/BB-7827)