### PR TITLE
chore: add algoliasearch dependency [BB-8083]

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -26,6 +26,7 @@
 #    as development.in or testing.in instead.
 
 acid-xblock
+algoliasearch
 analytics-python                    # Used for Segment analytics
 attrs                               # Reduces boilerplate code involving class attributes
 Babel                               # Internationalization utilities, used for date formatting in a few places

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -38,6 +38,8 @@ aiohttp==3.8.1
     # via geoip2
 aiosignal==1.2.0
     # via aiohttp
+algoliasearch==2.6.3
+    # via -r requirements/edx/base.in
 amqp==5.1.0
     # via kombu
 analytics-python==1.4.0
@@ -913,6 +915,7 @@ regex==2022.3.15
 requests==2.27.1
     # via
     #   -r requirements/edx/paver.txt
+    #   algoliasearch
     #   analytics-python
     #   coreapi
     #   django-oauth-toolkit

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -44,6 +44,8 @@ aiosignal==1.2.0
     #   aiohttp
 alabaster==0.7.12
     # via sphinx
+algoliasearch==2.6.3
+    # via -r requirements/edx/testing.txt
 amqp==5.1.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1277,6 +1279,7 @@ regex==2022.3.15
 requests==2.27.1
     # via
     #   -r requirements/edx/testing.txt
+    #   algoliasearch
     #   analytics-python
     #   coreapi
     #   django-oauth-toolkit

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -42,6 +42,8 @@ aiosignal==1.2.0
     # via
     #   -r requirements/edx/base.txt
     #   aiohttp
+algoliasearch==2.6.3
+    # via -r requirements/edx/base.txt
 amqp==5.1.0
     # via
     #   -r requirements/edx/base.txt
@@ -1199,6 +1201,7 @@ regex==2022.3.15
 requests==2.27.1
     # via
     #   -r requirements/edx/base.txt
+    #   algoliasearch
     #   analytics-python
     #   coreapi
     #   django-oauth-toolkit


### PR DESCRIPTION
This is needed for https://github.com/open-craft/edx-enterprise/pull/12 and https://github.com/open-craft/frontend-app-learner-portal-enterprise/pull/2.

We can't add this dependency directly to `edx-enterprise`, because although it's designed to be able to run separately from `edx-platform`, currently it uses platform's dependencies.