### PR TITLE
feat: in-context discussion for units can be disabled by default

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -592,6 +592,14 @@ FEATURES = {
     # .. toggle_creation_date: 2024-04-10
     'BADGES_ENABLED': False,
 
+    # .. toggle_name: FEATURES['IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Set to False to not enable in-context discussion for units by default.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2024-09-02
+    'IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT': True,
+
     # .. toggle_name: FEATURES['ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False

--- a/xmodule/vertical_block.py
+++ b/xmodule/vertical_block.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from functools import reduce
 
 import pytz
+from django.conf import settings
 from lxml import etree
 from openedx_filters.learning.filters import VerticalBlockChildRenderStarted, VerticalBlockRenderCompleted
 from web_fragments.fragment import Fragment
@@ -43,7 +44,7 @@ class VerticalFields:
     discussion_enabled = Boolean(
         display_name=_("Enable in-context discussions for the Unit"),
         help=_("Add discussion for the Unit."),
-        default=True,
+        default=settings.FEATURES.get('IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT', True),
         scope=Scope.settings,
     )
 


### PR DESCRIPTION
## Description

Currently for all new units which are added to a course, the discussions sidebar is enabled by default, which the course instructor can disable individually.

This PR, adds to the ability to disable discussions sidebar by default. That way all new units which are added will have the discussions sidebar disabled and can be individually enabled by the course instrutors.

Upstream PR : https://github.com/openedx/edx-platform/pull/35414

## Testing instructions

**Part 1: Discussion Sidebar disable by default**
1. Check [this sandbox](https://gitlab.com/opencraft/client/asu-moe/grove-development/-/blob/main/instances/opencraft/config.yml?ref_type=heads) has the [correct edx-platform branch](https://gitlab.com/opencraft/client/asu-moe/grove-development/-/blob/main/instances/opencraft/config.yml?ref_type=heads#L36) and has the `UNIT_DISCUSSION_SIDEBAR_ENABLED_BY_DEFAULT` flag [set to false](https://gitlab.com/opencraft/client/asu-moe/grove-development/-/blob/main/instances/opencraft/config.yml?ref_type=heads#L228).
2. Login to the sandbox [https://lms.oc.eshe.opencraft.hosting/lms-login](https://lms.oc.eshe.opencraft.hosting/lms-login)
3. Go to [Studio](https://studio.lms.oc.eshe.opencraft.hosting)
4. Create a new course, add a new unit and publish
5. Wait for a minute and then check the live version in LMS
6. Make sure the discussion sidebar is **missing** for this unit.
7. In Studio [enable discussion](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/manage_discussions/discussions.html#upgraded-edx-forum) for this unit and wait for a minute.
8. Go to LMS again and check that the discussions sidebar is now available.

**Part 2: Discussion Sidebar enabled by default**
1. Check [this sandbox](https://gitlab.com/opencraft/client/asu-moe/grove-development/-/blob/main/instances/kaustav-sandbox/config.yml?ref_type=heads#L36) has the correct edx-platform branch.
2. Login to the sandbox [https://lms.kaustav-two.eshe.opencraft.hosting/lms-login](https://lms.kaustav-two.eshe.opencraft.hosting/lms-login)
3. Go to [Studio](https://studio.lms.kaustav-two.eshe.opencraft.hosting)
4. Create a new course, add a new unit and publish
5. Wait for a minute and then check the live version in LMS
6. Make sure the discussion sidebar is **available** for this unit.
7. In Studio [disable discussion](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/manage_discussions/discussions.html#upgraded-edx-forum) for this unit and wait for a minute.
8. Go to LMS again and check that the discussions sidebar is now available.


## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Private Ref : [BB-9112](https://tasks.opencraft.com/browse/BB-9112)