### PR TITLE
Enable Studio course content search for eSHE Instructor and Teaching Assistant roles

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -53,6 +53,8 @@ from common.djangoapps.student.roles import (
     GlobalStaff,
     UserBasedRole,
     OrgStaffRole,
+    eSHEInstructorRole,
+    TeachingAssistantRole,
     strict_role_checking,
 )
 from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
@@ -537,7 +539,9 @@ def _accessible_courses_list_from_groups(request):
     with strict_role_checking():
         staff_courses = UserBasedRole(request.user, CourseStaffRole.ROLE).courses_with_role()
 
-    all_courses = list(filter(filter_ccx, instructor_courses | staff_courses))
+    eshe_instructor_courses = UserBasedRole(request.user, eSHEInstructorRole.ROLE).courses_with_role()
+    ta_courses = UserBasedRole(request.user, TeachingAssistantRole.ROLE).courses_with_role()
+    all_courses = list(filter(filter_ccx, instructor_courses | staff_courses | eshe_instructor_courses | ta_courses))
     courses_list = []
     course_keys = {}
 

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -24,6 +24,8 @@ from common.djangoapps.student.roles import (
     OrgInstructorRole,
     OrgLibraryUserRole,
     OrgStaffRole,
+    eSHEInstructorRole,
+    TeachingAssistantRole,
     strict_role_checking,
 )
 
@@ -100,6 +102,14 @@ def get_user_permissions(user, course_key, org=None, service_variant=None):
         return all_perms
     if course_key and user_has_role(user, CourseInstructorRole(course_key)):
         return all_perms
+    
+    # Allow custom eSHE roles to access course detail in studio
+    # We have offered all permissions equivalent to Staff user
+    # This is to demonstrate how the custom roles can be elevated, NOT PRODUCTION READY
+    if course_key:
+        if eSHEInstructorRole(course_key).has_user(user) or TeachingAssistantRole(course_key).has_user(user):
+            return STUDIO_EDIT_ROLES | STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT
+
     # HACK: Limited Staff should not have studio read access. However, since many LMS views depend on the
     #  `has_course_author_access` check and `course_author_access_required` decorator, we have to allow write access
     #  by returning STUDIO_EDIT_CONTENT, if the request is made from LMS, until the permissions become more granular.

--- a/openedx/core/djangoapps/content/search/models.py
+++ b/openedx/core/djangoapps/content/search/models.py
@@ -8,7 +8,7 @@ from opaque_keys.edx.django.models import LearningContextKeyField
 from rest_framework.request import Request
 
 from common.djangoapps.student.role_helpers import get_course_roles
-from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole
+from common.djangoapps.student.roles import CourseInstructorRole, CourseStaffRole, eSHEInstructorRole, TeachingAssistantRole
 from openedx.core.djangoapps.content_libraries.api import get_libraries_for_user
 
 
@@ -48,7 +48,7 @@ def get_access_ids_for_request(request: Request, omit_orgs: list[str] = None) ->
         role.course_id
         for role in course_roles
         if (
-            role.role in [CourseInstructorRole.ROLE, CourseStaffRole.ROLE]
+            role.role in [eSHEInstructorRole.ROLE, TeachingAssistantRole.ROLE, CourseInstructorRole.ROLE, CourseStaffRole.ROLE]
             and role.org not in omit_orgs
         )
     ])


### PR DESCRIPTION
**NOTE: THIS DRAFT PR IS FOR DEMONSTRATION ONLY, NOT FOR PRODUCTION**

The Studio course content search feature is not returning results for users with custom eSHE roles. Although these roles inherit from CourseStaffRole and had Studio access, the search backend filtering logic excludes courses for users with custom roles. Additionally, some Studio API endpoints returned 403 errors because the permission checks did not recognize the custom roles.

This PR demonstrates how the eSHE custom roles (eSHE Instructors and Teaching Assistants) can use the Studio course content search feature. For the search function to be operational for the custom roles, this PR also demonstrates how to elevate access permissions for the custom roles.
