### PR TITLE
feat: optional xblocks

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_utils.py
@@ -353,6 +353,7 @@ class InheritedOptionalCompletionTest(CourseTestCase):
         self.vertical = self.store.get_item(vertical.location)
         self.html = self.store.get_item(html.location)
         self.problem = self.store.get_item(problem.location)
+        self.orphan = BlockFactory.create(category='vertical', parent_location=self.sequential.location)
 
     def set_optional_completion(self, xblock, value):
         """ Sets optional_completion to specified value and calls update_item to persist the change. """
@@ -370,13 +371,6 @@ class InheritedOptionalCompletionTest(CourseTestCase):
         self.assertFalse(utils.ancestor_has_optional_completion(self.vertical))
         self.update_optional_completions(False, False, True)
         self.assertFalse(utils.ancestor_has_optional_completion(self.vertical))
-
-    def test_inheritance_in_optional_section(self):
-        """Tests that a vertical in an optional section has an inherited optional completion"""
-        self.update_optional_completions(True, False, False)
-        self.assertTrue(utils.ancestor_has_optional_completion(self.vertical))
-        self.update_optional_completions(True, False, True)
-        self.assertTrue(utils.ancestor_has_optional_completion(self.vertical))
 
     def test_inheritance_in_optional_subsection(self):
         """Tests that a vertical in an optional subsection has an inherited optional completion"""

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -342,7 +342,7 @@ def find_staff_lock_source(xblock):
 
 def ancestor_has_staff_lock(xblock, parent_xblock=None):
     """
-    Returns True iff one of xblock's ancestors has staff lock.
+    Returns True if one of xblock's ancestors has staff lock.
     Can avoid mongo query by passing in parent_xblock.
     """
     if parent_xblock is None:
@@ -356,7 +356,7 @@ def ancestor_has_staff_lock(xblock, parent_xblock=None):
 
 def ancestor_has_optional_completion(xblock, parent_xblock=None):
     """
-    Returns True iff one of xblock's ancestors has optional completion.
+    Returns True if one of xblock's ancestors has optional completion.
     Can avoid mongo query by passing in parent_xblock.
     """
     if parent_xblock is None:

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -354,6 +354,20 @@ def ancestor_has_staff_lock(xblock, parent_xblock=None):
     return parent_xblock.visible_to_staff_only
 
 
