### PR TITLE
fix: remove duplicate method due to rebasing error

### DIFF
--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -430,21 +430,6 @@ class BlocksInfoInCourseView(BlocksInCourseView):
                     }
                 })
 
-    def _extend_block_info_with_offline_data(blocks_info_data: Dict[str, Dict]) -> None:
-        """
-        Extends block info with offline download data.
-        If offline content is available for the block, adds the offline download data to the block info.
-        """
-        for block_id, block_info in blocks_info_data.items():
-            if offline_content_path := get_offline_block_content_path(usage_key=UsageKey.from_string(block_id)):
-                block_info.update({
-                    'offline_download': {
-                        'file_url': default_storage.url(offline_content_path),
-                        'last_modified': default_storage.get_modified_time(offline_content_path),
-                        'file_size': default_storage.size(offline_content_path)
-                    }
-                })
-
 
 @mobile_view()
 class CourseEnrollmentDetailsView(APIView):


### PR DESCRIPTION
## Description

This PR removes a duplicate method which was breaking the mobile api, and which was presumably caused due to rebasing error.

For reference, here's the [changes](https://github.com/open-craft/openedx-platform/commit/c773350024c1baa01be50b66302ef173ba13db51#diff-1ff7e8f63234d3d11e5c27da80f7665a8f42778adcbcfd8b4b7c38aaa0968e28R37-R417) from the original PR which was ported.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

[BB-10376](https://tasks.opencraft.com/browse/BB-10376)