### PR TITLE
fix(palm): handle countries not recognized by geoip2 DB

### DIFF
--- a/openedx/core/djangoapps/geoinfo/api.py
+++ b/openedx/core/djangoapps/geoinfo/api.py
@@ -22,7 +22,7 @@ def country_code_from_ip(ip_addr: str) -> str:
     try:
         response = reader.country(ip_addr)
         # pylint: disable=no-member
-        country_code = response.country.iso_code
+        country_code = response.country.iso_code or ""
     except geoip2.errors.AddressNotFoundError:
         country_code = ""
     reader.close()


### PR DESCRIPTION
This backports https://github.com/openedx/edx-platform/pull/34181 to Palm.