### PR TITLE
fix: make "fs" service available in XBlock preview module system

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -160,10 +160,15 @@ def _preview_module_system(request, descriptor, field_data):
     descriptor: An XModuleDescriptor
     """
 
+    # Import is placed here to avoid model import at project startup.
+    import xblock.reference.plugins
+
     course_id = descriptor.location.course_key
     display_name_only = (descriptor.category == 'static_tab')
 
     replace_url_service = ReplaceURLService(course_id=course_id)
+
+    fs_service = xblock.reference.plugins.FSService()
 
     wrappers = [
         # This wrapper wraps the block in the template specified above
@@ -229,7 +234,8 @@ def _preview_module_system(request, descriptor, field_data):
             "teams_configuration": TeamsConfigurationService(),
             "sandbox": SandboxService(contentstore=contentstore, course_id=course_id),
             "cache": CacheService(cache),
-            'replace_urls': replace_url_service
+            'replace_urls': replace_url_service,
+            "fs": fs_service
         },
     )
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -185,7 +185,8 @@ unicodecsv                          # Easier support for CSV files with unicode 
 user-util                           # Functionality for retiring users (GDPR compliance)
 webob
 web-fragments                       # Provides the ability to render fragments of web pages
-XBlock[django]                      # Courseware component architecture
+# Using OpenCraft fork of XBlock in github.in
+#XBlock[django]                      # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 xblock-poll                         # Xblock for polling users

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -762,8 +762,10 @@ openedx-blockstore==1.3.1
     # via -r requirements/edx/base.in
 openedx-calc==3.0.1
     # via -r requirements/edx/base.in
-openedx-django-pyfs==3.2.1
-    # via xblock
+openedx-django-pyfs @ git+https://github.com/open-craft/django-pyfs.git@opencraft-release/3.5.0-tox-3
+    # via
+    #   -r requirements/edx/github.in
+    #   xblock
 openedx-django-require==2.0.0
     # via -r requirements/edx/base.in
 openedx-django-wiki==2.0.0
@@ -1170,9 +1172,9 @@ wrapt==1.15.0
     # via
     #   -r requirements/edx/paver.txt
     #   deprecated
-xblock[django]==1.6.2
+xblock @ git+https://github.com/open-craft/XBlock.git@opencraft-release/1.6.2
     # via
-    #   -r requirements/edx/base.in
+    #   -r requirements/edx/github.in
     #   acid-xblock
     #   crowdsourcehinter-xblock
     #   done-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -575,7 +575,7 @@ edx-django-release-util==1.2.0
     #   openedx-blockstore
 edx-django-sites-extensions==4.0.0
     # via -r requirements/edx/testing.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/edx/testing.txt
     #   django-config-models
@@ -890,7 +890,6 @@ lazy==1.5
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-    #   xblock
 lazy-object-proxy==1.9.0
     # via
     #   -r requirements/edx/testing.txt
@@ -1019,10 +1018,8 @@ openedx-blockstore==1.3.1
     # via -r requirements/edx/testing.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/testing.txt
-openedx-django-pyfs==3.2.1
-    # via
-    #   -r requirements/edx/testing.txt
-    #   xblock
+openedx-django-pyfs @ git+https://github.com/open-craft/django-pyfs.git@opencraft-release/3.5.0-tox-3
+    # via -r requirements/edx/testing.txt
 openedx-django-require==2.0.0
     # via -r requirements/edx/testing.txt
 openedx-django-wiki==2.0.0
@@ -1699,7 +1696,7 @@ wrapt==1.15.0
     #   -r requirements/edx/testing.txt
     #   astroid
     #   deprecated
-xblock[django]==1.6.2
+xblock @ git+https://github.com/open-craft/XBlock.git@opencraft-release/1.6.2
     # via
     #   -r requirements/edx/testing.txt
     #   acid-xblock

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -85,7 +85,10 @@
 # Critical fixes for packages that are not yet available in a PyPI release.
 ##############################################################################
 
-# ... add dependencies here
+# https://github.com/open-craft/XBlock/pull/6
+git+https://github.com/open-craft/XBlock.git@opencraft-release/1.6.2#egg=XBlock[django]==1.6.2
+# https://github.com/openedx/django-pyfs/pull/169
+git+https://github.com/open-craft/django-pyfs.git@opencraft-release/3.5.0-tox-3#egg=openedx-django-pyfs==3.5.0
 
 
 ##############################################################################

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -553,7 +553,7 @@ edx-django-release-util==1.2.0
     #   openedx-blockstore
 edx-django-sites-extensions==4.0.0
     # via -r requirements/edx/base.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/edx/base.txt
     #   django-config-models
@@ -846,7 +846,6 @@ lazy==1.5
     #   bok-choy
     #   lti-consumer-xblock
     #   ora2
-    #   xblock
 lazy-object-proxy==1.9.0
     # via astroid
 learner-pathway-progress==1.3.3
@@ -966,10 +965,8 @@ openedx-blockstore==1.3.1
     # via -r requirements/edx/base.txt
 openedx-calc==3.0.1
     # via -r requirements/edx/base.txt
-openedx-django-pyfs==3.2.1
-    # via
-    #   -r requirements/edx/base.txt
-    #   xblock
+openedx-django-pyfs @ git+https://github.com/open-craft/django-pyfs.git@opencraft-release/3.5.0-tox-3
+    # via -r requirements/edx/base.txt
 openedx-django-require==2.0.0
     # via -r requirements/edx/base.txt
 openedx-django-wiki==2.0.0
@@ -1567,7 +1564,7 @@ wrapt==1.15.0
     #   -r requirements/edx/base.txt
     #   astroid
     #   deprecated
-xblock[django]==1.6.2
+xblock @ git+https://github.com/open-craft/XBlock.git@opencraft-release/1.6.2
     # via
     #   -r requirements/edx/base.txt
     #   acid-xblock


### PR DESCRIPTION
## Description

The "fs" XBlock runtime service is not made available in Palm when in preview mode (e.g. in Studio).

This causes an error when trying to use this service while editing an XBlock, e.g. uploading a screenshot for the [Recommender XBlock](https://github.com/openedx/RecommenderXBlock):
<details>
  <summary>Traceback</summary>

  ```
  Traceback (most recent call last):
    File "/openedx/edx-platform/./cms/djangoapps/contentstore/views/preview.py", line 75, in preview_handler
      resp = instance.handle(handler, req, suffix)
    File "/openedx/venv/lib/python3.8/site-packages/xblock/mixins.py", line 84, in handle
      return self.runtime.handle(self, handler_name, request, suffix)
    File "/openedx/edx-platform/xmodule/x_module.py", line 1033, in handle
      return super().handle(block, handler_name, request, suffix=suffix)
    File "/openedx/venv/lib/python3.8/site-packages/xblock/runtime.py", line 1081, in handle
      results = handler(request, suffix)
    File "/openedx/venv/lib/python3.8/site-packages/recommender/recommender.py", line 581, in upload_screenshot
      fhwrite = self.fs.open(file_name, "wb")
    File "/openedx/venv/lib/python3.8/site-packages/xblock/reference/plugins.py", line 141, in __get__
      value = xblock.runtime.service(xblock, 'fs').load(self, xblock)
    File "/openedx/edx-platform/xmodule/x_module.py", line 1810, in service
      service = self._module_system.service(block, service_name)
    File "/openedx/edx-platform/xmodule/x_module.py", line 1740, in service
      service = super().service(block=block, service_name=service_name)
    File "/openedx/venv/lib/python3.8/site-packages/xblock/runtime.py", line 1125, in service
      raise NoSuchServiceError(f"Service {service_name!r} is not available.")
  xblock.exceptions.NoSuchServiceError: Service 'fs' is not available.
  ```
</details>

This is fixed in master, possibly in [18fea86](https://github.com/openedx/edx-platform/commit/18fea868a9914854fd614d147ad9b0bbbe7616c5#diff-0f9960747639224845a14d42acee7d24eae92d50406e88a3142a7da45467c596R344), however that is part of openedx/edx-platform#31472 which is a rather large change. This is a smaller fix.

## Testing instructions

1. Install and enable the [Recommender XBlock](https://github.com/openedx/RecommenderXBlock/tree/master)
   - Install RecommenderXBlock from https://github.com/open-craft/RecommenderXBlock/tree/opencraft-release/2.1.0 if using S3
   - Make sure that openedx-django-pyfs is configured to use a writeable local directory, or an S3 bucket e.g.
      ```python
      # lms/envs/private.py
      DJFS = {
          'type': 'osfs',
          'directory_root': 'lms/static/djpyfs',
          'url_root': '/static/djpyfs'
      }
      # cms/envs/private.py
      DJFS = {
          'type': 'osfs',
          'directory_root': 'cms/static/djpyfs',
          'url_root': '/static/studio/djpyfs'
      }
      # Or,
      DJFS = {
          'type': 's3fs',
          'bucket': AWS_STORAGE_BUCKET_NAME,
          'prefix': 'pyfs/',
          # Note that explicitly passing credentials requires openedx-django-pyfs >= 3.4.1
          'aws_access_key_id': AWS_ACCESS_KEY_ID,
          'aws_secret_access_key': AWS_SECRET_ACCESS_KEY
      }
      ```
2. In Studio, add a recommender component to a course.
3. Add a resource in the recommender component, upload a preview screenshot.
   <details>

     ![image](https://github.com/open-craft/edx-platform/assets/1616648/d8f79978-9ea6-4472-8afc-a10d928aa54c)
   </details>
4. Save it. Make sure there are no errors and that it was saved correctly.
5. Reload the page. See the newly added item and that the screenshot loads on hover.

## Deadline

None

## Other information 

Private-ref: https://tasks.opencraft.com/browse/BB-8077