### PR TITLE
fix: use a single 'provider_type' key for storing discussion provider type in course [BACKPORT][BB-9323]

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -456,11 +456,11 @@ def sync_discussion_settings(course_key, user):
         if (
             ENABLE_NEW_STRUCTURE_DISCUSSIONS.is_enabled()
             and not course.discussions_settings['provider_type'] == Provider.OPEN_EDX
+            and not course.discussions_settings['provider'] == Provider.OPEN_EDX
         ):
             LOGGER.info(f"New structure is enabled, also updating {course_key} to use new provider")
             course.discussions_settings['enable_graded_units'] = False
             course.discussions_settings['unit_level_visibility'] = True
-            course.discussions_settings['provider'] = Provider.OPEN_EDX
             course.discussions_settings['provider_type'] = Provider.OPEN_EDX
             modulestore().update_item(course, user.id)
 

--- a/openedx/core/djangoapps/discussions/tasks.py
+++ b/openedx/core/djangoapps/discussions/tasks.py
@@ -196,7 +196,10 @@ def update_unit_discussion_state_from_discussion_blocks(course_key: CourseKey, u
     """
     store = modulestore()
     course = store.get_course(course_key)
-    provider = course.discussions_settings.get('provider', None)
+    provider = course.discussions_settings.get(
+        'provider_type',
+        course.discussions_settings.get('provider', None),
+    )
     # Only migrate to the new discussion provider if the current provider is the legacy provider.
     log.info(f"Current provider for {course_key} is {provider}")
     if provider is not None and provider != Provider.LEGACY and not force:


### PR DESCRIPTION
Backports https://github.com/openedx/edx-platform/pull/36039