### PR TITLE
fix: check masquerade on instructor dashboard tab acess check

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -26,6 +26,7 @@ from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import UserFactory
 from common.test.utils import XssTestMixin
 from lms.djangoapps.courseware.courses import get_studio_url
+from lms.djangoapps.courseware.masquerade import CourseMasquerade
 from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
@@ -120,6 +121,11 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
 
         staff = StaffFactory(course_key=self.course.id)
         assert has_instructor_tab(staff, self.course)
+
+        masquerade_staff = StaffFactory(course_key=self.course.id)
+        masquerade = CourseMasquerade(self.course.id, role='student')
+        masquerade_staff.masquerade_settings = {self.course.id: masquerade}
+        assert not has_instructor_tab(masquerade_staff, self.course)
 
         student = UserFactory.create()
         assert not has_instructor_tab(student, self.course)

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -53,6 +53,7 @@ from lms.djangoapps.certificates.models import (
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_studio_url
 from lms.djangoapps.courseware.block_render import get_block_by_usage_id
+from lms.djangoapps.courseware.masquerade import get_masquerade_role
 from lms.djangoapps.discussion.django_comment_client.utils import has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled
 from lms.djangoapps.instructor.constants import INSTRUCTOR_DASHBOARD_PLUGIN_VIEW_NAME
@@ -93,7 +94,9 @@ class InstructorDashboardTab(CourseTab):
         """
         Returns true if the specified user has staff access.
         """
-        return bool(user and user.is_authenticated and user.has_perm(permissions.VIEW_DASHBOARD, course.id))
+        return bool(user and user.is_authenticated and
+                    get_masquerade_role(user, course.id) != 'student' and
+                    user.has_perm(permissions.VIEW_DASHBOARD, course.id))
 
 
 def show_analytics_dashboard_message(course_key):


### PR DESCRIPTION
Backports https://github.com/openedx/edx-platform/pull/33684.

## Description

Check also masquerading role to determine if instructor tab is enabled, in order to hide it when a user with acess is masquerading as a student role without a specific different user.

Impacts Staff and Instructor users.

## Testing instructions

1. [Create a course with an enrollment track](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_features/diff_content/enroll_track_courseware.html)
2. Preview the course as a staff user
   ![image](https://github.com/open-craft/edx-platform/assets/1616648/7c1eb01b-8465-4b0c-8971-038a7b31dfb7)
3. Use the "View this course as:" option to select one of the enrollment tracks
4. See that the "Instructor" tab is not displayed
   ![image](https://github.com/open-craft/edx-platform/assets/1616648/8890d9c6-d7f6-4ba3-9376-1a7965e879a3)

## Deadline

None

## Other information

Private-Ref: https://tasks.opencraft.com/browse/BB-8087