### PR TITLE
fix: commentable_ids should be list of ids rather then a comma separated string

### DIFF
--- a/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/thread.py
@@ -82,6 +82,8 @@ class Thread(models.Model):
             else:
                 if user_id := params.get('user_id'):
                     params['user_id'] = str(user_id)
+                if params['commentable_ids']:
+                    params['commentable_ids'] = params['commentable_ids'].split(',')
                 response = forum_api.get_user_threads(**params)
         else:
             response = utils.perform_request(


### PR DESCRIPTION
This along with upgrading the openedx-forum package to v0.3.2 or above will fix the issue where in-context discussions are not filtered to the current unit. 

note: this can be dropped when upgrading to teak


**Testing instructions:**
- Create a tutor Sumac environment .
- Create new discussion topics under different units. 
- They should all show up when you navigate to any unit. 
- Switch the sumac environment to this branch and upgrade the openedx-forum package to v0.3.2
- Check that the discussion topics in each unit correspond to the current unit.



private ref: https://tasks.opencraft.com/browse/BB-10387