### PR TITLE
[BB-9706] fix: ensure certificate has a modified_date

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -351,7 +351,10 @@ def _get_user_certificate(request, user, course_key, course_overview, preview_mo
     """
     user_certificate = None
     if preview_mode:
-        # certificate is being previewed from studio
+        # The certificate is being previewed from the CMS. When previewing a certificate the "modified date" is
+        # displayed when rendered. We try to set the "modified date" of the artificial certificate record in such a way
+        # that it matches the date selection logic used by the system when rendering a "real" certificate instance. See
+        # the `display_date_for_certificate function` in the lms/djangoapps/certificates/api.py file.
         if request.user.has_perm(PREVIEW_CERTIFICATES, course_overview):
             if (
                 course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END_WITH_DATE
@@ -359,7 +362,11 @@ def _get_user_certificate(request, user, course_key, course_overview, preview_mo
                 and not course_overview.self_paced
             ):
                 modified_date = course_overview.certificate_available_date
-            elif course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END:
+            elif (
+                course_overview.certificates_display_behavior == CertificatesDisplayBehaviors.END
+                and course_overview.end
+                and not course_overview.self_paced
+            ):
                 modified_date = course_overview.end
             else:
                 modified_date = datetime.now().date()


### PR DESCRIPTION
## Description

The change in this PR ensures the certificate generated in preview always has a modified date, even when the course has no end date. This is necessary to ensure the certificate is rendered correctly.

### Copilot Summary
This pull request includes a small update to the `_get_user_certificate` function in `lms/djangoapps/certificates/views/webview.py`. The change ensures that the `modified_date` field defaults to the current date if no value is provided.

## Supporting information

- [BB-9706](https://tasks.opencraft.com/browse/BB-9706)

## Testing instructions

1. Go to Studio and create an instructor-paced course without an end date.
1. Create a certificate for the course.
1. Click Preview to preview the certificate in the LMS.
1. Verify that the certificate is displayed without issues.

## Deadline

ASAP