### PR TITLE
chore: bump ora2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -850,7 +850,7 @@ optimizely-sdk==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/bundled.in
-ora2 @ git+https://github.com/open-craft/edx-ora2@viadanna/block-uploads
+ora2==6.16.4
     # via -r requirements/edx/bundled.in
 packaging==24.1
     # via

--- a/requirements/edx/bundled.in
+++ b/requirements/edx/bundled.in
@@ -43,10 +43,7 @@ done-xblock                         # a very simple XBlock that allows learners 
 recommender-xblock                  # https://github.com/edx/RecommenderXBlock
 staff-graded-xblock                 # https://github.com/openedx/staff_graded-xblock Allows off-site bulk scoring.
 edx-sga                             # The more well known "staff graded assignment" XBlock, from MIT.
-# ora2>=4.5.0                         # Open Response Assessment XBlock
+ora2>=4.5.0                         # Open Response Assessment XBlock
 xblock-poll                         # Xblock for polling users
 xblock-drag-and-drop-v2             # Drag and Drop XBlock
 xblock-google-drive                 # XBlock for google docs and calendar
-
-# Fix for ORA uploads
-git+https://github.com/open-craft/edx-ora2@viadanna/block-uploads

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1411,7 +1411,7 @@ optimizely-sdk==4.1.1
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt
-ora2 @ git+https://github.com/open-craft/edx-ora2@viadanna/block-uploads
+ora2==6.16.4
     # via
     #   -r requirements/edx/doc.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -1019,7 +1019,7 @@ optimizely-sdk==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-ora2 @ git+https://github.com/open-craft/edx-ora2@viadanna/block-uploads
+ora2==6.16.4
     # via -r requirements/edx/base.txt
 packaging==24.1
     # via

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1064,7 +1064,7 @@ optimizely-sdk==4.1.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
-ora2 @ git+https://github.com/open-craft/edx-ora2@viadanna/block-uploads
+ora2==6.16.4
     # via -r requirements/edx/base.txt
 packaging==24.1
     # via


### PR DESCRIPTION
Removes ORA2 drift now that the upstream PR was merged. No changes in behavior.

Internal-ref: https://tasks.opencraft.com/browse/BB-9210