### PR TITLE
feat: duplicate tags when duplicating a tagged XBlock.

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
+++ b/cms/djangoapps/contentstore/views/tests/test_clipboard_paste.py
@@ -203,10 +203,8 @@ class ClipboardPasteTestCase(ModuleStoreTestCase):
         # Only tags from the taxonomy that is associated with the dest org should be copied
         tags = list(tagging_api.get_object_tags(str(dest_unit_key)))
         assert len(tags) == 2
-        assert str(tags[0]) == '<ObjectTag> ' \
-            'block-v1:org.2025+course_2025+Destination_Course+type@vertical+block@vertical1: test_taxonomy=tag_1'
-        assert str(tags[1]) == '<ObjectTag> ' \
-            'block-v1:org.2025+course_2025+Destination_Course+type@vertical+block@vertical1: test_taxonomy=tag_2'
+        assert str(tags[0]) == f'<ObjectTag> {dest_unit_key}: test_taxonomy=tag_1'
+        assert str(tags[1]) == f'<ObjectTag> {dest_unit_key}: test_taxonomy=tag_2'
 
     def test_paste_with_assets(self):
         """

--- a/cms/lib/xblock/tagging/tagged_block_mixin.py
+++ b/cms/lib/xblock/tagging/tagged_block_mixin.py
@@ -1,4 +1,6 @@
-# lint-amnesty, pylint: disable=missing-module-docstring
+"""
+Content tagging functionality for XBlocks.
+"""
 from urllib.parse import quote, unquote
 
 
@@ -6,6 +8,17 @@ class TaggedBlockMixin:
     """
     Mixin containing XML serializing and parsing functionality for tagged blocks
     """
+    def studio_post_duplicate(self, store, source_item):
+        """
+        Duplicates content tags from the source_item.
+        """
+        if hasattr(super(), 'studio_post_duplicate'):
+            super().studio_post_duplicate()
+
+        if hasattr(source_item, 'serialize_tag_data'):
+            tags = source_item.serialize_tag_data()
+            self.xml_attributes['tags-v1'] = tags
+        self.add_tags_from_xml()
 
     def serialize_tag_data(self):
         """

--- a/openedx/core/djangoapps/content_tagging/api.py
+++ b/openedx/core/djangoapps/content_tagging/api.py
@@ -203,3 +203,4 @@ delete_object_tags = oel_tagging.delete_object_tags
 resync_object_tags = oel_tagging.resync_object_tags
 get_object_tags = oel_tagging.get_object_tags
 tag_object = oel_tagging.tag_object
+add_tag_to_taxonomy = oel_tagging.add_tag_to_taxonomy


### PR DESCRIPTION
### Description

Updates the TaggedBlockMixin to add a `studio_post_duplicate` handler which copies the tags on the `source_item` to the duplicated block.

### More information

Closes https://github.com/openedx/modular-learning/issues/181

Depends on
* https://github.com/openedx/edx-platform/pull/34270
* https://github.com/openedx/openedx-learning/pull/164

Private ref: [FAL-3623](https://tasks.opencraft.com/browse/FAL-3623)

### Testing instructions

1. Run this branch on your devstack, and ensure you've installed the branch from https://github.com/openedx/openedx-learning/pull/164 on LMS + CMS.
1. Enable and run the frontend-app-course-authoring MFE
1. Set up Taxonomy/Tags data setup locally using https://github.com/open-craft/taxonomy-sample-data/
1. Choose a unit from a course, and add several content tags from a few taxonomies.
1. Add a block to the unit, and add several content tags to that too.
1. Duplicate this tagged unit from the content outline using this button: ![image](https://github.com/open-craft/edx-platform/assets/7556571/8557da7c-5cd1-4df4-bd41-45cf42c12413)
1. Ensure the new duplicate unit has the same tags as the source unit, and the duplicated child block also has the same tags as the source block.

### Author Notes & Concerns

The implementation plan sketched out in https://github.com/openedx/modular-learning/issues/181 has a flaw: When I tried storing the tag data in `duplicate_metadata`, eventually `modulestore.create_item` calls [partition_fields_by_scope](https://github.com/openedx/edx-platform/blob/master/xmodule/modulestore/__init__.py#L1276-L1277), which tries to call `field = getattr(cls, 'tags-v1')`. This errors out because `tags-v1` isn't a real XBlock field.

We could fix this by refactoring TaggedBlockMixin to use a proper [XBlock field](https://github.com/openedx/XBlock/blob/master/xblock/fields.py#L266) for the tag data (and since we can't have a class attribute with a hyphen in it, we'd need to rename the field from `tags-v1` to `tags_v1`).

Instead, I chose to use the XBlock `studio_post_duplicate` handler, as shown. A disadvantage of this approach is there's no good way to _disable_ duplicating content tags when duplicating an XBlock; content tags will always be duplicated too.