### PR TITLE
Verawood release branch

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -233,6 +233,17 @@ ENABLE_HIDE_FROM_TOC_UI = False
 # .. toggle_creation_date: 2024-09-02
 IN_CONTEXT_DISCUSSION_ENABLED_DEFAULT = True
 
+# .. toggle_name: settings.ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Whether to enable the legacy MD5 hashing algorithm to generate anonymous user id
+#   instead of the newer SHAKE128 hashing algorithm
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-08-08
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
+ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID = False
+
 # .. toggle_name: ENABLE_COPPA_COMPLIANCE
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False

--- a/common/djangoapps/student/models/user.py
+++ b/common/djangoapps/student/models/user.py
@@ -157,12 +157,21 @@ def anonymous_id_for_user(user, course_id):
         # function: Rotate at will, since the hashes are stored and
         # will not change.
         # include the secret key as a salt, and to make the ids unique across different LMS installs.
-        hasher = hashlib.shake_128()
+        legacy_hash_enabled = settings.FEATURES.get('ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID', False)
+        if legacy_hash_enabled:
+            # Use legacy MD5 algorithm if flag enabled
+            hasher = hashlib.md5()
+        else:
+            hasher = hashlib.shake_128()
         hasher.update(settings.SECRET_KEY.encode('utf8'))
         hasher.update(str(user.id).encode('utf8'))
         if course_id:
             hasher.update(str(course_id).encode('utf-8'))
