### PR TITLE
[backport] fix: handle AttributeError in exception clause (#36317)

### DIFF
--- a/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
+++ b/cms/djangoapps/contentstore/xblock_storage_handlers/view_handlers.py
@@ -1562,7 +1562,7 @@ def _get_release_date(xblock, user=None):
     reset_to_default = False
     try:
         reset_to_default = xblock.start.year < 1900
-    except ValueError:
+    except (ValueError, AttributeError):
         # For old mongo courses, accessing the start attribute calls `to_json()`,
         # which raises a `ValueError` for years < 1900.
         reset_to_default = True


### PR DESCRIPTION
(cherry picked from commit 988801f3c0779aebd8ef7898a543f5253d2275b7)

Please see https://github.com/openedx/edx-platform/pull/36317 for description.

Private-ref: https://tasks.opencraft.com/browse/BB-9924

## Testing instructions

- deploy this branch
- import a course that has a block containing a `start="null"` attribute
- view the course outline in the Authoring mfe
- verify the course outline loads without errors
- verify the block start date has been reset to the default (Jan 1, 2030 - but it should show as "Unscheduled" in the authoring ui)