### PR TITLE
feat: DEFAULT_COURSE_INVITATION_ONLY allow for invitation_only new courses by default

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1338,6 +1338,16 @@ class ContentStoreTest(ContentStoreTestCase):
             self.course_data['run'] = '����������'
             self.assert_create_course_failed(error_message)
 
+    @override_settings(DEFAULT_COURSE_INVITATION_ONLY=True)
+    def test_create_course_invitation_only(self):
+        """
+        Test new course creation with setting: DEFAULT_COURSE_INVITATION_ONLY=True.
+        """
+        test_course_data = self.assert_created_course()
+        course_id = _get_course_id(self.store, test_course_data)
+        course = self.store.get_course(course_id)
+        self.assertEqual(course.invitation_only, True)
+
     def assert_course_permission_denied(self):
         """
         Checks that the course did not get created due to a PermissionError.

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -986,8 +986,9 @@ def create_new_course_in_store(store, user, org, number, run, fields):
 
     # Set default language from settings and enable web certs
     fields.update({
-        'language': getattr(settings, 'DEFAULT_COURSE_LANGUAGE', 'en'),
         'cert_html_view_enabled': True,
+        'invitation_only': getattr(settings, 'DEFAULT_COURSE_INVITATION_ONLY', False),
+        'language': getattr(settings, 'DEFAULT_COURSE_LANGUAGE', 'en'),
     })
 
     with modulestore().default_store(store):

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2755,3 +2755,7 @@ BRAZE_COURSE_ENROLLMENT_CANVAS_ID = ''
 
 DISCUSSIONS_INCONTEXT_FEEDBACK_URL = ''
 DISCUSSIONS_INCONTEXT_LEARNMORE_URL = ''
+
+############## Default value for invitation_only when creating courses ##############
+
+DEFAULT_COURSE_INVITATION_ONLY = False


### PR DESCRIPTION
## Description

This pull request adds a `DEFAULT_COURSE_INVITATION_ONLY` setting to the CMS that, when set to `True`, makes all courses created in Studio invitation-only by default.

## Supporting information
- [BB-8746](https://tasks.opencraft.com/browse/BB-8746)

## Testing instructions
1. Deploy this branch to a sandbox or devstack.
2. Set the `DEFAULT_COURSE_INVITATION_ONLY` configuration to `True` in the appropriate configuration file.
3. Create a new course using Studio.
4. Verify the course Advanced Settings has invitation_only=True
5. Set the `DEFAULT_COURSE_INVITATION_ONLY` configuration to `False` in the appropriate configuration file.
6. Repeat steps 3 and 4 to verify invitation_only=False.

## Deadline
None