-        anonymous_user_id = hasher.hexdigest(16)
+
+        if legacy_hash_enabled:
+            anonymous_user_id = hasher.hexdigest()
+        else:
+            anonymous_user_id = hasher.hexdigest(16)  # pylint: disable=too-many-function-args
 
         try:
             AnonymousUserId.objects.create(

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -440,7 +440,7 @@ class GlobalStaff(AccessRole):
     The global staff role
     """
     def has_user(self, user):
-        return bool(user and user.is_staff)
+        return bool(user and (user.is_superuser or user.is_staff))
 
     def add_users(self, *users):
         for user in users:
@@ -732,6 +732,25 @@ class CourseLimitedStaffRole(CourseStaffRole):
     """A Staff member of a course without access to Studio."""
 
     ROLE = 'limited_staff'
+    BASE_ROLE = CourseStaffRole.ROLE
+
+
+@register_access_role
+class eSHEInstructorRole(CourseStaffRole):
+    """A Staff member of a course without access to the membership tab and enrollment-related operations."""
+
+    ROLE = 'eshe_instructor'
+    BASE_ROLE = CourseStaffRole.ROLE
+
+
+@register_access_role
+class TeachingAssistantRole(CourseStaffRole):
+    """
+    A Staff member of a course without access to the membership tab, enrollment-related operations and
+    grade-related operations.
+    """
+
+    ROLE = 'teaching_assistant'
     BASE_ROLE = CourseStaffRole.ROLE
 
 

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -44,6 +44,8 @@ from common.djangoapps.student.roles import (
     OrgInstructorRole,
     OrgStaffRole,
     RoleCache,
+    TeachingAssistantRole,
+    eSHEInstructorRole,
     get_authz_compat_course_access_roles_for_user,
     get_role_cache_key_for_course,
 )
@@ -391,6 +393,8 @@ class RoleCacheTestCase(TestCase):  # lint-amnesty, pylint: disable=missing-clas
     ROLES = (
         (CourseStaffRole(IN_KEY), ('staff', IN_KEY, 'edX')),
         (CourseLimitedStaffRole(IN_KEY), ('limited_staff', IN_KEY, 'edX')),
+        (eSHEInstructorRole(IN_KEY), ('eshe_instructor', IN_KEY, 'edX')),
+        (TeachingAssistantRole(IN_KEY), ('teaching_assistant', IN_KEY, 'edX')),
         (CourseInstructorRole(IN_KEY), ('instructor', IN_KEY, 'edX')),
         (OrgStaffRole(IN_KEY.org), ('staff', None, 'edX')),
         (CourseFinanceAdminRole(IN_KEY), ('finance_admin', IN_KEY, 'edX')),

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -1135,6 +1135,17 @@ class AnonymousLookupTable(ModuleStoreTestCase):
             assert anonymous_id != new_anonymous_id
             assert self.user == user_by_anonymous_id(new_anonymous_id)
 
+    def test_enable_legacy_hash_flag(self):
+        """Test that different anonymous id returned if ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID enabled."""
+        CourseEnrollment.enroll(self.user, self.course.id)
+        anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+        with patch.dict(settings.FEATURES, ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID=True):
+            # Recreate user object to clear cached anonymous id.
+            self.user = User.objects.get(pk=self.user.id)
+            AnonymousUserId.objects.filter(user=self.user).filter(course_id=self.course.id).delete()
+            new_anonymous_id = anonymous_id_for_user(self.user, self.course.id)
+            assert anonymous_id != new_anonymous_id
+
 
 @skip_unless_lms
 @patch('openedx.core.djangoapps.programs.utils.get_programs')

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -318,6 +318,8 @@ class DatesTab(EnrolledTab):
 
     @classmethod
     def is_enabled(cls, course, user=None):
+        if settings.FEATURES.get('DISABLE_DATES_TAB'):
+            return False
         if not super().is_enabled(course, user=user):
             return False
         dates_tab = CourseTabList.get_tab_by_id(course.tabs, 'dates')

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -895,6 +895,19 @@ class DatesTabTestCase(TabListTestCase):
                 num_dates_tabs += 1
         assert num_dates_tabs == 1
 
+    def test_dates_tab_is_enabled_by_default(self):
+        """Test dates tab is enabled by default."""
+        tab = DatesTab({'type': DatesTab.type, 'name': 'dates'})
+        user = self.create_mock_user()
+        assert self.is_tab_enabled(tab, self.course, user)
+
+    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_DATES_TAB": True})
+    def test_dates_tab_disabled_by_feature_flag(self):
+        """Test dates tab is disabled by the feature flag."""
+        tab = DatesTab({'type': DatesTab.type, 'name': 'dates'})
+        user = self.create_mock_user()
+        assert not self.is_tab_enabled(tab, self.course, user)
+
     @patch('common.djangoapps.student.models.course_enrollment.CourseEnrollment.is_enrolled')
     def test_dates_tab_respects_hide_flag(self, is_enrolled):
         """Test that the dates tab respects the hide flag."""

--- a/lms/djangoapps/instructor/access.py
+++ b/lms/djangoapps/instructor/access.py
@@ -22,6 +22,8 @@ from common.djangoapps.student.roles import (
     CourseInstructorRole,
     CourseLimitedStaffRole,
     CourseStaffRole,
+    TeachingAssistantRole,
+    eSHEInstructorRole,
 )
 from lms.djangoapps.instructor.enrollment import enroll_email, get_email_params
 from openedx.core.djangoapps.django_comment_common.models import (
@@ -39,6 +41,8 @@ ROLES = {
     'instructor': CourseInstructorRole,
     'staff': CourseStaffRole,
     'limited_staff': CourseLimitedStaffRole,
+    'eshe_instructor': eSHEInstructorRole,
+    'teaching_assistant': TeachingAssistantRole,
     'ccx_coach': CourseCcxCoachRole,
     'data_researcher': CourseDataResearcherRole,
 }
@@ -55,7 +59,7 @@ FORUM_ROLES = (
 
 INSTRUCTOR_DASHBOARD_ROLE_SORT_ORDER = (
     'staff', 'limited_staff', 'instructor', 'beta', 'data_researcher',
-    *FORUM_ROLES, 'ccx_coach',
+    *FORUM_ROLES, 'ccx_coach', 'teaching_assistant', 'eshe_instructor',
 )
 
 ROLE_DISPLAY_NAMES = {
@@ -63,6 +67,8 @@ ROLE_DISPLAY_NAMES = {
     'staff': _('Staff'),
     'limited_staff': _('Limited Staff'),
     'beta': _('Beta Tester'),
+    'eshe_instructor': _('e-SHE Instructor'),
+    'teaching_assistant': _('Teaching Assistant'),
     'ccx_coach': _('CCX Coach'),
     'data_researcher': _('Data Researcher'),
     FORUM_ROLE_ADMINISTRATOR: _('Discussion Admin'),

--- a/lms/djangoapps/instructor/permissions.py
+++ b/lms/djangoapps/instructor/permissions.py
@@ -44,6 +44,21 @@ VIEW_DASHBOARD = 'instructor.dashboard'
 VIEW_ENROLLMENTS = 'instructor.view_enrollments'
 VIEW_FORUM_MEMBERS = 'instructor.view_forum_members'
 
+# Due to how the roles iheritance is implemented currently, eshe_instructor and teaching_assistant have implicit
+# staff access, but unlike staff, they shouldn't be able to enroll and do grade-related operations as per client's
+# requirements. At the same time, all other staff-derived roles, like Limited Staff, should be able to enroll students.
+# This solution is far from perfect, but it's probably the best we can do untill the roles system is reworked.
+_is_teaching_assistant = HasRolesRule('teaching_assistant')
+_is_eshe_instructor = HasRolesRule('eshe_instructor')
+_is_eshe_instructor_or_teaching_assistant = _is_teaching_assistant | _is_eshe_instructor
+is_staff_but_not_teaching_assistant = (
+    (_is_teaching_assistant & HasAccessRule('staff', strict=True)) |
+    (~_is_teaching_assistant & HasAccessRule('staff'))
+)
+is_staff_but_not_eshe_instructor_or_teaching_assistant = (
+    (_is_eshe_instructor_or_teaching_assistant & HasAccessRule('staff', strict=True)) |
+    (~_is_eshe_instructor_or_teaching_assistant & HasAccessRule('staff'))
+)
 
 perms[ALLOW_STUDENT_TO_BYPASS_ENTRANCE_EXAM] = HasAccessRule('staff')
 perms[ASSIGN_TO_COHORTS] = HasAccessRule('staff')
@@ -57,17 +72,17 @@ perms[START_CERTIFICATE_GENERATION] = is_staff | HasAccessRule('instructor')
 perms[START_CERTIFICATE_REGENERATION] = is_staff | HasAccessRule('instructor')
 perms[CERTIFICATE_EXCEPTION_VIEW] = is_staff | HasAccessRule('instructor')
 perms[CERTIFICATE_INVALIDATION_VIEW] = is_staff | HasAccessRule('instructor')
-perms[GIVE_STUDENT_EXTENSION] = HasAccessRule('staff')
+perms[GIVE_STUDENT_EXTENSION] = is_staff_but_not_teaching_assistant
 perms[VIEW_ISSUED_CERTIFICATES] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 # only global staff or those with the data_researcher role can access the data download tab
 # HasAccessRule('staff') also includes course staff
 perms[CAN_RESEARCH] = is_staff | HasRolesRule('data_researcher')
-perms[CAN_ENROLL] = HasAccessRule('staff')
+perms[CAN_ENROLL] = is_staff_but_not_eshe_instructor_or_teaching_assistant
 perms[CAN_BETATEST] = HasAccessRule('instructor')
 perms[ENROLLMENT_REPORT] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 perms[VIEW_COUPONS] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 perms[EXAM_RESULTS] = HasAccessRule('staff')
-perms[OVERRIDE_GRADES] = HasAccessRule('staff')
+perms[OVERRIDE_GRADES] = is_staff_but_not_teaching_assistant
 perms[SHOW_TASKS] = HasAccessRule('staff') | HasRolesRule('data_researcher')
 perms[EMAIL] = HasAccessRule('staff')
 perms[RESCORE_EXAMS] = HasAccessRule('instructor')

--- a/lms/djangoapps/instructor/tests/test_api_v2.py
+++ b/lms/djangoapps/instructor/tests/test_api_v2.py
@@ -3090,7 +3090,7 @@ class CourseTeamRolesViewTest(SharedModuleStoreTestCase):
         assert returned_roles == [
             'staff', 'limited_staff', 'instructor', 'beta', 'data_researcher',
             'Administrator', 'Moderator', 'Group Moderator', 'Community TA',
-            'ccx_coach',
+            'ccx_coach', 'teaching_assistant', 'eshe_instructor',
         ]
 
     def test_list_roles_unauthenticated(self):

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -31,6 +31,7 @@ from lms.djangoapps.courseware.masquerade import CourseMasquerade
 from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK
 from lms.djangoapps.instructor.toggles import DATA_DOWNLOAD_V2, LEGACY_INSTRUCTOR_DASHBOARD
 from lms.djangoapps.instructor.views.gradebook_api import calculate_page_info
@@ -39,6 +40,7 @@ from openedx.core.djangoapps.discussions.config.waffle import (
     ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND,
     OVERRIDE_DISCUSSION_LEGACY_SETTINGS_FLAG,
 )
+from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_ADMINISTRATOR
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -322,6 +324,103 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
             self.assertContains(response, reason_field)
         else:
             self.assertNotContains(response, reason_field)
+
+    @ddt.data('eshe_instructor', 'teaching_assistant')
+    def test_membership_tab_content(self, role):
+        """
+        Verify that eSHE Instructors and Teaching Assistants don't have access to membership tab and
+        work correctly with other roles.
+        """
+
+        membership_section = (
+            '<li class="nav-item">'
+            '<button type="button" class="btn-link membership" data-section="membership">'
+            'Membership'
+            '</button>'
+            '</li>'
+        )
+        batch_enrollment = (
+            '<fieldset class="batch-enrollment membership-section">'
+        )
+
+        user = UserFactory.create()
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
+
+        # eSHE Instructors / Teaching Assistants shouldn't have access to membership tab
+        CourseAccessRoleFactory(
+            course_id=self.course.id,
+            user=user,
+            role=role,
+            org=self.course.id.org
+        )
+        response = self.client.get(self.url)
+        self.assertNotContains(response, membership_section)
+
+        # However if combined with forum_admin, they should have access to this
+        # tab, but not to batch enrollment
+        forum_admin_role = RoleFactory(name=FORUM_ROLE_ADMINISTRATOR, course_id=self.course.id)
+        forum_admin_role.users.add(user)
+        response = self.client.get(self.url)
+        self.assertContains(response, membership_section)
+        self.assertNotContains(response, batch_enrollment)
+
+        # Combined with course staff, should have union of all three roles
+        # permissions sets
+        CourseAccessRoleFactory(
+            course_id=self.course.id,
+            user=user,
+            role='staff',
+            org=self.course.id.org
+        )
+        response = self.client.get(self.url)
+        self.assertContains(response, membership_section)
+        self.assertContains(response, batch_enrollment)
+
+    def test_student_admin_tab_content(self):
+        """
+        Verify that Teaching Assistants don't have access to the gradebook-related sections
+        of the student admin tab.
+        """
+
+        # Should be visible to Teaching Assistants
+        view_enrollment_status = '<div class="student-enrollment-status-container action-type-container">'
+        view_progress = '<div class="student-progress-container action-type-container">'
+
+        # Should not be visible to Teaching Assistants
+        view_gradebook = '<div class="action-type-container ">'
+        adjust_learner_grade = '<div class="student-grade-container action-type-container ">'
+        adjust_all_learners_grades = '<div class="course-specific-container action-type-container ">'
+
+        user = UserFactory.create()
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
+
+        # Teaching Assistants shouldn't have access to the gradebook-related sections
+        CourseAccessRoleFactory(
+            course_id=self.course.id,
+            user=user,
+            role='teaching_assistant',
+            org=self.course.id.org
+        )
+        response = self.client.get(self.url)
+        self.assertContains(response, view_enrollment_status)
+        self.assertContains(response, view_progress)
+        self.assertNotContains(response, view_gradebook)
+        self.assertNotContains(response, adjust_learner_grade)
+        self.assertNotContains(response, adjust_all_learners_grades)
+
+        # However if combined with instructor, they should have access to all sections
+        CourseAccessRoleFactory(
+            course_id=self.course.id,
+            user=user,
+            role='instructor',
+            org=self.course.id.org
+        )
+        response = self.client.get(self.url)
+        self.assertContains(response, view_enrollment_status)
+        self.assertContains(response, view_progress)
+        self.assertContains(response, view_gradebook)
+        self.assertContains(response, adjust_learner_grade)
+        self.assertContains(response, adjust_all_learners_grades)
 
     def test_student_admin_staff_instructor(self):
         """

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -33,6 +33,9 @@ from common.djangoapps.student.roles import (
     CourseInstructorRole,
     CourseSalesAdminRole,
     CourseStaffRole,
+    TeachingAssistantRole,
+    eSHEInstructorRole,
+    strict_role_checking,
 )
 from common.djangoapps.util.json_request import JsonResponse
 from common.djangoapps.util.proctoring import requires_escalation_email
@@ -146,12 +149,17 @@ def instructor_dashboard_2(request, course_id):  # lint-amnesty, pylint: disable
     access = {
         'admin': request.user.is_staff,
         'instructor': bool(has_access(request.user, 'instructor', course)),
+        'eshe_instructor': eSHEInstructorRole(course_key).has_user(request.user),
+        'teaching_assistant': TeachingAssistantRole(course_key).has_user(request.user),
         'finance_admin': CourseFinanceAdminRole(course_key).has_user(request.user),
         'sales_admin': CourseSalesAdminRole(course_key).has_user(request.user),
         'staff': bool(has_access(request.user, 'staff', course)),
         'forum_admin': has_forum_access(request.user, course_key, FORUM_ROLE_ADMINISTRATOR),
         'data_researcher': request.user.has_perm(permissions.CAN_RESEARCH, course_key),
     }
+
+    with strict_role_checking():
+        access['explicit_staff'] = bool(has_access(request.user, 'staff', course))
 
     if not request.user.has_perm(permissions.VIEW_DASHBOARD, course_key):
         raise Http404()
@@ -546,7 +554,19 @@ def _section_membership(course, access):
             'update_forum_role_membership',
             kwargs={'course_id': str(course_key)}
         ),
