### PR TITLE
feat: port code drift for open-craft/edx-platform [BB-8914]

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1372,6 +1372,16 @@ class ContentStoreTest(ContentStoreTestCase):
             self.course_data['run'] = '����������'
             self.assert_create_course_failed(error_message)
 
+    @override_settings(DEFAULT_COURSE_INVITATION_ONLY=True)
+    def test_create_course_invitation_only(self):
+        """
+        Test new course creation with setting: DEFAULT_COURSE_INVITATION_ONLY=True.
+        """
+        test_course_data = self.assert_created_course()
+        course_id = _get_course_id(self.store, test_course_data)
+        course = self.store.get_course(course_id)
+        self.assertEqual(course.invitation_only, True)
+
     def assert_course_permission_denied(self):
         """
         Checks that the course did not get created due to a PermissionError.

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -990,8 +990,9 @@ def create_new_course_in_store(store, user, org, number, run, fields):
 
     # Set default language from settings and enable web certs
     fields.update({
-        'language': getattr(settings, 'DEFAULT_COURSE_LANGUAGE', 'en'),
         'cert_html_view_enabled': True,
+        'invitation_only': getattr(settings, 'DEFAULT_COURSE_INVITATION_ONLY', False),
+        'language': getattr(settings, 'DEFAULT_COURSE_LANGUAGE', 'en'),
     })
 
     with modulestore().default_store(store):

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -3014,3 +3014,7 @@ MEILISEARCH_PUBLIC_URL = "http://meilisearch.example.com"
 # See https://www.meilisearch.com/docs/learn/security/tenant_tokens
 MEILISEARCH_INDEX_PREFIX = ""
 MEILISEARCH_API_KEY = "devkey"
+
+############## Default value for invitation_only when creating courses ##############
+
+DEFAULT_COURSE_INVITATION_ONLY = False

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -591,6 +591,17 @@ FEATURES = {
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2024-04-10
     'BADGES_ENABLED': False,
+
+    # .. toggle_name: FEATURES['ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to enable the legacy MD5 hashing algorithm to generate anonymous user id
+    #   instead of the newer SHAKE128 hashing algorithm
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-08-08
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
+    'ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID': False,
 }
 
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -154,12 +154,21 @@ def anonymous_id_for_user(user, course_id):
         # function: Rotate at will, since the hashes are stored and
         # will not change.
         # include the secret key as a salt, and to make the ids unique across different LMS installs.
-        hasher = hashlib.shake_128()
+        legacy_hash_enabled = settings.FEATURES.get('ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID', False)
+        if legacy_hash_enabled:
+            # Use legacy MD5 algorithm if flag enabled
+            hasher = hashlib.md5()
+        else:
+            hasher = hashlib.shake_128()
         hasher.update(settings.SECRET_KEY.encode('utf8'))
         hasher.update(str(user.id).encode('utf8'))
         if course_id:
             hasher.update(str(course_id).encode('utf-8'))
-        anonymous_user_id = hasher.hexdigest(16)
+
+        if legacy_hash_enabled:
+            anonymous_user_id = hasher.hexdigest()
+        else:
+            anonymous_user_id = hasher.hexdigest(16)  # pylint: disable=too-many-function-args
 
         try:
             AnonymousUserId.objects.create(

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -211,7 +211,7 @@ class GlobalStaff(AccessRole):
     The global staff role
     """
     def has_user(self, user):
-        return bool(user and user.is_staff)
+        return bool(user and (user.is_superuser or user.is_staff))
 
     def add_users(self, *users):
         for user in users:
@@ -358,6 +358,25 @@ class CourseLimitedStaffRole(CourseStaffRole):
     """A Staff member of a course without access to Studio."""
 
     ROLE = 'limited_staff'
