### PR TITLE
feat: Map custom eSHE Instructor and Teaching Assistant roles to 'Staff'

### DIFF
--- a/lms/djangoapps/discussion/rest_api/serializers.py
+++ b/lms/djangoapps/discussion/rest_api/serializers.py
@@ -33,6 +33,8 @@ from lms.djangoapps.discussion.rest_api.utils import (
     get_course_staff_users_list,
     get_moderator_users_list,
     get_course_ta_users_list,
+    get_course_eshe_instructors,
+    get_course_teaching_assistants,
 )
 from openedx.core.djangoapps.discussions.models import DiscussionTopicLink
 from openedx.core.djangoapps.discussions.utils import get_group_names_by_id
@@ -67,6 +69,11 @@ def get_context(course, request, thread=None):
     course_staff_user_ids = get_course_staff_users_list(course.id)
     moderator_user_ids = get_moderator_users_list(course.id)
     ta_user_ids = get_course_ta_users_list(course.id)
+
+    custom_staff_role_user_ids = set(
+        get_course_eshe_instructors(course.id) + get_course_teaching_assistants(course.id)
+        )
+
     requester = request.user
     cc_requester = CommentClientUser.from_django_user(requester).retrieve(course_id=course.id)
     cc_requester["course_id"] = course.id
@@ -82,6 +89,7 @@ def get_context(course, request, thread=None):
         "moderator_user_ids": moderator_user_ids,
         "course_staff_user_ids": course_staff_user_ids,
         "ta_user_ids": ta_user_ids,
+        "custom_staff_role_user_ids": custom_staff_role_user_ids,
         "cc_requester": cc_requester,
         "has_moderation_privilege": has_moderation_privilege,
         "is_global_staff": is_global_staff,
@@ -207,11 +215,12 @@ class _ContentSerializer(serializers.Serializer):
         with the given id.
         """
         is_staff = user_id in self.context["course_staff_user_ids"]
+        is_custom_staff_role = user_id in self.context["custom_staff_role_user_ids"]
         is_moderator = user_id in self.context["moderator_user_ids"]
         is_ta = user_id in self.context["ta_user_ids"]
 
         return (
-            "Staff" if is_staff else
+            "Staff" if is_staff or is_custom_staff_role else
             "Moderator" if is_moderator else
             "Community TA" if is_ta else
             None

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -19,7 +19,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_MODERATOR,
     Role
 )
-
+from common.djangoapps.student.roles import ( eSHEInstructorRole, CourseStaffRole)
 
 class AttributeDict(dict):
     """
@@ -379,3 +379,18 @@ def is_posting_allowed(posting_restrictions: str, blackout_schedules: List):
         return not any(schedule["start"] <= now <= schedule["end"] for schedule in blackout_schedules)
     else:
         return False
+
+
+def get_course_eshe_instructors(course_key):
+    """
+    Return a list of user ids for users with custom eSHE Instructor Role.
+    """
+    role = eSHEInstructorRole(course_key)
+    return [user.id for user in role.users_with_role()]
+
+def get_course_teaching_assistants(course_key):
+    """
+    Return a list of user ids for users with custom TeachingAssistantRole.
+    """
+    role = CourseStaffRole(course_key)
+    return [user.id for user in role.users_with_role()]


### PR DESCRIPTION
This PR demonstrates an implementation to show the Staff label on discussion posts for custom roles such as eSHE Instructor and Teaching Assistant. The result, as shown in the figure below, shows the identity label of Staff even though the user has no is_staff flag set.

<img width="503" height="857" alt="Screenshot 2026-06-15 at 8 05 12 PM" src="https://github.com/user-attachments/assets/a31665bd-49c4-424d-a588-c2132cafcfd6" />