-        'is_reason_field_enabled': configuration_helpers.get_value('ENABLE_MANUAL_ENROLLMENT_REASON_FIELD', False)
+        'is_reason_field_enabled': configuration_helpers.get_value('ENABLE_MANUAL_ENROLLMENT_REASON_FIELD', False),
+
+        # Membership section should be hidden for eSHE instructors.
+        # Since they get Course Staff role implicitly, we need to hide this
+        # section if the user doesn't have the Course Staff role set explicitly
+        # or have the Discussion Admin role.
+        'is_hidden': (
+            not access['forum_admin']
+            and (
+                (access['eshe_instructor'] or access['teaching_assistant'])
+                and not access['explicit_staff']
+            )
+        ),
     }
     return section_data
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -760,6 +760,17 @@ ENABLE_CROSS_DOMAIN_CSRF_COOKIE = False
 # .. toggle_warning: Requires configuration of third party auth
 ENABLE_REQUIRE_THIRD_PARTY_AUTH = False
 
+# .. toggle_name: settings.ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Whether to enable the legacy MD5 hashing algorithm to generate anonymous user id
+#   instead of the newer SHAKE128 hashing algorithm
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-08-08
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
+ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID = False
+
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API
 # Should be a list of tuples of (block_type, field_name), where block_type can also be "*" for all block types.
 # e.g. COURSE_BLOCKS_API_EXTRA_FIELDS = [  ('course', 'other_course_settings'), ("problem", "weight")  ]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -771,6 +771,26 @@ ENABLE_REQUIRE_THIRD_PARTY_AUTH = False
 # .. toggle_tickets: 'https://github.com/openedx/edx-platform/pull/30832'
 ENABLE_LEGACY_MD5_HASH_FOR_ANONYMOUS_USER_ID = False
 
