### PR TITLE
fix: add permissions roles to new course

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -13,6 +13,7 @@ from cms.djangoapps.contentstore.views.assets import update_course_run_asset
 from cms.djangoapps.contentstore.views.course import create_new_course, get_course_and_check_access, rerun_course
 from common.djangoapps.student.models import CourseAccessRole
 from openedx.core.lib.courses import course_image_url
+from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=wrong-import-order
 
 IMAGE_TYPES = {
@@ -235,4 +236,5 @@ class CourseCloneSerializer(serializers.Serializer):  # lint-amnesty, pylint: di
         dest_key = CourseKey.from_string(destination_course_id)
         with store.default_store('split'):
             new_course = store.clone_course(source_key, dest_key, user_id)
+        seed_permissions_roles(dest_key)
         return new_course


### PR DESCRIPTION
Private-ref: [BB-8292](https://tasks.opencraft.com/browse/BB-8292)

This PR,

- [x] Adds permission roles to new course when cloned

This avoids having user roles errors when trying to set Discussion Moderators or Administrators.

**Testing instructions**
- Checkout to this branch, `git checkout steff456/add-roles-clones`
- Use the API to clone a course
- Open Studio and go to the instructor tab
- Try to add a new user under the course team management as a Discussion Moderator or Discussion Administrator
- No error should appear!