### PR TITLE
fix: CourseLimitedStaffRole should not be able to access studio.

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -53,6 +53,7 @@ from common.djangoapps.student.roles import (
     GlobalStaff,
     UserBasedRole,
     OrgStaffRole,
+    strict_role_checking,
 )
 from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
 from common.djangoapps.util.string_utils import _has_non_ascii_characters
@@ -533,7 +534,9 @@ def _accessible_courses_list_from_groups(request):
         return not isinstance(course_access.course_id, CCXLocator)
 
     instructor_courses = UserBasedRole(request.user, CourseInstructorRole.ROLE).courses_with_role()
-    staff_courses = UserBasedRole(request.user, CourseStaffRole.ROLE).courses_with_role()
+    with strict_role_checking():
+        staff_courses = UserBasedRole(request.user, CourseStaffRole.ROLE).courses_with_role()
+
     all_courses = list(filter(filter_ccx, instructor_courses | staff_courses))
     courses_list = []
     course_keys = {}

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -24,6 +24,7 @@ from common.djangoapps.student.roles import (
     OrgInstructorRole,
     OrgLibraryUserRole,
     OrgStaffRole,
+    strict_role_checking,
 )
 
 # Studio permissions:
@@ -115,8 +116,9 @@ def get_user_permissions(user, course_key, org=None, service_variant=None):
             return STUDIO_NO_PERMISSIONS
 
     # Staff have all permissions except EDIT_ROLES:
-    if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):
-        return STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT
+    with strict_role_checking():
+        if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):
+            return STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT
 
     # Otherwise, for libraries, users can view only:
     if course_key and isinstance(course_key, LibraryLocator):


### PR DESCRIPTION
## Description

We previously fixed this when the CourseLimitedStaffRole was applied to a course, but did not handle the case where the role is applied to a user for a whole org.  The underlying issue is that the CourseLimitedStaffRole is a subclass of the CourseStaffRole, and much of the system assumes that subclasses are for giving more access, not less access.

To prevent that from happening for the case of the CourseLimitedStaffRole, when we do CourseStaffRole access checks, we use the strict_role_checking context manager to ensure that we're not accidentally granting the limited_staff role too much access.

## Supporting information

- https://tasks.opencraft.com/browse/BB-10385
- https://discuss.openedx.org/t/security-upcoming-security-release-for-edx-platform-on-2025-12-16/17787
- https://github.com/openedx/edx-platform/security/advisories/GHSA-rh64-vc2h-7wfj
- https://github.com/openedx/edx-platform/pull/37773/commits/9091801260359a07a465ecc3a1a89a19c2fc032e