+# .. toggle_name: settings.ENABLE_ESHE_INSTRUCTOR_ROLE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Whether to enable the ESHE Instructor role
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2023-07-31
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/561/files'
+ENABLE_ESHE_INSTRUCTOR_ROLE = False
+
+# .. toggle_name: settings.ENABLE_TEACHING_ASSISTANT_ROLE
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Whether to enable the Teaching Assistant role
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-02-12
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/632/files'
+ENABLE_TEACHING_ASSISTANT_ROLE = False
+
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API
 # Should be a list of tuples of (block_type, field_name), where block_type can also be "*" for all block types.
 # e.g. COURSE_BLOCKS_API_EXTRA_FIELDS = [  ('course', 'other_course_settings'), ("problem", "weight")  ]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -791,6 +791,15 @@ ENABLE_ESHE_INSTRUCTOR_ROLE = False
 # .. toggle_tickets: 'https://github.com/open-craft/edx-platform/pull/632/files'
 ENABLE_TEACHING_ASSISTANT_ROLE = False
 
+# .. toggle_name: settings.DISABLE_DATES_TAB
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Disables dates tab for all courses.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-04-15
+# .. toggle_tickets: https://github.com/openedx/edx-platform/pull/34511
+DISABLE_DATES_TAB = False
+
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API
 # Should be a list of tuples of (block_type, field_name), where block_type can also be "*" for all block types.
 # e.g. COURSE_BLOCKS_API_EXTRA_FIELDS = [  ('course', 'other_course_settings'), ("problem", "weight")  ]

