### PR TITLE
feat: add ability to override middlewares for recurring nudges

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/__init__.py
+++ b/openedx/core/djangoapps/schedules/management/commands/__init__.py
@@ -37,8 +37,8 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
         )
         parser.add_argument(
             '--override-middlewares',
-            nargs='*',
-            help='Use these middelwares when emulating http request'
+            action='append',
+            help='Use these middlewares when emulating http requests. Provide the option multiple times to use multiple middlewares.'
         )
 
     def handle(self, *args, **options):

--- a/openedx/core/djangoapps/schedules/management/commands/__init__.py
+++ b/openedx/core/djangoapps/schedules/management/commands/__init__.py
@@ -8,9 +8,11 @@ import datetime
 import pytz
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
+from django.db.models import Q
 
 from openedx.core.djangoapps.schedules.utils import PrefixedDebugLoggerMixin
 
+ALL_SITES = "all-sites"
 
 class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
     async_send_task = None  # define in subclass
@@ -29,7 +31,11 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
             '--override-recipient-email',
             help='Send all emails to this address instead of the actual recipient'
         )
-        parser.add_argument('site_domain_name')
+        parser.add_argument(
+            'site_domain_name',
+            nargs='?',
+            default=ALL_SITES
+        )
         parser.add_argument(
             '--weeks',
             type=int,
@@ -54,13 +60,17 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
             tzinfo=pytz.UTC
         )
         self.log_debug('Current date = %s', current_date.isoformat())
-
-        site = Site.objects.get(domain__iexact=options['site_domain_name'])
-        self.log_debug('Running for site %s', site.domain)
-
         override_recipient_email = options.get('override_recipient_email')
         override_middlewares = options.get('override_middlewares')
