### PR TITLE
feat: set course for wiki based on the wiki_slug

### DIFF
--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -15,6 +15,8 @@ from openedx.core.lib.request_utils import course_id_from_url
 from openedx.features.enterprise_support.api import get_enterprise_consent_url
 from common.djangoapps.student.models import CourseEnrollment
 
+from xmodule import modulestore
+
 
 class WikiAccessMiddleware(MiddlewareMixin):
     """
@@ -54,6 +56,21 @@ class WikiAccessMiddleware(MiddlewareMixin):
 
         course_id = course_id_from_url(request.path)
         wiki_path = request.path.partition('/wiki/')[2]
+
+        # if no wiki_path, can't get wiki_slug, so no point trying to look up
+        # course_id by wiki_slug
+        if not course_id and wiki_path:
+            # wiki path always starts with wiki_slug
+            wiki_slug = wiki_path.split('/')[0]
+
+            modstore = modulestore.django.modulestore()
+            course_ids = modstore.get_courses_for_wiki(wiki_slug)
+            # the above can return multiple courses, and to avoid ambiguity and
+            # avoid pointing to wrong courses, we only set course_id if we've
+            # got an exact match, i.e. only one course was returned for a
+            # wiki_slug
+            if len(course_ids) == 1:
+                course_id = course_ids[0]
 
         if course_id:
             # This is a /courses/org/name/run/wiki request

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -34,3 +34,10 @@ class TestWikiAccessMiddleware(ModuleStoreTestCase):
         response = self.client.get('/courses/edx/math101/2014/wiki/math101/')
         self.assertContains(response, '/courses/edx/math101/2014/wiki/math101/_edit/')
         self.assertContains(response, '/courses/edx/math101/2014/wiki/math101/_settings/')
+
+    def test_finds_course_by_wiki_slug(self):
+        """Test that finds course by wiki slug, if course id is not present in the url."""
+        response = self.client.get('/wiki/math101/')
+        request = response.wsgi_request
+        self.assertTrue(hasattr(request, 'course'))
+        self.assertEqual(request.course.id, self.course_math101.id)


### PR DESCRIPTION
Upstream PR: https://github.com/openedx/edx-platform/pull/33338

## Description

Learners want to have the usual course navigation when viewing a wiki, so that they can go back to the course related to the wiki and browse other tabs/sections of the course.

Wiki reads the course from the `request.course`. If it's not present, i.e.  None or not set on the request, it will not show the course navigation UI.

It seems like `WikiAccessMiddleware` already has the code that parses course id from the request (when the request is for a wiki view) and sets the course for the request. However, it doesn't work in most scenarios, because the course id is not in the it's normal format in most requests that go to wiki.

For example, when a leaner clicks on a wiki tab from the course overview, they are redirected to `/wiki/<wiki_slug>/` path. The wiki slug is taken from course's `wiki_slug` field. This slug can be used to figure out what course this wiki belongs to in most (not all) cases.

This commit adds code to the `WikiAccessMiddleware` that attempts to find a course based on wiki slug, and in case of success, sets the course to the `request.course`, so that wiki can display course navigation UI.

## Testing instructions

* Setup `devstack` of latest version
* `make dev.up.lms+cms+frontend-app-learning`
* Log in at `localhost:18000` as `edx@example.com` (`edx` as password)
* Enroll into the demo course
* Go to studio for this course, in the navigation find "Content -> Pages", click on it, and make the Wiki tab visible by clicking the crossed eye icon
* Go back to the course, and click the wiki tab
* You will see that the wiki doesn't have any course tabs, there is no way to go back to the course you came from, etc.
  <details>
    <summary>Screenshot</summary>

    ![image](https://github.com/openedx/edx-platform/assets/30300520/feaa2f37-de00-4b09-9058-94fe1fa7da18)
  </details>
* Now checkout the branch from the PR
* Go back to the wiki page and reload (it might need a minute for the dev server to restart)
* You will now see that the course navigation UI is showing correctly.
  <details>
    <summary>Screenshot</summary>

    ![image](https://github.com/openedx/edx-platform/assets/30300520/af11a5e7-8f1c-4eab-baa1-2759fb89c094)
  </details>
* Check that the links are pointing to the correct course

## Deadline

"None"