--- a/lms/static/js/fixtures/instructor_dashboard/membership.html
+++ b/lms/static/js/fixtures/instructor_dashboard/membership.html
@@ -11,6 +11,8 @@
         <select id="member-lists-selector" class="member-lists-selector">
           <option value="staff">Staff</option>
           <option value="limited_staff">Limited Staff</option>
+          <option value="eshe_instructor">eSHE Instructor</option>
+          <option value="teaching_assistant">Teaching Assistant</option>
           <option value="instructor">Admin</option>
           <option value="beta">Beta Testers</option>
           <option value="Administrator">Discussion Admins</option>

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -268,7 +268,9 @@
                         this.clearFormErrors();
                         this.renderThirdPartyAuthWarning();
                     }
-                    window.location.href = redirectURL;
+                    if (typeof redirectURL === "string" && redirectURL.length) {
+                        window.location.href = redirectURL;
+                    }
                 } else {
                     this.renderErrors(this.defaultFormErrorsTitle, this.errors);
                 }

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -216,6 +216,7 @@
             saveError: function(error) {
                 var errorCode;
                 var msg;
+                var redirectURL;
                 if (error.status === 0) {
                     msg = gettext('An error has occurred. Check your Internet connection and try again.');
                 } else if (error.status === 500) {
@@ -245,6 +246,7 @@
                 } else if (error.responseJSON !== undefined) {
                     msg = error.responseJSON.value;
                     errorCode = error.responseJSON.error_code;
+                    redirectURL = error.responseJSON.redirect_url;
                 } else {
                     msg = gettext('An unexpected error has occurred.');
                 }
@@ -266,6 +268,7 @@
                         this.clearFormErrors();
                         this.renderThirdPartyAuthWarning();
                     }
