### PR TITLE
fix(palm): receive XBlock visibility from the Learning MFE

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: save pytest warnings json file
       if: success()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-warnings-json
         path: |

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -73,7 +73,7 @@ jobs:
         xvfb-run --auto-servernum ./scripts/all-tests.sh
 
     - name: Save Job Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Build-Artifacts
         path: |

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Save Job Artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Build-Artifacts
         path: |

--- a/lms/static/completion/js/ViewedEvent.js
+++ b/lms/static/completion/js/ViewedEvent.js
@@ -110,7 +110,13 @@ export class ViewedEventTracker {
     constructor() {
         this.elementViewings = new Set();
         this.handlers = [];
-        this.registerDomHandlers();
+        if (window === window.parent) {
+          // Preview (legacy LMS frontend).
+          this.registerDomHandlers();
+        } else {
+          // Learning MFE.
+          window.addEventListener('message', this.handleVisibilityMessage.bind(this));
+        }
     }
 
     /** Add an element to track.  */
@@ -122,7 +128,11 @@ export class ViewedEventTracker {
                 (el, event) => this.callHandlers(el, event),
             ),
         );
-        this.updateVisible();
+        // Update visibility status immediately after adding the element (in case it's already visible).
+        // We don't need this for the Learning MFE because it will send a message once the iframe is loaded.
+        if (window === window.parent) {
+          this.updateVisible();
+        }
     }
 
     /** Register a new handler to be called when an element has been viewed.  */
@@ -177,6 +187,38 @@ export class ViewedEventTracker {
         this.handlers.forEach((handler) => {
             handler(el, event);
         });
+    }
+
+    /** Handle a unit.visibilityStatus message from the Learning MFE. */
+    handleVisibilityMessage(event) {
+        if (event.data.type === 'unit.visibilityStatus') {
+          const { topPosition, viewportHeight } = event.data.data;
+
+          this.elementViewings.forEach((elv) => {
+              const rect = elv.getBoundingRect();
+              let visible = false;
+
+              // Convert iframe-relative rect coordinates to be relative to the parent's viewport.
+              const elTopPosition = rect.top + topPosition;
+              const elBottomPosition = rect.bottom + topPosition;
+
+              // Check if the element is visible in the parent's viewport.
+              if (elTopPosition < viewportHeight && elTopPosition >= 0) {
+                  elv.markTopSeen();
+                  visible = true;
+              }
+              if (elBottomPosition <= viewportHeight && elBottomPosition > 0) {
+                  elv.markBottomSeen();
+                  visible = true;
+              }
+
+              if (visible) {
+                  elv.handleVisible();
+              } else {
+                  elv.handleNotVisible();
+              }
+          });
+      }
     }
 }
 


### PR DESCRIPTION
Currently, the LMS retrieves the viewport information with `getBoundingClientRect`. However, it doesn't work correctly when the XBlocks are rendered in an iframe because the iframe is automatically resized to its full height.

This solves the described problem by sending the visibility status from the Learning MFE to the LMS.

## Testing instructions:
1. (Optional) Set `COMPLETION_BY_VIEWING_DELAY_MS = 1000` in `lms/envs/private.py` for easier testing. The default value is `5000`.
2. (Optional) Change `publish_completion` to `publish_completions` in `lms/static/completion/js/CompletionOnViewService.js` for easier testing. Otherwise, you will need to create a new XBlock for the next check or manually remove the `BlockCompletion` object from the DB to get the API call re-triggered the next time you view it.
3. Check out the current PR and https://github.com/open-craft/frontend-app-learning/pull/16.
4. Create an HTML block with a single line. Check that the `publish_completion` request is called in both the Learning MFE and the Preview (to check for regressions).
5. Create two HTML blocks with enough lines to exceed your viewport. Check that the `publish_completion` request is called when you scroll down to the bottom of each of these blocks (in the Learning MFE and Preview).

_Private-ref: [BB-8826](https://tasks.opencraft.com/browse/BB-8826)_