### PR TITLE
fix: prevent cross-org ObjectTags from being created

### DIFF
--- a/openedx/core/djangoapps/content_tagging/rest_api/v1/filters.py
+++ b/openedx/core/djangoapps/content_tagging/rest_api/v1/filters.py
@@ -65,7 +65,7 @@ class ObjectTagTaxonomyOrgFilterBackend(BaseFilterBackend):
 
     def filter_queryset(self, request, queryset, _):
         if oel_tagging.is_taxonomy_admin(request.user):
-            return queryset
+            return queryset.prefetch_related('taxonomy__taxonomyorg_set')
 
         user_admin_orgs = get_admin_orgs(request.user)
         user_orgs = get_user_orgs(request.user)
@@ -87,4 +87,4 @@ class ObjectTagTaxonomyOrgFilterBackend(BaseFilterBackend):
                     )
                 )
             )
-        )
+        ).prefetch_related('taxonomy__taxonomyorg_set')

--- a/openedx/core/djangoapps/content_tagging/rules.py
+++ b/openedx/core/djangoapps/content_tagging/rules.py
@@ -275,6 +275,31 @@ def can_view_object_tag_objectid(user: UserType, object_id: str) -> bool:
 
 
 @rules.predicate
+def can_change_object_tag(
+    user: UserType, perm_obj: oel_tagging.ObjectTagPermissionItem | None = None
+) -> bool:
+    """
+    Returns True if the given user may change object tags with the given taxonomy + object_id.
+
+    Adds additional checks to ensure the taxonomy is available for use with the object_id's org.
+    """
+    if oel_tagging.can_change_object_tag(user, perm_obj):
+        if perm_obj and perm_obj.taxonomy and perm_obj.object_id:
+            is_all_org, taxonomy_orgs = TaxonomyOrg.get_organizations(perm_obj.taxonomy)
+            if not is_all_org:
+                # object_id is valid, else it would have thrown in can_change_object_tag_objectid
+                context_key = get_context_key_from_key_string(perm_obj.object_id)
+                assert context_key.org
+
+                # Ensure the object_id's org is among the allowed taxonomy orgs
+                object_org = rules_cache.get_orgs([context_key.org])
+                return bool(object_org) and object_org[0] in taxonomy_orgs
+
+        return True
+    return False
+
+
+@rules.predicate
 def can_change_taxonomy_tag(user: UserType, tag: oel_tagging.Tag | None = None) -> bool:
     """
     Even taxonomy admins cannot add tags to system taxonomies (their tags are system-defined), or free-text taxonomies
@@ -304,7 +329,10 @@ rules.set_perm("oel_tagging.delete_tag", can_change_taxonomy_tag)
 rules.set_perm("oel_tagging.view_tag", rules.always_allow)
 
 # ObjectTag
-rules.set_perm("oel_tagging.can_tag_object", oel_tagging.can_change_object_tag)
+rules.set_perm("oel_tagging.add_objecttag", can_change_object_tag)
+rules.set_perm("oel_tagging.change_objecttag", can_change_object_tag)
+rules.set_perm("oel_tagging.delete_objecttag", can_change_object_tag)
+rules.set_perm("oel_tagging.can_tag_object", can_change_object_tag)
 
 # This perms are used in the tagging rest api from openedx_tagging that is exposed in the CMS. They are overridden here
 # to include Organization and objects permissions.

--- a/openedx/core/djangoapps/content_tagging/tests/test_rules.py
+++ b/openedx/core/djangoapps/content_tagging/tests/test_rules.py
@@ -537,7 +537,7 @@ class TestRulesTaxonomy(TestTaxonomyMixin, TestCase):
         """Only superusers can create/edit an ObjectTag with a no-org Taxonomy"""
         object_tag = getattr(self, tag_attr)
         assert self.superuser.has_perm(perm, object_tag)
-        assert self.staff.has_perm(perm, object_tag)
+        assert not self.staff.has_perm(perm, object_tag)
         assert not self.user_both_orgs.has_perm(perm, object_tag)
         assert not self.user_org2.has_perm(perm, object_tag)
         assert not self.learner.has_perm(perm, object_tag)


### PR DESCRIPTION
Addresses this comment https://github.com/openedx/edx-platform/pull/34146#discussion_r1475359581 about disallowing cross-org tagging and tagging using "no org" taxonomies.

**Testing instructions**

These changes should be validated by the unit tests.