+                    window.location.href = redirectURL;
                 } else {
                     this.renderErrors(this.defaultFormErrorsTitle, this.errors);
                 }

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -5,6 +5,13 @@ from django.utils.translation import gettext as _
 from django.utils.translation import pgettext
 from openedx.core.djangolib.markup import HTML, Text
 %>
+
+<%
+  eshe_instructor_or_teaching_assistant_access = section_data['access']['eshe_instructor'] or section_data['access']['teaching_assistant']
+  membership_section_visible = not eshe_instructor_or_teaching_assistant_access or section_data['access']['explicit_staff']
+%>
+
+% if membership_section_visible:
 <fieldset class="batch-enrollment membership-section">
     <legend id="heading-batch-enrollment" class="hd hd-3">${_("Batch Enrollment")}</legend>
     <label>
@@ -90,6 +97,8 @@ from openedx.core.djangolib.markup import HTML, Text
     </form>
     <div class="results"></div>
 </div>
+%endif
+
 %endif
 
 <hr class="divider" />
@@ -192,6 +201,34 @@ from openedx.core.djangolib.markup import HTML, Text
       data-modify-endpoint="${ section_data['modify_access_url'] }"
       data-add-button-label="${_("Add Limited Staff")}"
     ></div>
+
+    %if settings.FEATURES.get('ENABLE_ESHE_INSTRUCTOR_ROLE', None):
+    <div class="auth-list-container"
+      data-rolename="eshe_instructor"
+      data-display-name="${_("eSHE Instructor")}"
+      data-info-text="
+        ${_("Course team members with the eSHE Instructor role help you manage your course. "
+        "eSHE Instructor permissions are similar to Staff, but they can't assign course team roles and "
+        "can't enroll and unenroll learners")}"
+      data-list-endpoint="${ section_data['list_course_role_members_url'] }"
+      data-modify-endpoint="${ section_data['modify_access_url'] }"
+      data-add-button-label="${_("Add eSHE Instructor")}"
+    ></div>
+    %endif
+
+    %if settings.FEATURES.get('ENABLE_TEACHING_ASSISTANT_ROLE', None):
+    <div class="auth-list-container"
+      data-rolename="teaching_assistant"
+      data-display-name="${_("Teaching Assistant")}"
+      data-info-text="
+        ${_("Course team members with the Teaching Assistant role help you manage your course. "
+        "Teaching Assistant permissions are similar to Staff, but they can't assign course team roles, "
+        "enroll and unenroll learners and view or override grades")}"
+      data-list-endpoint="${ section_data['list_course_role_members_url'] }"
+      data-modify-endpoint="${ section_data['modify_access_url'] }"
+      data-add-button-label="${_("Add Teaching Assistant")}"
+    ></div>
+    %endif%
 
     ## Note that "Admin" is identified as "Instructor" in the Django admin panel.
     <div class="auth-list-container"

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -1,7 +1,13 @@
 <%page args="section_data" expression_filter="h"/>
 <%! from django.utils.translation import gettext as _ %>