+def ancestor_has_optional_completion(xblock, parent_xblock=None):
+    """
+    Returns True iff one of xblock's ancestors has optional completion.
+    Can avoid mongo query by passing in parent_xblock.
+    """
+    if parent_xblock is None:
+        parent_location = modulestore().get_parent_location(xblock.location,
+                                                            revision=ModuleStoreEnum.RevisionOption.draft_preferred)
+        if not parent_location:
+            return False
+        parent_xblock = modulestore().get_item(parent_location)
+    return parent_xblock.optional_completion
+
+
 def reverse_url(handler_name, key_name=None, key_value=None, kwargs=None):
     """
     Creates the URL for the given handler.

--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -60,6 +60,7 @@ from xmodule.tabs import CourseTabList  # lint-amnesty, pylint: disable=wrong-im
 from xmodule.x_module import AUTHOR_VIEW, PREVIEW_VIEWS, STUDENT_VIEW, STUDIO_VIEW  # lint-amnesty, pylint: disable=wrong-import-order
 
 from ..utils import (
+    ancestor_has_optional_completion,
     ancestor_has_staff_lock,
     find_release_date_source,
     find_staff_lock_source,
@@ -1321,7 +1322,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             'group_access': xblock.group_access,
             'user_partitions': user_partitions,
             'show_correctness': xblock.show_correctness,
-            'optional_content': xblock.optional_content,
+            'optional_completion': xblock.optional_completion,
         })
 
         if xblock.category == 'sequential':
@@ -1406,6 +1407,11 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             xblock_info['ancestor_has_staff_lock'] = False
 
         if course_outline:
+            if xblock_info['optional_completion']:
+                xblock_info['ancestor_has_optional_completion'] = ancestor_has_optional_completion(xblock, parent_xblock)
+            else:
+                xblock_info['ancestor_has_optional_completion'] = False
+
             if xblock_info['has_explicit_staff_lock']:
                 xblock_info['staff_only_message'] = True
             elif child_info and child_info['children']:

--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -1321,6 +1321,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             'group_access': xblock.group_access,
             'user_partitions': user_partitions,
             'show_correctness': xblock.show_correctness,
+            'optional_content': xblock.optional_content,
         })
 
         if xblock.category == 'sequential':

--- a/cms/djangoapps/contentstore/views/block.py
+++ b/cms/djangoapps/contentstore/views/block.py
@@ -1407,10 +1407,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             xblock_info['ancestor_has_staff_lock'] = False
 
         if course_outline:
-            if xblock_info['optional_completion']:
-                xblock_info['ancestor_has_optional_completion'] = ancestor_has_optional_completion(xblock, parent_xblock)
-            else:
-                xblock_info['ancestor_has_optional_completion'] = False
+            xblock_info['ancestor_has_optional_completion'] = ancestor_has_optional_completion(xblock, parent_xblock)
 
             if xblock_info['has_explicit_staff_lock']:
                 xblock_info['staff_only_message'] = True

--- a/cms/djangoapps/contentstore/views/tests/test_block.py
+++ b/cms/djangoapps/contentstore/views/tests/test_block.py
@@ -2630,7 +2630,7 @@ class TestXBlockInfo(ItemTest):
 
     @ddt.data(
         (ModuleStoreEnum.Type.split, 3, 3),
-        (ModuleStoreEnum.Type.mongo, 8, 12),
+        (ModuleStoreEnum.Type.mongo, 10, 14),
     )
     @ddt.unpack
     def test_xblock_outline_handler_mongo_calls(self, store_type, chapter_queries, chapter_queries_1):

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -78,7 +78,7 @@ class CourseMetadata:
         'highlights_enabled_for_messaging',
         'is_onboarding_exam',
         'discussions_settings',
-        'optional',
+        'optional_completion',
     ]
 
     @classmethod

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -78,6 +78,7 @@ class CourseMetadata:
         'highlights_enabled_for_messaging',
         'is_onboarding_exam',
         'discussions_settings',
+        'optional',
     ]
 
     @classmethod

--- a/cms/static/js/models/xblock_info.js
+++ b/cms/static/js/models/xblock_info.js
@@ -120,6 +120,10 @@ define(
              */
                 ancestor_has_staff_lock: null,
                 /**
+             * True if this any of this xblock's ancestors are optional for completion.
+             */
+                ancestor_has_optional_completion: null,
+                /**
              * The xblock which is determining the staff lock value. For instance, for a unit,
              * this will either be the parent subsection or the grandparent section.
              * This can be null if the xblock has no inherited staff lock. Will only be present if

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -1065,6 +1065,24 @@ describe('CourseOutlinePage', function() {
               outlinePage.$('.section-header-actions .configure-button').click();
               expect($('#optional_completion').is(':disabled')).toBe(true);
             });
+
+            it('sets optional completion to null instead of false', function() {
+                var mockCourseJSON = createMockCourseJSON({}, [
+                  createMockSectionJSON({optional_completion: true})
+                ]);
+                createCourseOutlinePage(this, mockCourseJSON, false);
+                outlinePage.$('.section-header-actions .configure-button').click();
+                expect($('#optional_completion').is(':checked')).toBe(true);
+                $('#optional_completion').click()
+                expect($('#optional_completion').is(':checked')).toBe(false);
+                $('.wrapper-modal-window .action-save').click();
+                AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/mock-section', {
+                    publish: 'republish',
+                    metadata: {
+                        optional_completion: null
+                    }
+                });
+            });
         });
     });
 
@@ -2386,7 +2404,7 @@ describe('CourseOutlinePage', function() {
             });
 
             it('shows optional completion checkbox checked', function() {
-              var mockCourseJSON = createMockCourseJSON({}, [
+                var mockCourseJSON = createMockCourseJSON({}, [
                     createMockSectionJSON({}, [
                         createMockSubsectionJSON({optional_completion: true}, [])
                     ])
@@ -2398,14 +2416,42 @@ describe('CourseOutlinePage', function() {
             });
 
             it('disables optional completion checkbox when the parent uses optional completion', function() {
-              var mockCourseJSON = createMockCourseJSON({}, [
-                  createMockSectionJSON({}, [
-                      createMockSubsectionJSON({ancestor_has_optional_completion: true}, [])
-                  ])
-              ]);
-              createCourseOutlinePage(this, mockCourseJSON, false);
-              outlinePage.$('.outline-subsection .configure-button').click();
-              expect($('#optional_completion').is(':disabled')).toBe(true);
+                var mockCourseJSON = createMockCourseJSON({}, [
+                    createMockSectionJSON({}, [
+                        createMockSubsectionJSON({ancestor_has_optional_completion: true}, [])
+                    ])
+                ]);
+                createCourseOutlinePage(this, mockCourseJSON, false);
+                outlinePage.$('.outline-subsection .configure-button').click();
+                expect($('#optional_completion').is(':disabled')).toBe(true);
+            });
+
+            it('sets optional completion to null instead of false', function() {
+                var mockCourseJSON = createMockCourseJSON({}, [
+                    createMockSectionJSON({}, [
+                        createMockSubsectionJSON({optional_completion: true}, [])
+                    ])
+                ]);
+                createCourseOutlinePage(this, mockCourseJSON, false);
+                outlinePage.$('.outline-subsection .configure-button').click();
+                expect($('#optional_completion').is(':checked')).toBe(true);
+                $('#optional_completion').click()
+                expect($('#optional_completion').is(':checked')).toBe(false);
+                $('.wrapper-modal-window .action-save').click();
+                AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/mock-subsection', {
+                    publish: 'republish',
+                    graderType: 'notgraded',
+                    isPrereq: false,
+                    metadata: {
+                        optional_completion: null,
+                        due: null,
+                        is_practice_exam: false,
+                        is_time_limited: false,
+                        is_proctored_enabled: false,
+                        default_time_limit_minutes: null,
+                        is_onboarding_exam: false,
+                    }
+                });
             });
         });
     });
@@ -2551,9 +2597,25 @@ describe('CourseOutlinePage', function() {
             });
 
             it('disables optional completion checkbox when the parent uses optional completion', function() {
-              getUnitStatus({ancestor_has_optional_completion: true}, {});
-              outlinePage.$('.outline-unit .configure-button').click();
-              expect($('#optional_completion').is(':disabled')).toBe(true);
+                getUnitStatus({ancestor_has_optional_completion: true}, {});
+                outlinePage.$('.outline-unit .configure-button').click();
+                expect($('#optional_completion').is(':disabled')).toBe(true);
+            });
+
+            it('sets optional completion to null instead of false', function() {
+                getUnitStatus({optional_completion: true}, {});
+                outlinePage.$('.outline-unit .configure-button').click();
+                expect($('#optional_completion').is(':checked')).toBe(true);
+                $('#optional_completion').click()
+                expect($('#optional_completion').is(':checked')).toBe(false);
+                $('.wrapper-modal-window .action-save').click();
+                AjaxHelpers.expectJsonRequest(requests, 'POST', '/xblock/mock-unit', {
+                    publish: 'republish',
+                    metadata: {
+                        visible_to_staff_only: null,
+                        optional_completion: null
+                    }
+                });
             });
         });
     });

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -42,8 +42,7 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights_enabled: true,
             highlights_enabled_for_messaging: false,
-            show_delete_button: true,
-            completion_tracking_enabled: true,
+            show_delete_button: true
         }, options, {child_info: {children: children}});
     };
 
@@ -71,7 +70,6 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights_enabled: true,
             highlights_enabled_for_messaging: false,
-            completion_tracking_enabled: true,
             show_delete_button: true
         }, options, {child_info: {children: children}});
     };
@@ -98,7 +96,6 @@ describe('CourseOutlinePage', function() {
             user_partition_info: {},
             highlights: [],
             highlights_enabled: true,
-            completion_tracking_enabled: true,
             show_delete_button: true
         }, options, {child_info: {children: children}});
     };
@@ -130,7 +127,6 @@ describe('CourseOutlinePage', function() {
             user_partitions: [],
             group_access: {},
             user_partition_info: {},
-            completion_tracking_enabled: true,
             show_delete_button: true
         }, options, {child_info: {children: children}});
     };
@@ -150,7 +146,6 @@ describe('CourseOutlinePage', function() {
             user_partitions: [],
             group_access: {},
             user_partition_info: {},
-            completion_tracking_enabled: true,
             show_delete_button: true
         }, options);
     };
@@ -225,7 +220,6 @@ describe('CourseOutlinePage', function() {
     createCourseOutlinePage = function(test, courseJSON, createOnly) {
         requests = AjaxHelpers.requests(test);
         model = new XBlockOutlineInfo(courseJSON, {parse: true});
-        console.warn("course:", model)
         outlinePage = new CourseOutlinePage({
             model: model,
             el: $('#content')
@@ -322,7 +316,7 @@ describe('CourseOutlinePage', function() {
             'course-highlights-enable', 'optional-completion-editor'
         ]);
         appendSetFixtures(mockOutlinePage);
-        mockCourseJSON = createMockCourseJSON({completion_tracking_enabled: true}, [
+        mockCourseJSON = createMockCourseJSON({}, [
             createMockSectionJSON({}, [
                 createMockSubsectionJSON({}, [
                     createMockVerticalJSON()
@@ -950,7 +944,6 @@ describe('CourseOutlinePage', function() {
             createCourseOutlinePage(this, mockCourseJSON, false);
             outlinePage.$('.section-header-actions .configure-button').click();
             $('#start_date').val('1/2/2015');
-
             // Section release date can't be cleared.
             expect($('.wrapper-modal-window .action-clear')).not.toExist();
 
@@ -2556,7 +2549,7 @@ describe('CourseOutlinePage', function() {
             it('hides discussion settings if unit level discussions are disabled', function() {
                 getUnitStatus({}, {unit_level_discussions: false});
                 outlinePage.$('.outline-unit .configure-button').click();
-                expect($('.modal-section .edit-discussion').length).toBe(0);
+                expect($('.modal-section .edit-discussion')).not.toExist();
             });
 
         });

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -1228,7 +1228,9 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 return {
                     publish: 'republish',
                     metadata: {
-                        optional_completion: this.currentValue()
+                        // This variable relies on the inheritance mechanism, so we want to unset it instead of
+                        // explicitly setting it to `false`.
+                        optional_completion: this.currentValue() || null
                     }
                 };
             } else {

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -18,7 +18,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         ReleaseDateEditor, DueDateEditor, SelfPacedDueDateEditor, GradingEditor, PublishEditor, AbstractVisibilityEditor,
         StaffLockEditor, UnitAccessEditor, ContentVisibilityEditor, TimedExaminationPreferenceEditor,
         AccessEditor, ShowCorrectnessEditor, HighlightsEditor, HighlightsEnableXBlockModal, HighlightsEnableEditor,
-        DiscussionEditor;
+        DiscussionEditor, OptionalContentEditor;
 
     CourseOutlineXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
@@ -1201,6 +1201,46 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         }
     });
 
+    OptionalContentEditor = AbstractEditor.extend(
+    {
+        templateName: 'optional-content-editor',
+        className: 'edit-optional-content',
+
+        afterRender: function() {
+            AbstractEditor.prototype.afterRender.call(this);
+            this.setValue(this.model.get("optional_content"));
+        },
+
+        setValue: function(value) {
+            this.$('input[name=optional_content]').prop('checked', value);
+        },
+                
+        currentValue: function() {
+            return this.$('input[name=optional_content]').is(':checked');
+        },
+
+        hasChanges: function() {
+            return this.model.get('optional_content') !== this.currentValue();
+        },
+
+        getRequestData: function() {
+            if (this.hasChanges()) {
+                return {
+                    publish: 'republish',
+                    metadata: {
+                        optional_content: this.currentValue()
+                    }
+                };
+            } else {
+                return {};
+            }
+        },
+        getContext: function() {
+            return {
+                optional_content: this.model.get('optional_content')
+            };
+        },
+    })
     return {
         getModal: function(type, xblockInfo, options) {
             if (type === 'edit') {
@@ -1240,10 +1280,10 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                     }
                 ];
                 if (xblockInfo.isChapter()) {
-                    tabs[0].editors = [ReleaseDateEditor];
+                    tabs[0].editors = [ReleaseDateEditor, OptionalContentEditor];
                     tabs[1].editors = [StaffLockEditor];
                 } else if (xblockInfo.isSequential()) {
-                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor];
+                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor, OptionalContentEditor];
                     tabs[1].editors = [ContentVisibilityEditor, ShowCorrectnessEditor];
                     if (course.get('self_paced') && course.get('is_custom_relative_dates_active')) {
                         tabs[0].editors.push(SelfPacedDueDateEditor);

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -1214,7 +1214,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         setValue: function(value) {
             this.$('input[name=optional_completion]').prop('checked', value);
         },
-                
+
         currentValue: function() {
             return this.$('input[name=optional_completion]').is(':checked');
         },
@@ -1306,7 +1306,11 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
             }
 
             if (course.get('completion_tracking_enabled')) {
-                tabs[0].editors.push(OptionalCompletionEditor)
+                if (tabs.length > 0) {
+                  tabs[0].editors.push(OptionalCompletionEditor);
+                } else {
+                  editors.push(OptionalCompletionEditor);
+                }
             }
 
             /* globals course */

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -1239,7 +1239,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         getContext: function() {
             return {
                 optional_completion: this.model.get('optional_completion'),
-                optionalAncestor: this.model.get('ancestor_has_optional_completion')
+                optional_ancestor: this.model.get('ancestor_has_optional_completion')
             };
         },
     })
@@ -1267,7 +1267,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 editors: []
             };
             if (xblockInfo.isVertical()) {
-                editors = [StaffLockEditor, UnitAccessEditor, DiscussionEditor, OptionalCompletionEditor];
+                editors = [StaffLockEditor, UnitAccessEditor, DiscussionEditor];
             } else {
                 tabs = [
                     {
@@ -1282,10 +1282,10 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                     }
                 ];
                 if (xblockInfo.isChapter()) {
-                    tabs[0].editors = [ReleaseDateEditor, OptionalCompletionEditor];
+                    tabs[0].editors = [ReleaseDateEditor];
                     tabs[1].editors = [StaffLockEditor];
                 } else if (xblockInfo.isSequential()) {
-                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor, OptionalCompletionEditor];
+                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor];
                     tabs[1].editors = [ContentVisibilityEditor, ShowCorrectnessEditor];
                     if (course.get('self_paced') && course.get('is_custom_relative_dates_active')) {
                         tabs[0].editors.push(SelfPacedDueDateEditor);
@@ -1303,6 +1303,10 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                         tabs.push(advancedTab);
                     }
                 }
+            }
+
+            if (course.get('completion_tracking_enabled')) {
+                tabs[0].editors.push(OptionalCompletionEditor)
             }
 
             /* globals course */

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -18,7 +18,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         ReleaseDateEditor, DueDateEditor, SelfPacedDueDateEditor, GradingEditor, PublishEditor, AbstractVisibilityEditor,
         StaffLockEditor, UnitAccessEditor, ContentVisibilityEditor, TimedExaminationPreferenceEditor,
         AccessEditor, ShowCorrectnessEditor, HighlightsEditor, HighlightsEnableXBlockModal, HighlightsEnableEditor,
-        DiscussionEditor, OptionalContentEditor;
+        DiscussionEditor, OptionalCompletionEditor;
 
     CourseOutlineXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
@@ -1201,26 +1201,26 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         }
     });
 
-    OptionalContentEditor = AbstractEditor.extend(
+    OptionalCompletionEditor = AbstractEditor.extend(
     {
-        templateName: 'optional-content-editor',
-        className: 'edit-optional-content',
+        templateName: 'optional-completion-editor',
+        className: 'edit-optional-completion',
 
         afterRender: function() {
             AbstractEditor.prototype.afterRender.call(this);
-            this.setValue(this.model.get("optional_content"));
+            this.setValue(this.model.get("optional_completion"));
         },
 
         setValue: function(value) {
-            this.$('input[name=optional_content]').prop('checked', value);
+            this.$('input[name=optional_completion]').prop('checked', value);
         },
                 
         currentValue: function() {
-            return this.$('input[name=optional_content]').is(':checked');
+            return this.$('input[name=optional_completion]').is(':checked');
         },
 
         hasChanges: function() {
-            return this.model.get('optional_content') !== this.currentValue();
+            return this.model.get('optional_completion') !== this.currentValue();
         },
 
         getRequestData: function() {
@@ -1228,16 +1228,18 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 return {
                     publish: 'republish',
                     metadata: {
-                        optional_content: this.currentValue()
+                        optional_completion: this.currentValue()
                     }
                 };
             } else {
                 return {};
             }
         },
+
         getContext: function() {
             return {
-                optional_content: this.model.get('optional_content')
+                optional_completion: this.model.get('optional_completion'),
+                optionalAncestor: this.model.get('ancestor_has_optional_completion')
             };
         },
     })
@@ -1265,7 +1267,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 editors: []
             };
             if (xblockInfo.isVertical()) {
-                editors = [StaffLockEditor, UnitAccessEditor, DiscussionEditor];
+                editors = [StaffLockEditor, UnitAccessEditor, DiscussionEditor, OptionalCompletionEditor];
             } else {
                 tabs = [
                     {
@@ -1280,10 +1282,10 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                     }
                 ];
                 if (xblockInfo.isChapter()) {
-                    tabs[0].editors = [ReleaseDateEditor, OptionalContentEditor];
+                    tabs[0].editors = [ReleaseDateEditor, OptionalCompletionEditor];
                     tabs[1].editors = [StaffLockEditor];
                 } else if (xblockInfo.isSequential()) {
-                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor, OptionalContentEditor];
+                    tabs[0].editors = [ReleaseDateEditor, GradingEditor, DueDateEditor, OptionalCompletionEditor];
                     tabs[1].editors = [ContentVisibilityEditor, ShowCorrectnessEditor];
                     if (course.get('self_paced') && course.get('is_custom_relative_dates_active')) {
                         tabs[0].editors.push(SelfPacedDueDateEditor);

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -747,6 +747,7 @@
 
     .edit-discussion,
     .edit-staff-lock,
+    .edit-optional-content,
     .edit-content-visibility,
     .edit-unit-access {
       margin-bottom: $baseline;
@@ -760,19 +761,20 @@
     // UI: staff lock and discussion
     .edit-discussion,
     .edit-staff-lock,
+    .edit-optional-content,
     .edit-settings-timed-examination,
     .edit-unit-access {
       .checkbox-cosmetic .input-checkbox {
         @extend %cont-text-sr;
 
         // CASE: unchecked
-        ~ .tip-warning {
+        ~.tip-warning {
           display: block;
         }
 
         // CASE: checked
         &:checked {
-          ~ .tip-warning {
+          ~.tip-warning {
             display: none;
           }
         }
@@ -832,6 +834,7 @@
 
   .edit-discussion,
   .edit-unit-access,
+  .edit-optional-content,
   .edit-staff-lock {
     .modal-section-content {
       @include font-size(16);
@@ -874,6 +877,7 @@
 
   .edit-discussion,
   .edit-unit-access,
+  .edit-optional-content,
   .edit-staff-lock {
     .modal-section-content {
       @include font-size(16);

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -747,7 +747,7 @@
 
     .edit-discussion,
     .edit-staff-lock,
-    .edit-optional-content,
+    .edit-optional-completion,
     .edit-content-visibility,
     .edit-unit-access {
       margin-bottom: $baseline;
@@ -761,20 +761,20 @@
     // UI: staff lock and discussion
     .edit-discussion,
     .edit-staff-lock,
-    .edit-optional-content,
+    .edit-optional-completion,
     .edit-settings-timed-examination,
     .edit-unit-access {
       .checkbox-cosmetic .input-checkbox {
         @extend %cont-text-sr;
 
         // CASE: unchecked
-        ~.tip-warning {
+        ~ .tip-warning {
           display: block;
         }
 
         // CASE: checked
         &:checked {
-          ~.tip-warning {
+          ~ .tip-warning {
             display: none;
           }
         }
@@ -832,9 +832,17 @@
     }
   }
 
+  .edit-optional-completion {
+    .field-message {
+      @extend %t-copy-sub1;
+      color: $gray-d1;
+      margin-bottom: ($baseline/4);
+    }
+  }
+
   .edit-discussion,
   .edit-unit-access,
-  .edit-optional-content,
+  .edit-optional-completion,
   .edit-staff-lock {
     .modal-section-content {
       @include font-size(16);
@@ -877,7 +885,7 @@
 
   .edit-discussion,
   .edit-unit-access,
-  .edit-optional-content,
+  .edit-optional-completion,
   .edit-staff-lock {
     .modal-section-content {
       @include font-size(16);

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -8,6 +8,7 @@
 ## Standard imports
 <%namespace name='static' file='static_content.html'/>
 <%!
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from django.utils.translation import gettext as _
 
 from cms.djangoapps.contentstore.config.waffle import CUSTOM_RELATIVE_DATES
@@ -158,6 +159,7 @@ from openedx.core.release import RELEASE_LINE
           revision: "${context_course.location.branch | n, js_escaped_string}",
           self_paced: ${ context_course.self_paced | n, dump_js_escaped_json },
           is_custom_relative_dates_active: ${CUSTOM_RELATIVE_DATES.is_enabled(context_course.id) | n, dump_js_escaped_json},
+          completion_tracking_enabled: ${ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled() | n, dump_js_escaped_json},
           start: ${context_course.start | n, dump_js_escaped_json},
           discussions_settings: ${context_course.discussions_settings | n, dump_js_escaped_json}
         });

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -29,7 +29,7 @@ from django.urls import reverse
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable', 'optional-content-editor']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable', 'optional-completion-editor']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -29,7 +29,7 @@ from django.urls import reverse
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'self-paced-due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'discussion-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable', 'optional-content-editor']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -225,6 +225,9 @@ if (is_proctored_exam) {
                             <% if (xblockInfo.get('release_date')) { %>
                                 <%- xblockInfo.get('release_date') %>
                             <% } %>
+                            <% if (xblockInfo.get('optional_content')) { %>
+                                - <%- gettext('Optional') %>
+                            <% } %>
                         <% } %>
                     </span>
                 </p>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -225,7 +225,7 @@ if (is_proctored_exam) {
                             <% if (xblockInfo.get('release_date')) { %>
                                 <%- xblockInfo.get('release_date') %>
                             <% } %>
-                            <% if (xblockInfo.get('optional_content')) { %>
+                            <% if (xblockInfo.get('optional_completion')) { %>
                                 - <%- gettext('Optional') %>
                             <% } %>
                         <% } %>

--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -22,6 +22,8 @@ var addStatusMessage = function (statusType, message) {
         statusIconClass = 'fa-lock';
     } else if (statusType === 'partition-groups') {
         statusIconClass = 'fa-eye';
+    } else if (statusType === 'optional-completion') {
+        statusIconClass = 'fa-lightbulb-o';
     }
 
     statusMessages.push({iconClass: statusIconClass, text: message});
@@ -80,6 +82,11 @@ if (staffOnlyMessage) {
 var gradingType = gettext('Ungraded');
 if (xblockInfo.get('graded')) {
     gradingType = xblockInfo.get('format')
+}
+if (xblockInfo.get('optional_completion') && !xblockInfo.get('ancestor_has_optional_completion')) {
+    messageType = 'optional-completion';
+    messageText = gettext('Optional completion');
+    addStatusMessage(messageType, messageText);
 }
 
 var is_proctored_exam = xblockInfo.get('is_proctored_exam');
@@ -224,9 +231,6 @@ if (is_proctored_exam) {
                             <% } %>
                             <% if (xblockInfo.get('release_date')) { %>
                                 <%- xblockInfo.get('release_date') %>
-                            <% } %>
-                            <% if (xblockInfo.get('optional_completion')) { %>
-                                - <%- gettext('Optional') %>
                             <% } %>
                         <% } %>
                     </span>

--- a/cms/templates/js/optional-completion-editor.underscore
+++ b/cms/templates/js/optional-completion-editor.underscore
@@ -1,0 +1,26 @@
+<form>
+<h3 class="modal-section-title">
+    <%- gettext('Completion') %>
+</h3>
+<div class="modal-section-content optional-completion">
+    <label class="label">
+	    <% if (optionalAncestor) { %>
+		    <input disabled type="checkbox" id="optional_completion" name="optional_completion"
+		          class="input input-checkbox" />
+			<%- gettext('Optional') %>
+	        <p class="tip tip-warning">
+	            <% var message = gettext('This %(xblockType)s already has an optional parent.') %>
+	            <%- interpolate(message, { xblockType: xblockType }, true) %>
+	        </p>
+	    <% } else { %>
+		    <input type="checkbox" id="optional_completion" name="optional_completion"
+		          class="input input-checkbox" />
+			<%- gettext('Optional') %>
+          <% } %>
+        <p class="field-message">
+            <% var message = gettext('Optional %(xblockType)ss won\'t count towards course or parent completion. Only has an effect if completion module is enabled.') %>
+            <%- interpolate(message, { xblockType: xblockType }, true) %>
+        </p>
+	</label>
+</div>
+</form>

--- a/cms/templates/js/optional-completion-editor.underscore
+++ b/cms/templates/js/optional-completion-editor.underscore
@@ -4,7 +4,7 @@
 </h3>
 <div class="modal-section-content optional-completion">
     <label class="label">
-	    <% if (optionalAncestor) { %>
+	    <% if (optional_ancestor) { %>
 		    <input disabled type="checkbox" id="optional_completion" name="optional_completion"
 		          class="input input-checkbox" />
 			<%- gettext('Optional') %>
@@ -18,7 +18,7 @@
 			<%- gettext('Optional') %>
           <% } %>
         <p class="field-message">
-            <% var message = gettext('Optional %(xblockType)ss won\'t count towards course or parent completion. Only has an effect if completion module is enabled.') %>
+            <% var message = gettext('Optional %(xblockType)ss won\'t count towards course or parent completion.') %>
             <%- interpolate(message, { xblockType: xblockType }, true) %>
         </p>
 	</label>

--- a/cms/templates/js/optional-content-editor.underscore
+++ b/cms/templates/js/optional-content-editor.underscore
@@ -1,5 +1,0 @@
-<h3 class="modal-section-title">
-    <input type="checkbox" id="optional_content" name="optional_content"
-          class="input input-checkbox" />
-    <%- gettext('Mark as optional') %>
-</h3>

--- a/cms/templates/js/optional-content-editor.underscore
+++ b/cms/templates/js/optional-content-editor.underscore
@@ -1,0 +1,5 @@
+<h3 class="modal-section-title">
+    <input type="checkbox" id="optional_content" name="optional_content"
+          class="input input-checkbox" />
+    <%- gettext('Mark as optional') %>
+</h3>

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -56,7 +56,7 @@ SUPPORTED_FIELDS = [
     SupportedFieldType('has_score'),
     SupportedFieldType('has_scheduled_content'),
     SupportedFieldType('weight'),
-    SupportedFieldType('optional_content'),
+    SupportedFieldType('optional_completion'),
     SupportedFieldType('show_correctness'),
     # 'student_view_data'
     SupportedFieldType(StudentViewTransformer.STUDENT_VIEW_DATA, StudentViewTransformer),

--- a/lms/djangoapps/course_api/blocks/serializers.py
+++ b/lms/djangoapps/course_api/blocks/serializers.py
@@ -56,6 +56,7 @@ SUPPORTED_FIELDS = [
     SupportedFieldType('has_score'),
     SupportedFieldType('has_scheduled_content'),
     SupportedFieldType('weight'),
+    SupportedFieldType('optional_content'),
     SupportedFieldType('show_correctness'),
     # 'student_view_data'
     SupportedFieldType(StudentViewTransformer.STUDENT_VIEW_DATA, StudentViewTransformer),

--- a/lms/djangoapps/course_api/blocks/transformers/block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/block_completion.py
@@ -14,7 +14,7 @@ class BlockCompletionTransformer(BlockStructureTransformer):
     Keep track of the completion of each block within the block structure.
     """
     READ_VERSION = 1