+    BASE_ROLE = CourseStaffRole.ROLE
+
+
+@register_access_role
+class eSHEInstructorRole(CourseStaffRole):
+    """A Staff member of a course without access to the membership tab and enrollment-related operations."""
+
+    ROLE = 'eshe_instructor'
+    BASE_ROLE = CourseStaffRole.ROLE
+
+
+@register_access_role
+class TeachingAssistantRole(CourseStaffRole):
+    """
+    A Staff member of a course without access to the membership tab, enrollment-related operations and
+    grade-related operations.
+    """
+
+    ROLE = 'teaching_assistant'
     BASE_ROLE = CourseStaffRole.ROLE
 
 

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -17,6 +17,8 @@ from common.djangoapps.student.roles import (
     CourseStaffRole,
     CourseFinanceAdminRole,
     CourseSalesAdminRole,
+    eSHEInstructorRole,
+    TeachingAssistantRole,
     LibraryUserRole,
     CourseDataResearcherRole,
     GlobalStaff,
@@ -199,6 +201,8 @@ class RoleCacheTestCase(TestCase):  # lint-amnesty, pylint: disable=missing-clas
     ROLES = (
         (CourseStaffRole(IN_KEY), ('staff', IN_KEY, 'edX')),
         (CourseLimitedStaffRole(IN_KEY), ('limited_staff', IN_KEY, 'edX')),
+        (eSHEInstructorRole(IN_KEY), ('eshe_instructor', IN_KEY, 'edX')),
+        (TeachingAssistantRole(IN_KEY), ('teaching_assistant', IN_KEY, 'edX')),
         (CourseInstructorRole(IN_KEY), ('instructor', IN_KEY, 'edX')),
         (OrgStaffRole(IN_KEY.org), ('staff', None, 'edX')),
         (CourseFinanceAdminRole(IN_KEY), ('finance_admin', IN_KEY, 'edX')),

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -1064,6 +1064,17 @@ class AnonymousLookupTable(ModuleStoreTestCase):
             assert anonymous_id != new_anonymous_id
             assert self.user == user_by_anonymous_id(new_anonymous_id)
 
+    def test_enable_legacy_hash_flag(self):
+        """Test that different anonymous id returned if ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID enabled."""
+        CourseEnrollment.enroll(self.user, self.course.id)
+        anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+        with patch.dict(settings.FEATURES, ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID=True):
+            # Recreate user object to clear cached anonymous id.
+            self.user = User.objects.get(pk=self.user.id)
+            AnonymousUserId.objects.filter(user=self.user).filter(course_id=self.course.id).delete()
+            new_anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+            assert anonymous_id != new_anonymous_id
+
 
 @skip_unless_lms
 @patch('openedx.core.djangoapps.programs.utils.get_programs')

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -315,6 +315,12 @@ class DatesTab(EnrolledTab):
         tab_dict['link_func'] = link_func
         super().__init__(tab_dict)
 
+    @classmethod
+    def is_enabled(cls, course, user=None):
+        if settings.FEATURES.get('DISABLE_DATES_TAB'):
+            return False
+        return super().is_enabled(course, user)
+
 
 def get_course_tab_list(user, course):
     """

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -885,3 +885,16 @@ class DatesTabTestCase(TabListTestCase):
             if tab.type == 'dates':
                 num_dates_tabs += 1
         assert num_dates_tabs == 1
+
+    def test_dates_tab_is_enabled_by_default(self):
+        """Test dates tab is enabled by default."""
+        tab = DatesTab({'type': DatesTab.type, 'name': 'dates'})
+        user = self.create_mock_user()
+        assert self.is_tab_enabled(tab, self.course, user)
+
+    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_DATES_TAB": True})
+    def test_dates_tab_disabled_by_feature_flag(self):
+        """Test dates tab is disabled by the feature flag."""
+        tab = DatesTab({'type': DatesTab.type, 'name': 'dates'})
+        user = self.create_mock_user()
+        assert not self.is_tab_enabled(tab, self.course, user)

--- a/lms/djangoapps/instructor/access.py
+++ b/lms/djangoapps/instructor/access.py
@@ -19,6 +19,8 @@ from common.djangoapps.student.roles import (
     CourseInstructorRole,
     CourseLimitedStaffRole,
     CourseStaffRole,
+    eSHEInstructorRole,
+    TeachingAssistantRole,
 )
 from lms.djangoapps.instructor.enrollment import enroll_email, get_email_params
 from openedx.core.djangoapps.django_comment_common.models import Role
@@ -30,6 +32,8 @@ ROLES = {
     'instructor': CourseInstructorRole,
     'staff': CourseStaffRole,
     'limited_staff': CourseLimitedStaffRole,
+    'eshe_instructor': eSHEInstructorRole,
+    'teaching_assistant': TeachingAssistantRole,
     'ccx_coach': CourseCcxCoachRole,
     'data_researcher': CourseDataResearcherRole,
 }

--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -36,6 +36,21 @@ VIEW_DASHBOARD = 'instructor.dashboard'
 VIEW_ENROLLMENTS = 'instructor.view_enrollments'
 VIEW_FORUM_MEMBERS = 'instructor.view_forum_members'
 
+# Due to how the roles iheritance is implemented currently, eshe_instructor and teaching_assistant have implicit
+# staff access, but unlike staff, they shouldn't be able to enroll and do grade-related operations as per client's
+# requirements. At the same time, all other staff-derived roles, like Limited Staff, should be able to enroll students.
+# This solution is far from perfect, but it's probably the best we can do untill the roles system is reworked.
+_is_teaching_assistant = HasRolesRule('teaching_assistant')
+_is_eshe_instructor = HasRolesRule('eshe_instructor')
+_is_eshe_instructor_or_teaching_assistant = _is_teaching_assistant | _is_eshe_instructor
+is_staff_but_not_teaching_assistant = (
+    (_is_teaching_assistant & HasAccessRule('staff', strict=True)) |
+    (~_is_teaching_assistant & HasAccessRule('staff'))
+)
+is_staff_but_not_eshe_instructor_or_teaching_assistant = (
+    (_is_eshe_instructor_or_teaching_assistant & HasAccessRule('staff', strict=True)) |
+    (~_is_eshe_instructor_or_teaching_assistant & HasAccessRule('staff'))
+)
 
 perms[ALLOW_STUDENT_TO_BYPASS_ENTRANCE_EXAM] = HasAccessRule('staff')
 perms[ASSIGN_TO_COHORTS] = HasAccessRule('staff')
@@ -49,17 +64,17 @@ perms[START_CERTIFICATE_GENERATION] = is_staff | HasAccessRule('instructor')
 perms[START_CERTIFICATE_REGENERATION] = is_staff | HasAccessRule('instructor')
 perms[CERTIFICATE_EXCEPTION_VIEW] = is_staff | HasAccessRule('instructor')
 perms[CERTIFICATE_INVALIDATION_VIEW] = is_staff | HasAccessRule('instructor')
-perms[GIVE_STUDENT_EXTENSION] = HasAccessRule('staff')
+perms[GIVE_STUDENT_EXTENSION] = is_staff_but_not_teaching_assistant
 perms[VIEW_ISSUED_CERTIFICATES] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 # only global staff or those with the data_researcher role can access the data download tab
 # HasAccessRule('staff') also includes course staff
 perms[CAN_RESEARCH] = is_staff | HasRolesRule('data_researcher')
-perms[CAN_ENROLL] = HasAccessRule('staff')
+perms[CAN_ENROLL] = is_staff_but_not_eshe_instructor_or_teaching_assistant
 perms[CAN_BETATEST] = HasAccessRule('instructor')
 perms[ENROLLMENT_REPORT] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 perms[VIEW_COUPONS] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 perms[EXAM_RESULTS] = HasAccessRule('staff')
-perms[OVERRIDE_GRADES] = HasAccessRule('staff')
+perms[OVERRIDE_GRADES] = is_staff_but_not_teaching_assistant
 perms[SHOW_TASKS] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 perms[EMAIL] = HasAccessRule('staff')
 perms[RESCORE_EXAMS] = HasAccessRule('instructor')

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1116,6 +1116,15 @@ FEATURES = {
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/632/files'
     'ENABLE_TEACHING_ASSISTANT_ROLE': False,
+
+    # .. toggle_name: FEATURES['DISABLE_DATES_TAB']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Disables dates tab for all courses.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-04-15
+    # .. toggle_tickets: https://github.com/openedx/edx-platform/pull/34511
+    'DISABLE_DATES_TAB': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1096,6 +1096,26 @@ FEATURES = {
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
     'ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID': False,
+
+    # .. toggle_name: FEATURES['ENABLE_ESHE_INSTRUCTOR_ROLE']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to enable the ESHE Instructor role
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2023-07-31
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/561/files'
+    'ENABLE_ESHE_INSTRUCTOR_ROLE': False,
+
+    # .. toggle_name: FEATURES['ENABLE_TEACHING_ASSISTANT_ROLE']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to enable the Teaching Assistant role
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-02-12
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/632/files'
+    'ENABLE_TEACHING_ASSISTANT_ROLE': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1085,6 +1085,17 @@ FEATURES = {
     # .. toggle_creation_date: 2024-04-02
     # .. toggle_target_removal_date: None
     'BADGES_ENABLED': False,
+
+    # .. toggle_name: FEATURES['ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to enable the legacy MD5 hashing algorithm to generate anonymous user id
+    #   instead of the newer SHAKE128 hashing algorithm
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2022-08-08
+    # .. toggle_target_removal_date: None
+    # .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
+    'ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/lms/static/js/fixtures/instructor_dashboard/membership.html
+++ b/lms/static/js/fixtures/instructor_dashboard/membership.html
@@ -11,6 +11,8 @@
         <select id="member-lists-selector" class="member-lists-selector">
           <option value="staff">Staff</option>
           <option value="limited_staff">Limited Staff</option>
+          <option value="eshe_instructor">eSHE Instructor</option>
+          <option value="teaching_assistant">Teaching Assistant</option>
           <option value="instructor">Admin</option>
           <option value="beta">Beta Testers</option>
           <option value="Administrator">Discussion Admins</option>

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -216,6 +216,7 @@
             saveError: function(error) {
                 var errorCode;
                 var msg;
+                var redirectURL;
                 if (error.status === 0) {
                     msg = gettext('An error has occurred. Check your Internet connection and try again.');
                 } else if (error.status === 500) {
@@ -245,6 +246,7 @@
                 } else if (error.responseJSON !== undefined) {
                     msg = error.responseJSON.value;
                     errorCode = error.responseJSON.error_code;
+                    redirectURL = error.responseJSON.redirect_url;
                 } else {
                     msg = gettext('An unexpected error has occurred.');
                 }
@@ -266,6 +268,7 @@
                         this.clearFormErrors();
                         this.renderThirdPartyAuthWarning();
                     }
+                    window.location.href = redirectURL;
                 } else {
                     this.renderErrors(this.defaultFormErrorsTitle, this.errors);
                 }

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -19,7 +19,9 @@ from openedx.features.enterprise_support.utils import get_enterprise_learner_gen
 self.real_user = getattr(user, 'real_user', user)
 profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
 username = self.real_user.username
-displayname = get_enterprise_learner_generic_name(request) or username
+profile = getattr(self.real_user, 'profile', None)
+name = getattr(profile, 'name', username)
+displayname = get_enterprise_learner_generic_name(request) or name
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -5,6 +5,13 @@ from django.utils.translation import gettext as _
 from django.utils.translation import pgettext
 from openedx.core.djangolib.markup import HTML, Text
 %>
+
+<%
+  eshe_instructor_or_teaching_assistant_access = section_data['access']['eshe_instructor'] or section_data['access']['teaching_assistant']
+  membership_section_visible = not eshe_instructor_or_teaching_assistant_access or section_data['access']['explicit_staff']
+%>
+
+% if membership_section_visible:
 <fieldset class="batch-enrollment membership-section">
     <legend id="heading-batch-enrollment" class="hd hd-3">${_("Batch Enrollment")}</legend>
     <label>
@@ -90,6 +97,8 @@ from openedx.core.djangolib.markup import HTML, Text
     </form>
     <div class="results"></div>
 </div>
+%endif
+
 %endif
 
 <hr class="divider" />
@@ -192,6 +201,34 @@ from openedx.core.djangolib.markup import HTML, Text
       data-modify-endpoint="${ section_data['modify_access_url'] }"
       data-add-button-label="${_("Add Limited Staff")}"
     ></div>
+
+    %if settings.FEATURES.get('ENABLE_ESHE_INSTRUCTOR_ROLE', None):
+    <div class="auth-list-container"
+      data-rolename="eshe_instructor"
+      data-display-name="${_("eSHE Instructor")}"
+      data-info-text="
+        ${_("Course team members with the eSHE Instructor role help you manage your course. "
+        "eSHE Instructor permissions are similar to Staff, but they can't assign course team roles and "
+        "can't enroll and unenroll learners")}"
+      data-list-endpoint="${ section_data['list_course_role_members_url'] }"
+      data-modify-endpoint="${ section_data['modify_access_url'] }"
+      data-add-button-label="${_("Add eSHE Instructor")}"
+    ></div>
+    %endif
+
+    %if settings.FEATURES.get('ENABLE_TEACHING_ASSISTANT_ROLE', None):
+    <div class="auth-list-container"
+      data-rolename="teaching_assistant"
+      data-display-name="${_("Teaching Assistant")}"
+      data-info-text="
+        ${_("Course team members with the Teaching Assistant role help you manage your course. "
+        "Teaching Assistant permissions are similar to Staff, but they can't assign course team roles, "
+        "enroll and unenroll learners and view or override grades")}"
+      data-list-endpoint="${ section_data['list_course_role_members_url'] }"
+      data-modify-endpoint="${ section_data['modify_access_url'] }"
+      data-add-button-label="${_("Add Teaching Assistant")}"
+    ></div>
+    %endif%
 
     ## Note that "Admin" is identified as "Instructor" in the Django admin panel.
     <div class="auth-list-container"

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -1,7 +1,13 @@
 <%page args="section_data" expression_filter="h"/>
 <%! from django.utils.translation import gettext as _ %>
+
+<%
+  teaching_assistant_access = section_data['access']['teaching_assistant']
+  gradebook_related_sections_hidden = teaching_assistant_access and not section_data['access']['explicit_staff']
+%>
+
 %if section_data['access']['staff'] or section_data['access']['instructor']:
-<div class="action-type-container">
+<div class="action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     %if section_data.get('writable_gradebook_url') or section_data.get('is_small_course'):
         <br><br>
         <h4 class="hd hd-4">${_("View gradebook for enrolled learners")}</h4>
@@ -59,7 +65,7 @@
   <hr>
 </div>
 
-<div class="student-grade-container action-type-container">
+<div class="student-grade-container action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     <h4 class="hd hd-4">${_("Adjust a learner's grade for a specific problem")}</h4>
     <div class="request-response-error"></div>
     <label for="student-select-grade">
@@ -132,7 +138,7 @@
 </div>
 
 % if course.entrance_exam_enabled:
-<div class="entrance-exam-grade-container action-type-container">
+<div class="entrance-exam-grade-container action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     <h4 class="hd hd-4">${_("Adjust a learner's entrance exam results")}</h4>
     <div class="request-response-error"></div>
 
@@ -194,7 +200,7 @@
 
 %if section_data['access']['instructor']:
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
-<div class="course-specific-container action-type-container">
+<div class="course-specific-container action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     <h4 class="hd hd-4">${_("Adjust all enrolled learners' grades for a specific problem")}</h4>
     <div class="request-response-error"></div>
 
@@ -232,7 +238,7 @@
 %endif
 
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
-<div class="running-tasks-container action-type-container">
+<div class="running-tasks-container action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     <h4 class="hd hd-4">${_("Pending Tasks")}</h4>
     <div class="running-tasks-section">
         <label>${_("The status for any active tasks appears in a table below.")}</label>

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -68,7 +68,8 @@ from openedx.core.djangolib.markup import HTML, Text
           </span>
           <span class="sr">(${submit_disabled_cta['description']})</span>
         % else:
-            <form class="submit-cta" method="post" action="${submit_disabled_cta['link']}">
+          <form class="submit-cta" method="post" action="${submit_disabled_cta.get('link')}">
+            % if submit_disabled_cta.get('link'):
               <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
               % for form_name, form_value in submit_disabled_cta['form_values'].items():
                   <input type="hidden" name="${form_name}" value="${form_value}">
@@ -76,13 +77,14 @@ from openedx.core.djangolib.markup import HTML, Text
               <button class="submit-cta-link-button btn-link btn-small">
                 ${submit_disabled_cta['link_name']}
               </button>
-              <span class="submit-cta-description" tabindex="0" role="note" aria-label="description">
-                <span data-tooltip="${submit_disabled_cta['description']}" data-tooltip-show-on-click="true"
-                  class="fa fa-info-circle fa-lg" aria-hidden="true">
-                </span>
+            % endif
+            <span class="submit-cta-description" tabindex="0" role="note" aria-label="description">
+              <span data-tooltip="${submit_disabled_cta['description']}" data-tooltip-show-on-click="true"
+                class="fa fa-info-circle fa-lg" aria-hidden="true">
               </span>
-              <span class="sr">(${submit_disabled_cta['description']})</span>
-            </form>
+            </span>
+            <span class="sr">(${submit_disabled_cta['description']})</span>
+          </form>
         % endif
       % endif
       <div class="submission-feedback ${'cta-enabled' if submit_disabled_cta else ''}" id="submission_feedback_${short_id}">

--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -44,7 +44,7 @@ from openedx.core.djangolib.markup import HTML
         <div class="banner-cta-button">
             <button class="btn btn-outline-primary" onclick="emit_event(${vertical_banner_cta['event_data']})">${vertical_banner_cta['link_name']}</button>
         </div>
-      % else:
+      % elif vertical_banner_cta.get('link'):
         <div class="banner-cta-button">
           <form method="post" action="${vertical_banner_cta['link']}">
             <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logout.py
@@ -211,8 +211,10 @@ class LogoutTests(TestCase):
             mock_idp_logout_url.return_value = idp_logout_url
             self._authenticate_with_oauth(client)
             response = self.client.get(reverse('logout'))
-            assert response.status_code == 302
-            assert response.url == idp_logout_url
+            expected = {
+                'target': idp_logout_url,
+            }
+            self.assertDictContainsSubset(expected, response.context_data)
 
     @mock.patch('django.conf.settings.TPA_AUTOMATIC_LOGOUT_ENABLED', True)
     def test_no_automatic_tpa_logout_without_logout_url(self):

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -141,12 +141,18 @@ def get_start_block(block):
     return get_start_block(first_child)
 
 
-def dates_banner_should_display(course_key, user):
+def dates_banner_should_display(course_key, user, allow_warning=False):
     """
     Return whether or not the reset banner should display,
     determined by whether or not a course has any past-due,
     incomplete sequentials and which enrollment mode is being
     dealt with for the current user and course.
+
+    Args:
+        course_key (CourseKey)
+        user (User)
+        allow_warning (bool): whether to ignore relative_dates_disable_reset_flag, in order to render
+            warnings for past-due incomplete units.
 
     Returns:
         (missed_deadlines, missed_gated_content):
@@ -156,7 +162,7 @@ def dates_banner_should_display(course_key, user):
     if not RELATIVE_DATES_FLAG.is_enabled(course_key):
         return False, False
 
-    if RELATIVE_DATES_DISABLE_RESET_FLAG.is_enabled(course_key):
+    if RELATIVE_DATES_DISABLE_RESET_FLAG.is_enabled(course_key) and not allow_warning:
         # The `missed_deadlines` value is ignored by `reset_course_deadlines` views. Instead, they check the value of
         # `missed_gated_content` to determine if learners can reset the deadlines by themselves.
         # We could have added this logic directly to `reset_self_paced_schedule`, but this function is used in other


### PR DESCRIPTION
# Description
I've gone through every pull request [here](https://github.com/orgs/open-craft/projects/1/views/10) and checked and ported when needed each one not in the "Present in Redwood" status. I tested all pull requests except https://github.com/open-craft/edx-platform/pull/540 (I didn't manage to configure it). Also, I deployed this branch to https://lms.redwood-upgrade.opencraft.hosting (https://gitlab.com/opencraft/ops/redwood-upgrade-test) and gone through our checklist.

# Testing steps
I think this is already tested thoroughly. Feel free to do any additional tests using credentials from [here](https://tasks.opencraft.com/browse/BB-8914?focusedCommentId=293536&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-293536).