+
+<%
+  teaching_assistant_access = section_data['access']['teaching_assistant']
+  gradebook_related_sections_hidden = teaching_assistant_access and not section_data['access']['explicit_staff']
+%>
+
 %if section_data['access']['staff'] or section_data['access']['instructor']:
-<div class="action-type-container">
+<div class="action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     %if section_data.get('writable_gradebook_url') or section_data.get('is_small_course'):
         <br><br>
         <h4 class="hd hd-4">${_("View gradebook for enrolled learners")}</h4>
@@ -59,7 +65,7 @@
   <hr>
 </div>
 
-<div class="student-grade-container action-type-container">
+<div class="student-grade-container action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     <h4 class="hd hd-4">${_("Adjust a learner's grade for a specific problem")}</h4>
     <div class="request-response-error"></div>
     <label for="student-select-grade">
@@ -132,7 +138,7 @@
 </div>
 
 % if course.entrance_exam_enabled:
-<div class="entrance-exam-grade-container action-type-container">
+<div class="entrance-exam-grade-container action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     <h4 class="hd hd-4">${_("Adjust a learner's entrance exam results")}</h4>
     <div class="request-response-error"></div>
 
@@ -194,7 +200,7 @@
 
 %if section_data['access']['instructor']:
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
-<div class="course-specific-container action-type-container">
+<div class="course-specific-container action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     <h4 class="hd hd-4">${_("Adjust all enrolled learners' grades for a specific problem")}</h4>
     <div class="request-response-error"></div>
 