-    WRITE_VERSION = 1
+    WRITE_VERSION = 2
     COMPLETION = 'completion'
     COMPLETE = 'complete'
     RESUME_BLOCK = 'resume_block'
@@ -43,7 +43,7 @@ class BlockCompletionTransformer(BlockStructureTransformer):
 
     @classmethod
     def collect(cls, block_structure):
-        block_structure.request_xblock_fields('completion_mode', 'optional_content')
+        block_structure.request_xblock_fields('completion_mode', 'optional_completion')
 
     @staticmethod
     def _is_block_excluded(block_structure, block_key):

--- a/lms/djangoapps/course_api/blocks/transformers/block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/block_completion.py
@@ -14,7 +14,7 @@ class BlockCompletionTransformer(BlockStructureTransformer):
     Keep track of the completion of each block within the block structure.
     """
     READ_VERSION = 1
-    WRITE_VERSION = 2
+    WRITE_VERSION = 1
     COMPLETION = 'completion'
     COMPLETE = 'complete'
     RESUME_BLOCK = 'resume_block'

--- a/lms/djangoapps/course_api/blocks/transformers/block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/block_completion.py
@@ -43,7 +43,7 @@ class BlockCompletionTransformer(BlockStructureTransformer):
 
     @classmethod
     def collect(cls, block_structure):
-        block_structure.request_xblock_fields('completion_mode')
+        block_structure.request_xblock_fields('completion_mode', 'optional_content')
 
     @staticmethod
     def _is_block_excluded(block_structure, block_key):

--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -54,7 +54,7 @@ class CourseBlockSerializer(serializers.Serializer):
                 'resume_block': block.get('resume_block', False),
                 'type': block_type,
                 'has_scheduled_content': block.get('has_scheduled_content'),
-                'optional_content': block.get('optional_content'),
+                'optional_completion': block.get('optional_completion', False),
             },
         }
         for child in children:

--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -54,6 +54,7 @@ class CourseBlockSerializer(serializers.Serializer):
                 'resume_block': block.get('resume_block', False),
                 'type': block_type,
                 'has_scheduled_content': block.get('has_scheduled_content'),
+                'optional_content': block.get('optional_content'),
             },
         }
         for child in children:

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -437,3 +437,18 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.update_course_and_overview()
         CourseEnrollment.enroll(UserFactory(), self.course.id)  # grr, some rando took our spot!
         self.assert_can_enroll(False)
+
+    def test_optional_content(self):
+        CourseEnrollment.enroll(self.user, self.course.id)
+        assert not self.course.optional_content
+        response = self.client.get(self.url)
+        for block in response.data['course_blocks']['blocks'].values():
+            assert not block['optional_content']
+
+    def test_optional_content_true(self):
+        self.course.optional_content = True
+        self.update_course_and_overview()
+        CourseEnrollment.enroll(self.user, self.course.id)
+        response = self.client.get(self.url)
+        for block in response.data['course_blocks']['blocks'].values():
+            assert block['optional_content']

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -438,14 +438,14 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         CourseEnrollment.enroll(UserFactory(), self.course.id)  # grr, some rando took our spot!
         self.assert_can_enroll(False)
 
-    def test_optional_completion(self):
+    def test_optional_completion_off_by_default(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         assert not self.course.optional_completion
         response = self.client.get(self.url)
         for block in response.data['course_blocks']['blocks'].values():
             assert not block['optional_completion']
 
-    def test_optional_completion_true(self):
+    def test_optional_completion_on_is_inherited(self):
         self.course.optional_completion = True
         self.update_course_and_overview()
         CourseEnrollment.enroll(self.user, self.course.id)

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -438,17 +438,17 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         CourseEnrollment.enroll(UserFactory(), self.course.id)  # grr, some rando took our spot!
         self.assert_can_enroll(False)
 
-    def test_optional_content(self):
+    def test_optional_completion(self):
         CourseEnrollment.enroll(self.user, self.course.id)
-        assert not self.course.optional_content
+        assert not self.course.optional_completion
         response = self.client.get(self.url)
         for block in response.data['course_blocks']['blocks'].values():
-            assert not block['optional_content']
+            assert not block['optional_completion']
 
-    def test_optional_content_true(self):
-        self.course.optional_content = True
+    def test_optional_completion_true(self):
+        self.course.optional_completion = True
         self.update_course_and_overview()
         CourseEnrollment.enroll(self.user, self.course.id)
         response = self.client.get(self.url)
         for block in response.data['course_blocks']['blocks'].values():
-            assert block['optional_content']
+            assert block['optional_completion']

--- a/lms/djangoapps/course_home_api/progress/serializers.py
+++ b/lms/djangoapps/course_home_api/progress/serializers.py
@@ -134,6 +134,7 @@ class ProgressTabSerializer(VerifiedModeSerializer):
     access_expiration = serializers.DictField()
     certificate_data = CertificateDataSerializer()
     completion_summary = serializers.DictField()
+    optional_completion_summary = serializers.DictField()
     course_grade = CourseGradeSerializer()
     credit_course_requirements = serializers.DictField()
     end = serializers.DateTimeField()

--- a/lms/djangoapps/course_home_api/progress/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_views.py
@@ -314,3 +314,13 @@ class ProgressTabTestViews(BaseCourseHomeTests):
         assert response.status_code == 200
         assert response.data['course_grade']['percent'] == expected_percent
         assert response.data['course_grade']['is_passing'] == (expected_percent >= 0.5)
+
+    def test_optional_content(self):
+        CourseEnrollment.enroll(self.user, self.course.id)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.data['optional_completion_summary'] == {
+            'complete_count': 0,
+            'incomplete_count': 0,
+            'locked_count': 0,
+        }

--- a/lms/djangoapps/course_home_api/progress/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/progress/tests/test_views.py
@@ -315,7 +315,7 @@ class ProgressTabTestViews(BaseCourseHomeTests):
         assert response.data['course_grade']['percent'] == expected_percent
         assert response.data['course_grade']['is_passing'] == (expected_percent >= 0.5)
 
-    def test_optional_content(self):
+    def test_optional_completion(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         response = self.client.get(self.url)
         assert response.status_code == 200

--- a/lms/djangoapps/course_home_api/progress/views.py
+++ b/lms/djangoapps/course_home_api/progress/views.py
@@ -246,6 +246,7 @@ class ProgressTabView(RetrieveAPIView):
             'access_expiration': access_expiration,
             'certificate_data': get_cert_data(student, course, enrollment_mode, course_grade),
             'completion_summary': get_course_blocks_completion_summary(course_key, student),
+            'optional_completion_summary': get_course_blocks_completion_summary(course_key, student, optional=True),
             'course_grade': course_grade,
             'credit_course_requirements': credit_course_requirements(course_key, student),
             'end': course.end,

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -559,7 +559,13 @@ def get_course_blocks_completion_summary(course_key, user, optional=False):
     the given user. If a unit contains gated content, it is not counted towards the incomplete count.
 
     The object contains fields: complete_count, incomplete_count, locked_count
-    """
+
+    Args:
+        course_key (CourseKey): the course key object.
+        user (User): student user object.
+        optional (bool): if true will only count optional blocks towards summary, else it will exclude optional
+            blocks from summary.
+   """
     if not user.id:
         return []
     store = modulestore()

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -568,7 +568,7 @@ def get_course_blocks_completion_summary(course_key, user, optional=False):
 
     def _is_optional(*keys):
         for key in keys:
-            if block_data.get_xblock_field(key, 'optional_content', False):
+            if block_data.get_xblock_field(key, 'optional_completion', False):
                 return True
         return False
 

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -115,6 +115,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
             'completion',
             'complete',
             'resume_block',
+            'optional_content',
         ],
         allow_start_dates_in_future=allow_start_dates_in_future,
     )

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -115,7 +115,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
             'completion',
             'complete',
             'resume_block',
-            'optional_content',
+            'optional_completion',
         ],
         allow_start_dates_in_future=allow_start_dates_in_future,
     )

--- a/xmodule/modulestore/inheritance.py
+++ b/xmodule/modulestore/inheritance.py
@@ -238,6 +238,17 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings
     )
 
+    optional_content = Boolean(
+        display_name=_('Optional'),
+        help=_(
+            'Set this to true to mark this block as optional.'
+            'Progress in this block won\'t count towards course completion progress'
+            'and will count as optional progress instead.'
+        ),
+        default=False,
+        scope=Scope.settings,
+    )
+
     @property
     def close_date(self):
         """

