### PR TITLE
feat: set links for CourseAuthoring dicussion alert

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_course_index.py
@@ -61,8 +61,8 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
                 "blocks": [],
                 "advance_settings_url": f"/settings/advanced/{self.course.id}"
             },
-            "discussions_incontext_feedback_url": "",
-            "discussions_incontext_learnmore_url": "",
+            "discussions_incontext_feedback_url": "https://discuss.openedx.org/t/new-and-improved-discussions-forum/9183",  # lint-amnesty, pylint: disable=line-too-long
+            "discussions_incontext_learnmore_url": "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-redwood.master/manage_discussions/discussions.html",  # lint-amnesty, pylint: disable=line-too-long
             "is_custom_relative_dates_active": True,
             "initial_state": None,
             "initial_user_clipboard": {
@@ -102,8 +102,8 @@ class CourseIndexViewTest(CourseTestCase, PermissionAccessMixin):
                 "blocks": [],
                 "advance_settings_url": f"/settings/advanced/{self.course.id}"
             },
-            "discussions_incontext_feedback_url": "",
-            "discussions_incontext_learnmore_url": "",
+            "discussions_incontext_feedback_url": "https://discuss.openedx.org/t/new-and-improved-discussions-forum/9183",  # lint-amnesty, pylint: disable=line-too-long
+            "discussions_incontext_learnmore_url": "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-redwood.master/manage_discussions/discussions.html",  # lint-amnesty, pylint: disable=line-too-long
             "is_custom_relative_dates_active": False,
             "initial_state": {
                 "expanded_locators": [

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2891,8 +2891,9 @@ EDX_BRAZE_API_SERVER = None
 
 BRAZE_COURSE_ENROLLMENT_CANVAS_ID = ''
 
-DISCUSSIONS_INCONTEXT_FEEDBACK_URL = ''
-DISCUSSIONS_INCONTEXT_LEARNMORE_URL = ''
+# pylint: disable=line-too-long
+DISCUSSIONS_INCONTEXT_FEEDBACK_URL = "https://discuss.openedx.org/t/new-and-improved-discussions-forum/9183"
+DISCUSSIONS_INCONTEXT_LEARNMORE_URL = "https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/open-release-redwood.master/manage_discussions/discussions.html"
 
 #### django-simple-history##
 # disable indexing on date field its coming django-simple-history.


### PR DESCRIPTION

# Description
There is an [alert](https://github.com/open-craft/frontend-app-course-authoring/blob/04bdc64391ab092b85ebb2f7de6bf10a09fda1ea/src/course-outline/page-alerts/PageAlerts.jsx#L104) in CourseAuthoring MFE to inform about the usage of an upgraded version of discussion. This PR sets the links used in that alert.

# ref
BB-9079