@@ -232,7 +238,7 @@
 %endif
 
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
-<div class="running-tasks-container action-type-container">
+<div class="running-tasks-container action-type-container ${'hidden' if gradebook_related_sections_hidden else ''}">
     <h4 class="hd hd-4">${_("Pending Tasks")}</h4>
     <div class="running-tasks-section">
         <label>${_("The status for any active tasks appears in a table below.")}</label>

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -771,6 +771,7 @@ class SequenceMetadata(DeveloperErrorViewMixin, APIView):
 
     authentication_classes = (
         JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
 

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -80,7 +80,7 @@ def _do_third_party_auth(request):
 
     try:
         return pipeline.get_authenticated_user(requested_provider, username, third_party_uid)
-    except USER_MODEL.DoesNotExist:
+    except USER_MODEL.DoesNotExist as err:
         AUDIT_LOG.info(
             "Login failed - user with username {username} has no social auth "  # noqa: UP032
             "with backend_name {backend_name}".format(username=username, backend_name=backend_name)
@@ -101,7 +101,13 @@ def _do_third_party_auth(request):
             register_label_strong=HTML("<strong>{register_text}</strong>").format(register_text=_("Register")),
         )
 
-        raise AuthFailedError(message, error_code="third-party-auth-with-no-linked-account")  # lint-amnesty, pylint: disable=raise-missing-from  # noqa: B904
+        redirect_url = configuration_helpers.get_value('OC_REDIRECT_ON_TPA_UNLINKED_ACCOUNT', None)
+
+        raise AuthFailedError(
+            message,
+            error_code='third-party-auth-with-no-linked-account',
+            redirect_url=redirect_url
+        ) from err
 
 
 def _get_user_by_email(email):


### PR DESCRIPTION
## Description

Cherry pick of non-upstream commits to OpenCraft's branch for verawood.

## Rebased

- 610da023bb feat: allow switching anonymous user ID hashing algorithm from shake to md5
- 9fab2fdc5d temp: Add configuration option to redirect to external site when TAP account is unlinked
- b1bff53d1d feat: add eSHE-specific roles (this commit was amended to fix tests and make it work with the newer roles UI; the previous commit message was "feat: all eSHE role features squashed in one commit")
- dd36ac47fe feat: add a feature flag to disable dates tab for all courses
- 87e56de0e8 fix: prevent redirects to /undefined after saml auth
- 3af2aaba8f feat: allow Bearer auth for sequence metadata


## Dropped, Already Upstream

- 388985bbc0 feat: User agreements API for generic agreement records
- 93a62a8c96 style: Fix pylint violations.
- 336bb682af fix(lint): extra empty line added during merge
- 7558ea78f0 fix: don't break indexing on non-existant course (#848)
- 062a0cd415 Merge pull request #840 from open-craft/agrendalath/sync-ulmo-with-upstream
- ffae33f9e6 Merge remote-tracking branch 'upstream/release/ulmo' into tecoholic/BB-10886-security-patches
- 41c0e6b23c Merge pull request #842 from open-craft/tecoholic/BB-10886-security-patches
- f0da25e5ff Merge pull request #849 from open-craft/agrendalath/bb-10988-security-patches
- 7ce3600289 Merge pull request #852 from open-craft/kaustav/bb-11021-security-patches
- 61124099ab Merge pull request #856 from open-craft/sync-release/ulmo-2026-08-04--1785884403
- febd507f34 fix: prevent null start date in course details (#792) (fix no longer required since the root issue was fixed another way)

private-ref: https://tasks.opencraft.com/browse/BB-11000