### PR TITLE
fix: prevent redirects to /undefined after saml auth

### DIFF
--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -267,7 +267,9 @@
                         this.clearFormErrors();
                         this.renderThirdPartyAuthWarning();
                     }
-                    window.location.href = redirectURL;
+                    if (typeof redirectURL === "string" && redirectURL.length) {
+                        window.location.href = redirectURL;
+                    }
                 } else {
                     this.renderErrors(this.defaultFormErrorsTitle, this.errors);
                 }


### PR DESCRIPTION
When a user authenticates using SAML, but their accounts aren't linked, they land on the login page with the message to link their accounts. If the
OC_REDIRECT_ON_TPA_UNLINKED_ACCOUNT value is not setup, they end up getting redirected to /undefined. This commit validates the redirectURL as a valid string before performing the redirect.

Internal-ref: https://tasks.opencraft.com/browse/BB-9010