### PR TITLE
fix: prevent null release date field in xblocks

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -424,6 +424,11 @@ def _save_xblock(
                 for metadata_key, value in metadata.items():
                     field = xblock.fields[metadata_key]
 
+                    # Prevent setting release date to null
+                    # remove field and inherit from parent instead
+                    if metadata_key == "start" and value == "":
+                        value = None
+
                     if value is None:
                         field.delete_from(xblock)
                     else:


### PR DESCRIPTION
The change prevents setting the release date to null by removing the field and inheriting from the parent instead.

* [`cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py`](diffhunk://#diff-343136d98fafed84f78ef477490a344fd7cb6a8029c15811af364476cd2fc2eeR427-R431): Added a check to prevent setting the release date to null.

Ref: BB-9629