### PR TITLE
feat: filter courses by user language by default

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -276,6 +276,7 @@ def courses(request):
     """
     courses_list = []
     course_discovery_meanings = getattr(settings, 'COURSE_DISCOVERY_MEANINGS', {})
+    set_default_filter = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER')
     if not settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
         courses_list = get_courses(request.user)
 
@@ -293,6 +294,7 @@ def courses(request):
         {
             'courses': courses_list,
             'course_discovery_meanings': course_discovery_meanings,
+            'set_default_filter': set_default_filter,
             'programs_list': programs_list,
         }
     )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -659,6 +659,17 @@ FEATURES = {
     # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/7845
     'ENABLE_COURSE_DISCOVERY': False,
 
+    # .. toggle_name: FEATURES['ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Enable courses to be filtered by user language by default.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2023-11-02
+    # .. toggle_target_removal_date: None
+    # .. toggle_warning: The ENABLE_COURSE_DISCOVERY setting should be enabled.
+    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/33647
+    'ENABLE_COURSE_DISCOVERY_DEFAULT_LANGUAGE_FILTER': False,
+
     # .. toggle_name: FEATURES['ENABLE_COURSE_FILENAME_CCX_SUFFIX']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False

--- a/lms/static/js/discovery/discovery_factory.js
+++ b/lms/static/js/discovery/discovery_factory.js
@@ -5,7 +5,7 @@
         'js/discovery/views/search_form', 'js/discovery/views/courses_listing',
         'js/discovery/views/filter_bar', 'js/discovery/views/refine_sidebar'],
     function(Backbone, SearchState, Filters, SearchForm, CoursesListing, FilterBar, RefineSidebar) {
-        return function(meanings, searchQuery, userLanguage, userTimezone) {
+        return function(meanings, searchQuery, userLanguage, userTimezone, setDefaultFilter) {
             var dispatcher = _.extend({}, Backbone.Events);
             var search = new SearchState();
             var filters = new Filters();
@@ -21,10 +21,16 @@
                 userLanguage: userLanguage,
                 userTimezone: userTimezone
             };
+            if (setDefaultFilter && userLanguage) {
+                filters.add({
+                    type: 'language',
+                    query: userLanguage,
+                    name: refineSidebar.termName('language', userLanguage)
+                });
+            }
             listing = new CoursesListing({model: courseListingModel});
 
             dispatcher.listenTo(form, 'search', function(query) {
-                filters.reset();
                 form.showLoadingIndicator();
                 search.performSearch(query, filters.getTerms());
             });
@@ -42,6 +48,7 @@
             dispatcher.listenTo(filterBar, 'clearFilter', removeFilter);
 
             dispatcher.listenTo(filterBar, 'clearAll', function() {
+                filters.reset();
                 form.doSearch('');
             });
 

--- a/lms/static/js/spec/discovery/discovery_factory_spec.js
+++ b/lms/static/js/spec/discovery/discovery_factory_spec.js
@@ -47,7 +47,8 @@ define([
                     start: '1970-01-01T05:00:00+00:00',
                     image_url: '/c4x/edX/DemoX/asset/images_course_image.jpg',
                     org: 'edX',
-                    id: 'edX/DemoX/Demo_Course'
+                    id: 'edX/DemoX/Demo_Course',
+                    language: 'en'
                 }
             }
         ],
@@ -197,5 +198,17 @@ define([
             $('.search-facets li [data-value="edX1"]').trigger('click');
             expect($('.active-filter [data-value="edX1"]').length).toBe(0);
         });
+
+        it('filters by default language', function() {
+            DiscoveryFactory(MEANINGS, '', 'en', 'Asia/Kolkata', true);
+            var requests = AjaxHelpers.requests(this);
+            $('.discovery-submit').trigger('click');
+            AjaxHelpers.respondWithJson(requests, JSON_RESPONSE);
+            expect($('.courses-listing article').length).toEqual(1);
+            expect($('.courses-listing .course-title')).toContainHtml('edX Demonstration Course');
+            expect($('.active-filter').length).toBe(1);
+            expect($('.active-filter .query')).toContainHtml("English");
+        });
+
     });
 });

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -23,7 +23,8 @@
       ${course_discovery_meanings | n, dump_js_escaped_json},
       getParameterByName('search_query'),
       "${user_language | n, js_escaped_string}",
-      "${user_timezone | n, js_escaped_string}"
+      "${user_timezone | n, js_escaped_string}",
+      ${set_default_filter | n, dump_js_escaped_json}
     );
   </%static:require_module>
 </%block>


### PR DESCRIPTION
Adds a feature flag to filter courses by users preferred language by default

test: add test
(cherry picked from commit eca9398c098ee54a25cdb7f9612cff144c98f652)

`Private-ref`: https://tasks.opencraft.com/browse/BB-8091