### PR TITLE
feat: allow Bearer auth for sequence metadata

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -583,6 +583,7 @@ class SequenceMetadata(DeveloperErrorViewMixin, APIView):
 
     authentication_classes = (
         JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
 


### PR DESCRIPTION
We need this endpoint to support Bearer token authentication because we switched our Android app to use this type of authentication.

Private-ref: https://tasks.opencraft.com/browse/BB-9182