### PR TITLE
build: replace py2neo with a fork

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -125,7 +125,12 @@ openedx-filters                     # Open edX Filters from Hooks Extension Fram
 ora2
 piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo                              # Driver for converting Python modulestore structures to Neo4j's schema (for Coursegraph).
+
+# Driver for converting Python modulestore structures to Neo4j's schema (for Coursegraph).
+# Using the fork because official package has been removed from PyPI/GitHub
+# Follow up issue to remove this fork: https://github.com/openedx/edx-platform/issues/33456
+https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
+
 pycountry
 pycryptodomex
 pygments                            # Used to support colors in paver command output

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -782,7 +782,7 @@ psutil==5.9.0
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
-py2neo==2021.2.3
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1062,7 +1062,7 @@ py==1.11.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.3
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -999,7 +999,7 @@ py==1.11.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.3
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
The original library was removed from PyPI and GitHub.

https://discuss.openedx.org/t/missing-py2neo-package-causing-build-issues-in-all-edx-platform-releases/11371