--- a/xmodule/modulestore/inheritance.py
+++ b/xmodule/modulestore/inheritance.py
@@ -238,7 +238,7 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings
     )
 
-    optional_content = Boolean(
+    optional_completion = Boolean(
         display_name=_('Optional'),
         help=_(
             'Set this to true to mark this block as optional.'


### PR DESCRIPTION
## Description

This PR implements separating optional progress from normal progress, and also displaying optional chapters and sequences in the outline.

- Impacts: Learners and authors

## Supporting information

- Fontend App Learning PR: https://github.com/open-craft/frontend-app-learning/pull/9

## Testing instructions

1. Run the MFE from this branch: https://github.com/openedx/frontend-app-learning/pull/1296
2. Add  "done" to the advanced module list
3. As a non-staff user go to the progress tab and assert only the typical progress donut appears 
4. As a staff user, on the cms open the settings of any sequence or chapter and mark as optional
5. As a non-staff user, complete some units, and also the optional unit
6. Navigate to the progress tab again and assert a new optional donut appears with your progress

# Screenshots

![optional-outline](https://github.com/openedx/edx-platform/assets/19278837/acc01f1c-cb0a-423c-afea-87b0dd559a6e)

![cms-optional](https://github.com/openedx/edx-platform/assets/19278837/07c7fb7a-8c9b-4b8a-8261-43b2ecf6e94d)


![progress](https://github.com/openedx/edx-platform/assets/19278837/d0428b24-26c4-43ae-ba90-8e20eeaa139f)

![course-settings](https://github.com/openedx/edx-platform/assets/19278837/53e8efcf-eec5-442a-9dbc-6e9b9e2be590)

Private-ref: https://tasks.opencraft.com/browse/BB-8586