-        self.send_emails(site, current_date, override_recipient_email, override_middlewares)
+
+        site_domain_name = options['site_domain_name']
+        site_filter = Q()
+        if site_domain_name != ALL_SITES:
+            site_filter |= Q(domain__iexact=site_domain_name)
+
+        for site in Site.objects.filter(site_filter):
+            self.log_debug('Running for site %s', site.domain)
+            self.send_emails(site, current_date, override_recipient_email, override_middlewares)
 
     def enqueue(self, day_offset, site, current_date, override_recipient_email=None, override_middlewares = None):
         self.async_send_task.enqueue(

--- a/openedx/core/djangoapps/schedules/management/commands/__init__.py
+++ b/openedx/core/djangoapps/schedules/management/commands/__init__.py
@@ -8,11 +8,8 @@ import datetime
 import pytz
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
-from django.db.models import Q
 
 from openedx.core.djangoapps.schedules.utils import PrefixedDebugLoggerMixin
-
-ALL_SITES = "all-sites"
 
 
 class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
@@ -35,7 +32,11 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
         parser.add_argument(
             'site_domain_name',
             nargs='?',
-            default=ALL_SITES
+            default=None,
+            help=(
+                'Domain name for the site to use. '
+                'Do not provide a domain if you wish to run this for all sites'
+            )
         )
         parser.add_argument(
             '--weeks',
@@ -45,7 +46,10 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
         parser.add_argument(
             '--override-middlewares',
             action='append',
-            help='Use these middlewares when emulating http requests.'
+            help=(
+                'Use this middleware when emulating http requests. '
+                'To use multiple middlewares, provide this argument multiple times'
+            )
         )
 
     def handle(self, *args, **options):
@@ -65,13 +69,14 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
         override_middlewares = options.get('override_middlewares')
 
         site_domain_name = options['site_domain_name']
-        site_filter = Q()
-        if site_domain_name != ALL_SITES:
-            site_filter |= Q(domain__iexact=site_domain_name)
+        sites = Site.objects.filter(domain__iexact=site_domain_name) if site_domain_name else Site.objects.all()
 
-        for site in Site.objects.filter(site_filter):
-            self.log_debug('Running for site %s', site.domain)
-            self.send_emails(site, current_date, override_recipient_email, override_middlewares)
+        if sites:
+            for site in sites:
+                self.log_debug('Running for site %s', site.domain)
+                self.send_emails(site, current_date, override_recipient_email, override_middlewares)
+        else:
+            self.log_info("No matching site found")
 
     def enqueue(self, day_offset, site, current_date, override_recipient_email=None, override_middlewares=None):
         self.async_send_task.enqueue(

--- a/openedx/core/djangoapps/schedules/management/commands/__init__.py
+++ b/openedx/core/djangoapps/schedules/management/commands/__init__.py
@@ -14,6 +14,7 @@ from openedx.core.djangoapps.schedules.utils import PrefixedDebugLoggerMixin
 
 ALL_SITES = "all-sites"
 
+
 class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnesty, pylint: disable=missing-class-docstring
     async_send_task = None  # define in subclass
 
@@ -44,7 +45,7 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
         parser.add_argument(
             '--override-middlewares',
             action='append',
-            help='Use these middlewares when emulating http requests. Provide the option multiple times to use multiple middlewares.'
+            help='Use these middlewares when emulating http requests.'
         )
 
     def handle(self, *args, **options):
@@ -72,7 +73,7 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
             self.log_debug('Running for site %s', site.domain)
             self.send_emails(site, current_date, override_recipient_email, override_middlewares)
 
-    def enqueue(self, day_offset, site, current_date, override_recipient_email=None, override_middlewares = None):
+    def enqueue(self, day_offset, site, current_date, override_recipient_email=None, override_middlewares=None):
         self.async_send_task.enqueue(
             site,
             current_date,

--- a/openedx/core/djangoapps/schedules/management/commands/__init__.py
+++ b/openedx/core/djangoapps/schedules/management/commands/__init__.py
@@ -35,6 +35,11 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
             type=int,
             help='Number of weekly emails to be sent',
         )
+        parser.add_argument(
+            '--override-middlewares',
+            nargs='*',
+            help='Use these middelwares when emulating http request'
+        )
 
     def handle(self, *args, **options):
         self.log_debug('Args = %r', options)
@@ -54,14 +59,16 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):  # lint-amnes
         self.log_debug('Running for site %s', site.domain)
 
         override_recipient_email = options.get('override_recipient_email')
-        self.send_emails(site, current_date, override_recipient_email)
+        override_middlewares = options.get('override_middlewares')
+        self.send_emails(site, current_date, override_recipient_email, override_middlewares)
 
-    def enqueue(self, day_offset, site, current_date, override_recipient_email=None):
+    def enqueue(self, day_offset, site, current_date, override_recipient_email=None, override_middlewares = None):
         self.async_send_task.enqueue(
             site,
             current_date,
             day_offset,
             override_recipient_email,
+            override_middlewares,
         )
 
     def send_emails(self, *args, **kwargs):

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
@@ -12,7 +12,7 @@ import pytz
 from django.conf import settings
 from django.contrib.sites.models import Site
 
-from openedx.core.djangoapps.schedules.management.commands import SendEmailBaseCommand, ALL_SITES
+from openedx.core.djangoapps.schedules.management.commands import SendEmailBaseCommand
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory, SiteFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 
@@ -40,7 +40,7 @@ class TestSendEmailBaseCommand(CacheIsolationTestCase):  # lint-amnesty, pylint:
 
     def test_handle_all_sites(self):
         with patch.object(self.command, 'send_emails') as send_emails:
-            self.command.handle(site_domain_name=ALL_SITES, date='2017-09-29')
+            self.command.handle(site_domain_name=None, date='2017-09-29')
             expected_sites = Site.objects.all()
             for expected_site in expected_sites:
                 send_emails.assert_any_call(

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
@@ -10,8 +10,9 @@ from unittest.mock import DEFAULT, Mock, patch
 import ddt
 import pytz
 from django.conf import settings
+from django.contrib.sites.models import Site
 
-from openedx.core.djangoapps.schedules.management.commands import SendEmailBaseCommand
+from openedx.core.djangoapps.schedules.management.commands import SendEmailBaseCommand, ALL_SITES
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory, SiteFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 
@@ -33,8 +34,22 @@ class TestSendEmailBaseCommand(CacheIsolationTestCase):  # lint-amnesty, pylint:
             send_emails.assert_called_once_with(
                 self.site,
                 datetime.datetime(2017, 9, 29, tzinfo=pytz.UTC),
+                None,
                 None
             )
+
+    def test_handle_all_sites(self):
+        with patch.object(self.command, 'send_emails') as send_emails:
+            self.command.handle(site_domain_name=ALL_SITES, date='2017-09-29')
+            expected_sites = Site.objects.all()
+            for expected_site in expected_sites:
+                send_emails.assert_any_call(
+                    expected_site,
+                    datetime.datetime(2017, 9, 29, tzinfo=pytz.UTC),
+                    None,
+                    None
+                )
+            assert send_emails.call_count == len(expected_sites)
 
     def test_weeks_option(self):
         with patch.object(self.command, 'enqueue') as enqueue:

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -20,6 +20,7 @@ from edx_django_utils.monitoring import (
     set_custom_attribute
 )
 from eventtracking import tracker
+from importlib import import_module
 from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -103,7 +104,7 @@ class BinnedScheduleMessageBaseTask(ScheduleMessageBaseTask):
     task_instance = None
 
     @classmethod
-    def enqueue(cls, site, current_date, day_offset, override_recipient_email=None):  # lint-amnesty, pylint: disable=missing-function-docstring
+    def enqueue(cls, site, current_date, day_offset, override_recipient_email=None, override_middlewares=None):  # lint-amnesty, pylint: disable=missing-function-docstring
         set_code_owner_attribute_from_module(__name__)
         current_date = resolvers._get_datetime_beginning_of_day(current_date)  # lint-amnesty, pylint: disable=protected-access
 
@@ -120,6 +121,7 @@ class BinnedScheduleMessageBaseTask(ScheduleMessageBaseTask):
                 day_offset,
                 bin,
                 override_recipient_email,
+                override_middlewares,
             )
             cls.log_info('Launching task with args = %r', task_args)
             cls.task_instance.apply_async(
@@ -128,16 +130,17 @@ class BinnedScheduleMessageBaseTask(ScheduleMessageBaseTask):
             )
 
     def run(  # lint-amnesty, pylint: disable=arguments-differ
-        self, site_id, target_day_str, day_offset, bin_num, override_recipient_email=None,
+        self, site_id, target_day_str, day_offset, bin_num, override_recipient_email=None, override_middlewares=None,
     ):
         set_code_owner_attribute_from_module(__name__)
         site = Site.objects.select_related('configuration').get(id=site_id)
-        with emulate_http_request(site=site):
+        middleware_classes = [self.class_from_classpath(cls) for cls in override_middlewares] if override_middlewares else None
+        with emulate_http_request(site=site, middleware_classes=middleware_classes) as request:
             msg_type = self.make_message_type(day_offset)
-            _annotate_for_monitoring(msg_type, site, bin_num, target_day_str, day_offset)
+            _annotate_for_monitoring(msg_type, request.site, bin_num, target_day_str, day_offset)
             return self.resolver(  # lint-amnesty, pylint: disable=not-callable
                 self.async_send_task,
-                site,
+                request.site,
                 deserialize(target_day_str),
                 day_offset,
                 bin_num,
@@ -146,6 +149,11 @@ class BinnedScheduleMessageBaseTask(ScheduleMessageBaseTask):
 
     def make_message_type(self, day_offset):
         raise NotImplementedError
+    
+    def class_from_classpath(self, class_path):
+        module_name, klass = class_path.rsplit('.', 1)
+        module = import_module(module_name)
+        return getattr(module, klass)
 
 
 @shared_task(base=LoggedTask, ignore_result=True)

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -134,8 +134,8 @@ class BinnedScheduleMessageBaseTask(ScheduleMessageBaseTask):
     ):
         set_code_owner_attribute_from_module(__name__)
         site = Site.objects.select_related('configuration').get(id=site_id)
-        middleware_classes = [self.class_from_classpath(cls) for cls in override_middlewares] if override_middlewares else None
-        with emulate_http_request(site=site, middleware_classes=middleware_classes) as request:
+        middlewares = [self.class_from_classpath(cls) for cls in override_middlewares] if override_middlewares else None
+        with emulate_http_request(site=site, middleware_classes=middlewares) as request:
             msg_type = self.make_message_type(day_offset)
             _annotate_for_monitoring(msg_type, request.site, bin_num, target_day_str, day_offset)
             return self.resolver(  # lint-amnesty, pylint: disable=not-callable
@@ -149,7 +149,7 @@ class BinnedScheduleMessageBaseTask(ScheduleMessageBaseTask):
 
     def make_message_type(self, day_offset):
         raise NotImplementedError
-    
+
     def class_from_classpath(self, class_path):
         module_name, klass = class_path.rsplit('.', 1)
         module = import_module(module_name)

--- a/openedx/core/lib/celery/task_utils.py
+++ b/openedx/core/lib/celery/task_utils.py
@@ -45,7 +45,7 @@ def emulate_http_request(site=None, user=None, middleware_classes=None):
         _run_method_if_implemented(middleware, 'process_request', request)
 
     try:
-        yield
+        yield request
     except Exception as exc:
         for middleware in reversed(middleware_instances):
             _run_method_if_implemented(middleware, 'process_exception', request, exc)


### PR DESCRIPTION
## Description

This PR brings two changes to all the management command based on [SendEmailBaseCommand](https://github.com/openedx/edx-platform/blob/4d8e0556e1b0820adbe66c0441966a988c6c9a73/openedx/core/djangoapps/schedules/management/commands/__init__.py#L15):

1. Add ability to pass a list of middlewares to override the [default list of middlewares](https://github.com/openedx/edx-platform/blob/4d8e0556e1b0820adbe66c0441966a988c6c9a73/openedx/core/lib/celery/task_utils.py#L37-L40) used to emulate http requests in the [async message tasks](https://github.com/openedx/edx-platform/blob/4d8e0556e1b0820adbe66c0441966a988c6c9a73/openedx/core/djangoapps/schedules/tasks.py#L135) - This would be very helpful for instances running custom middlewares which they want to apply to recurring messages.
2. Add ability to run the management command for all sites by not passing any site domain. This would be helpful for instances running lots of sites who would otherwise need to run the same command individually for each site.


## Testing instructions

1. Set up this branch in a sandbox.
2. Set up two or more sites with `course_org_filter` setup for each site to map it to a unique org.
3. Create courses for each site/org and enroll in them.
4. Make sure [date conditions](https://docs.openedx.org/en/open-release-redwood.master/educators/migration_wip/16_manage_live_course/automatic_email.html) for recurring nudges are satisfied for the enrollments and run the [send_recurring_nudge](https://github.com/openedx/edx-platform/blob/4d8e0556e1b0820adbe66c0441966a988c6c9a73/openedx/core/djangoapps/schedules/management/commands/send_recurring_nudge.py#L12) command without passing any site domain name.
5. Make sure emails from each site/org are triggered.

## Other information

Private Ref : [BB-9883](https://tasks.opencraft.com/browse/BB-9883)