### PR TITLE
fix: remove activation_key from account REST API response

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4314,7 +4314,6 @@ ACCOUNT_VISIBILITY_CONFIGURATION["admin_fields"] = (
         "secondary_email_enabled",
         "year_of_birth",
         "phone_number",
-        "activation_key",
         "pending_name_change",
     ]
 )

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -142,11 +142,6 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
         except ObjectDoesNotExist:
             account_recovery = None
 
-        try:
-            activation_key = user.registration.activation_key
-        except ObjectDoesNotExist:
-            activation_key = None
-
         data = {
             "username": user.username,
             "url": self.context.get('request').build_absolute_uri(
@@ -161,7 +156,6 @@ class UserReadOnlySerializer(serializers.Serializer):  # lint-amnesty, pylint: d
             "date_joined": user.date_joined.replace(microsecond=0),
             "last_login": user.last_login,
             "is_active": user.is_active,
-            "activation_key": activation_key,
             "bio": None,
             "country": None,
             "state": None,

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -635,7 +635,6 @@ class AccountSettingsOnCreationTest(CreateAccountMixin, TestCase):
             'id': user.id,
             'name': self.USERNAME,
             'verified_name': None,
-            'activation_key': user.registration.activation_key,
             'gender': None, 'goals': '',
             'is_active': False,
             'level_of_education': None,

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -358,8 +358,8 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
     """
 
     ENABLED_CACHES = ['default']
-    TOTAL_QUERY_COUNT = 26
-    FULL_RESPONSE_FIELD_COUNT = 29
+    TOTAL_QUERY_COUNT = 25
+    FULL_RESPONSE_FIELD_COUNT = 28
 
     def setUp(self):
         super().setUp()
@@ -488,19 +488,19 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
         ("client", "user"),
     )
     @ddt.unpack
-    def test_regsitration_activation_key(self, api_client, user):
+    def test_regsitration_activation_key_not_exposed(self, api_client, user):
         """
-        Test that registration activation key has a value.
+        Test that activation_key is NOT returned in the account API response.
 
-        UserFactory does not auto-generate registration object for the test users.
-        It is created only for users that signup via email/API.  Therefore, activation key has to be tested manually.
+        The activation_key is a secret used for email verification and must not be
+        exposed via the API, as doing so allows bypassing email verification.
         """
         self.create_user_registration(self.user)
 
         client = self.login_client(api_client, user)
         response = self.send_get(client)
 
-        assert response.data["activation_key"] is not None
+        assert "activation_key" not in response.data
 
     def test_successful_get_account_by_email(self):
         """
@@ -811,12 +811,12 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
             assert data['time_zone'] is None
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        verify_get_own_information(self._get_num_queries(24))
+        verify_get_own_information(self._get_num_queries(23))
 
         # Now make sure that the user can get the same information, even if not active
         self.user.is_active = False
         self.user.save()
-        verify_get_own_information(self._get_num_queries(16))
+        verify_get_own_information(self._get_num_queries(15))
 
     def test_get_account_empty_string(self):
         """
@@ -831,7 +831,7 @@ class TestAccountsAPI(FilteredQueryCountMixin, CacheIsolationTestCase, UserAPITe
         legacy_profile.save()
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        with self.assertNumQueries(self._get_num_queries(24), table_ignorelist=WAFFLE_TABLES):
+        with self.assertNumQueries(self._get_num_queries(23), table_ignorelist=WAFFLE_TABLES):
             response = self.send_get(self.client)
         for empty_field in ("level_of_education", "gender", "country", "state", "bio",):
             assert response.data[empty_field] is None


### PR DESCRIPTION
cherry-pick from upstream: https://github.com/openedx/openedx-platform/pull/38241

The activation_key field was exposed in /api/user/v1/accounts/{username}, allowing an attacker to bypass email verification by combining two behaviors:
1. OAuth2 password grant issues tokens to inactive users (intentional)
2. activation_key returned in API response (the vulnerability)

An attacker could register, get an OAuth2 token, read the activation_key from the API, then GET /activate/{key} to activate without email access.

Fix: remove activation_key from UserReadOnlySerializer.to_representation() and from ACCOUNT_VISIBILITY_CONFIGURATION["admin_fields"] (which controls the field whitelist in _filter_fields — listed fields default to None even if absent from the serializer data dict).

Reported by Daniel Baillo via the Open edX security working group.