### PR TITLE
fix: Reapply CourseLimitedStaffRole update and add eSHE Instructor permissions

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -53,6 +53,7 @@ from common.djangoapps.student.roles import (
     GlobalStaff,
     UserBasedRole,
     OrgStaffRole,
+    strict_role_checking,
 )
 from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
 from common.djangoapps.util.string_utils import _has_non_ascii_characters
@@ -533,7 +534,9 @@ def _accessible_courses_list_from_groups(request):
         return not isinstance(course_access.course_id, CCXLocator)
 
     instructor_courses = UserBasedRole(request.user, CourseInstructorRole.ROLE).courses_with_role()
-    staff_courses = UserBasedRole(request.user, CourseStaffRole.ROLE).courses_with_role()
+    with strict_role_checking():
+        staff_courses = UserBasedRole(request.user, CourseStaffRole.ROLE).courses_with_role()
+
     all_courses = list(filter(filter_ccx, instructor_courses | staff_courses))
     courses_list = []
     course_keys = {}

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -53,6 +53,7 @@ from common.djangoapps.student.roles import (
     GlobalStaff,
     UserBasedRole,
     OrgStaffRole,
+    eSHEInstructorRole,
     strict_role_checking,
 )
 from common.djangoapps.util.json_request import JsonResponse, JsonResponseBadRequest, expect_json
@@ -537,7 +538,10 @@ def _accessible_courses_list_from_groups(request):
     with strict_role_checking():
         staff_courses = UserBasedRole(request.user, CourseStaffRole.ROLE).courses_with_role()
 
-    all_courses = list(filter(filter_ccx, instructor_courses | staff_courses))
+    # Courses for eSHE instructors
+    eshe_courses = UserBasedRole(request.user, eSHEInstructorRole.ROLE).courses_with_role()
+
+    all_courses = list(filter(filter_ccx, instructor_courses | staff_courses | eshe_courses))
     courses_list = []
     course_keys = {}
 

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -24,6 +24,7 @@ from common.djangoapps.student.roles import (
     OrgInstructorRole,
     OrgLibraryUserRole,
     OrgStaffRole,
+    strict_role_checking,
 )
 
 # Studio permissions:
@@ -115,8 +116,9 @@ def get_user_permissions(user, course_key, org=None, service_variant=None):
             return STUDIO_NO_PERMISSIONS
 
     # Staff have all permissions except EDIT_ROLES:
-    if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):
-        return STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT
+    with strict_role_checking():
+        if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):
+            return STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT
 
     # Otherwise, for libraries, users can view only:
     if course_key and isinstance(course_key, LibraryLocator):

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -24,6 +24,7 @@ from common.djangoapps.student.roles import (
     OrgInstructorRole,
     OrgLibraryUserRole,
     OrgStaffRole,
+    eSHEInstructorRole,
     strict_role_checking,
 )
 
@@ -119,6 +120,10 @@ def get_user_permissions(user, course_key, org=None, service_variant=None):
     with strict_role_checking():
         if OrgStaffRole(org=org).has_user(user) or (course_key and user_has_role(user, CourseStaffRole(course_key))):
             return STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT
+
+    # eSHEInstructor-specific permissions
+    if course_key and user_has_role(user, eSHEInstructorRole(course_key)):
+        return STUDIO_VIEW_USERS | STUDIO_EDIT_CONTENT | STUDIO_VIEW_CONTENT
 
     # Otherwise, for libraries, users can view only:
     if course_key and isinstance(course_key, LibraryLocator):


### PR DESCRIPTION
## Description

This PR reapplies the CourseLimitedStaffRole security fix changes and adds the necessary permissions for the eSHE Instructor role.

## Supporting information

- Private ref: https://tasks.opencraft.com/browse/BB-10500

## Testing instructions

1. Create a test user and course.
2. Add the user as an eSHE Instructor to the course.
3. Log in to Studio with the test user and check the course shows in the list.
4. Confirm the test user can also see the course outline and make changes.
5. Verify the test user has access to the course's Gradebook.