### PR TITLE
fix: store tags in TaggedBlockMixin.tags_v1 field

### DIFF
--- a/cms/djangoapps/contentstore/helpers.py
+++ b/cms/djangoapps/contentstore/helpers.py
@@ -348,6 +348,7 @@ def _import_xml_node_to_parent(
 
     from cms.lib.xblock.tagging.tagged_block_mixin import TaggedBlockMixin
     if isinstance(new_xblock, TaggedBlockMixin):
+        new_xblock.read_tags_from_node(node)
         new_xblock.add_tags_from_xml()
 
     return new_xblock

--- a/openedx/core/lib/xblock_serializer/block_serializer.py
+++ b/openedx/core/lib/xblock_serializer/block_serializer.py
@@ -89,6 +89,11 @@ class XBlockSerializer:
                     with filesystem.open(file_path, 'rb') as fh:
                         data = fh.read()
                     self.static_files.append(StaticFile(name=unit_file.name, data=data, url=None))
+
+        # Serialize and add tag data if any
+        if isinstance(block, TaggedBlockMixin):
+            block.add_tags_to_node(olx_node)
+
         if block.has_children:
             self._serialize_children(block, olx_node)
         return olx_node


### PR DESCRIPTION
Previously, we relied on the presence of the xml_attributes field, which is added by the XmlMixin. However, XmlMixin is not part of the default [XBLOCK_MIXINS](https://github.com/openedx/edx-platform/blob/ea55eca47e81bd205b423373304c9437ef95915f/cms/envs/common.py#L973-L980) (because not all XBlocks support this), and so custom XBlocks weren't able to copy/paste tags.

This change maintains support for the `tags-v1` OLX attribute by adding a field with that name.

### Testing instructions

1. Install this branch in your devstack.
2. Downgrade the ORA2 requirement to prior to https://github.com/openedx/edx-ora2/pull/2181: `pip install edx-ora2==6.1.0`
3. In Studio, create a course with Text, Open Assessment, and Drag-and-Drop-v2 blocks.
4. Add tags to those blocks.
5. Ensure that you can copy/paste these blocks to a different area of the course, and that tags are copied too.
6. Ensure that you can duplicate these blocks, and that tags are duplicated too.