### PR TITLE
chore(teak): backport security patch

### DIFF
--- a/openedx/core/djangoapps/notifications/base_notification.py
+++ b/openedx/core/djangoapps/notifications/base_notification.py
@@ -1,6 +1,7 @@
 """
 Base setup for Notification Apps and Types.
 """
+from django.utils.html import escape
 from django.utils.translation import gettext_lazy as _
 
 from .email_notifications import EmailCadence
@@ -10,6 +11,13 @@ from ..django_comment_common.models import FORUM_ROLE_ADMINISTRATOR, FORUM_ROLE_
 from .notification_content import get_notification_type_context_function
 
 FILTER_AUDIT_EXPIRED_USERS_WITH_NO_ROLE = 'filter_audit_expired_users_with_no_role'
+
+# Context keys whose values are used as HTML tag names by content_templates
+# (e.g. `<{p}>...<{strong}>{post_title}</{strong}></{p}>`). These must NOT be
+# HTML-escaped before `template.format(**context)`; every other context value
+# must be, since it typically comes from user input (thread title, username,
+# etc.). See get_notification_content below.
+_STRUCTURAL_CONTEXT_KEYS = frozenset({'p', 'strong'})
 
 COURSE_NOTIFICATION_TYPES = {
     'new_comment_on_response': {
@@ -524,8 +532,16 @@ def get_notification_content(notification_type, context):
         context = context_function(context)
 
         if template:
-            # Handle grouped templates differently by modifying the context using a different function.
-            return template.format(**context)
+            # HTML-escape every context value except the structural tag-name
+            # keys, so that user-controlled input (post_title, replier_name,
+            # etc.) cannot inject `<style>` / `<script>` / other HTML into
+            # notification.content — which is rendered with `|safe` in the
+            # digest and batched email templates.
+            safe_context = {
+                key: value if key in _STRUCTURAL_CONTEXT_KEYS else escape(value)
+                for key, value in context.items()
+            }
+            return template.format(**safe_context)
 
     return ''
 

--- a/openedx/core/djangoapps/notifications/tests/test_base_notification.py
+++ b/openedx/core/djangoapps/notifications/tests/test_base_notification.py
@@ -1,6 +1,8 @@
 """
 Tests for base_notification
 """
+import pytest
+
 from common.djangoapps.student.tests.factories import UserFactory
 from openedx.core.djangoapps.notifications import base_notification, models
 from openedx.core.djangoapps.notifications.models import (
@@ -298,3 +300,40 @@ class NotificationPreferenceValidationTest(ModuleStoreTestCase):
                 assert isinstance(notification_type[key], str)
             for key in bool_keys:
                 assert isinstance(notification_type[key], bool)
+
+
+@pytest.mark.parametrize(
+    ('user_input', 'escaped'),
+    [
+        ('<style>body{background:red}</style>evil', '&lt;style&gt;body{background:red}&lt;/style&gt;evil'),
+        ('<script>alert(1)</script>', '&lt;script&gt;alert(1)&lt;/script&gt;'),
+        ('AT&T "quoted"', 'AT&amp;T &quot;quoted&quot;'),
+    ],
+)
+def test_get_notification_content_escapes_user_input(user_input, escaped):
+    """
+    Regression test for GHSA-rv5w-f4r5-h77g: user-controlled context values
+    must be HTML-escaped before being interpolated into a content_template
+    via `str.format`. Structural context keys (`p`, `strong`) are exempt so
+    the template can still emit real <p>/<strong> tags.
+    """
+    context = {'replier_name': 'alice', 'post_title': user_input}
+    content = base_notification.get_notification_content('new_response', context)
+    assert '<style>' not in content
+    assert '<script>' not in content
+    assert escaped in content
+
+
+def test_get_notification_content_preserves_structural_tags():
+    """
+    Companion to test_get_notification_content_escapes_user_input: verify
+    that the structural `p` and `strong` keys still produce real HTML tags
+    after the escape pass, and that innocuous user input renders as plain
+    text alongside them.
+    """
+    context = {'replier_name': 'alice', 'post_title': 'Hello world'}
+    content = base_notification.get_notification_content('new_response', context)
+    assert '<p>' in content
+    assert '</p>' in content
+    assert '<strong>alice</strong>' in content
+    assert '<strong>Hello world</strong>' in content

--- a/openedx/core/lib/extract_archive.py
+++ b/openedx/core/lib/extract_archive.py
@@ -7,7 +7,7 @@ http://stackoverflow.com/questions/10060069/safely-extract-zip-or-tar-using-pyth
 """
 
 import logging
-from os.path import abspath, dirname
+from os.path import abspath, commonpath, dirname
 from os.path import join as joinpath
 from os.path import realpath
 from typing import List, Union
@@ -30,8 +30,18 @@ def resolved(rpath):
 def _is_bad_path(path, base):
     """
     Is (the canonical absolute path of) `path` outside `base`?
+
+    Uses ``os.path.commonpath`` for a segment-aware containment check so that
+    sibling directories whose names happen to extend ``base`` as a string
+    prefix (e.g. ``<base>evil/...``) are correctly classified as outside.
     """
-    return not resolved(joinpath(base, path)).startswith(base)
+    target = resolved(joinpath(base, path))
+    try:
+        return commonpath([target, base]) != base
+    except ValueError:
+        # commonpath raises when paths are incomparable (e.g. mixed absolute
+        # and relative, or different drives on Windows). Treat as bad.
+        return True
 
 
 def _is_bad_link(info, base):

--- a/openedx/core/lib/tests/test_extract_archive.py
+++ b/openedx/core/lib/tests/test_extract_archive.py
@@ -1,0 +1,93 @@
+"""
+Tests for openedx.core.lib.extract_archive.
+
+The path-containment helpers must treat ``base`` as a directory boundary, not
+a raw string prefix: a sibling whose name extends ``base`` as a string prefix
+(e.g. ``<parent>/foo_evil/x`` next to ``<parent>/foo``) is *outside* ``base``.
+These tests pin that boundary down at the helper level and end-to-end through
+``safe_extractall``.
+"""
+
+import io
+import os
+import tarfile
+import tempfile
+
+import pytest
+from django.core.exceptions import SuspiciousOperation
+from django.test import override_settings
+
+from openedx.core.lib.extract_archive import _is_bad_path, safe_extractall
+
+# Direct tests of the path-containment helper. No Django settings needed.
+
+def test_is_bad_path_prefix_bypass_is_rejected():
+    """
+    A sibling path whose name extends the base's name as a raw string prefix
+    (e.g. ``<parent>/Y29evil/file`` vs base ``<parent>/Y29``) is outside
+    ``base`` and must be flagged as bad.
+    """
+    with tempfile.TemporaryDirectory() as parent:
+        base = os.path.join(parent, "Y29")
+        os.mkdir(base)
+        assert _is_bad_path("../Y29evil/file", base) is True
+
+
+def test_is_bad_path_inside_base_is_accepted():
+    with tempfile.TemporaryDirectory() as parent:
+        base = os.path.join(parent, "Y29")
+        os.mkdir(base)
+        assert _is_bad_path("nested/file.txt", base) is False
+
+
+def test_is_bad_path_traversal_outside_base_is_rejected():
+    with tempfile.TemporaryDirectory() as parent:
+        base = os.path.join(parent, "Y29")
+        os.mkdir(base)
+        assert _is_bad_path("../../etc/passwd", base) is True
+
+
+# End-to-end tests of safe_extractall against crafted .tar.gz archives.
+
+def _add_file(tar, name, content=b""):
+    info = tarfile.TarInfo(name=name)
+    info.size = len(content)
+    tar.addfile(info, io.BytesIO(content))
+
+
+def _add_symlink(tar, name, linkname):
+    info = tarfile.TarInfo(name=name)
+    info.type = tarfile.SYMTYPE
+    info.linkname = linkname
+    tar.addfile(info)
+
+
+def test_safe_extractall_blocks_file_entry_with_prefix_bypass(tmp_path):
+    root = str(tmp_path)
+    extract_dir = os.path.join(root, "Y29")
+    os.mkdir(extract_dir)
+    archive = os.path.join(root, "malicious.tar.gz")
+    with tarfile.open(archive, "w:gz") as tar:
+        _add_file(tar, "../Y29evil/sentinel.txt", b"owned")
+
+    with override_settings(GITHUB_REPO_ROOT=root):
+        with pytest.raises(SuspiciousOperation):
+            safe_extractall(archive, extract_dir)
+
+    escape_target = os.path.join(root, "Y29evil", "sentinel.txt")
+    assert not os.path.exists(escape_target)
+
+
+def test_safe_extractall_blocks_symlink_target_with_prefix_bypass(tmp_path):
+    root = str(tmp_path)
+    extract_dir = os.path.join(root, "Y29")
+    os.mkdir(extract_dir)
+    archive = os.path.join(root, "malicious.tar.gz")
+    # symlink inside extract_dir pointing at a sibling whose name extends
+    # extract_dir's basename as a string prefix.
+    with tarfile.open(archive, "w:gz") as tar:
+        _add_symlink(tar, name="link", linkname="../Y29evil/secret")
+
+    with override_settings(GITHUB_REPO_ROOT=root):
+        with pytest.raises(SuspiciousOperation):
+            safe_extractall(archive, extract_dir)

--- a/openedx/core/lib/tests/test_extract_archive.py
+++ b/openedx/core/lib/tests/test_extract_archive.py
@@ -19,6 +19,7 @@ from django.test import override_settings
 
 from openedx.core.lib.extract_archive import _is_bad_path, safe_extractall
 
+
 # Direct tests of the path-containment helper. No Django settings needed.
 
 def test_is_bad_path_prefix_bypass_is_rejected():


### PR DESCRIPTION
This backports fixes for [GHSA-rv5w-f4r5-h77g](https://github.com/openedx/openedx-platform/security/advisories/GHSA-rv5w-f4r5-h77g) and [GHSA-6cmm-8875-5pcw](https://github.com/openedx/openedx-platform/security/advisories/GHSA-6cmm-8875-5pcw) to the common Teak branch.

Private-ref: [BB-11021](https://tasks.opencraft.com/browse/BB-11021)