### PR TITLE
fix: bound resource use in Studio video-download endpoint

### DIFF
--- a/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/tests/test_videos.py
@@ -1,6 +1,8 @@
 """
 Unit tests for course settings views.
 """
+import io
+import zipfile
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -155,6 +157,10 @@ class VideoDownloadViewTest(CourseTestCase):
     ALLOWED_URL = "http://example.com/profile1/test.mp4"
     # An internal address an attacker might try to reach via SSRF.
     SSRF_URL = "http://169.254.169.254/latest/meta-data/"
+    # Opt into the default-cache isolation provided by CacheIsolationMixin
+    # (inherited via CourseTestCase) so DRF's UserRateThrottle counter
+    # doesn't bleed across tests.
+    ENABLED_CACHES = ["default"]
 
     def setUp(self):
         super().setUp()
@@ -184,20 +190,37 @@ class VideoDownloadViewTest(CourseTestCase):
             ],
         })
 
+    @staticmethod
+    def _stream_response_mock(payload=b"video-bytes", content_type="video/mp4"):
+        """
+        Build a MagicMock that mimics a streamed requests.Response: iter_content
+        yields the given payload in one chunk, raise_for_status / close are
+        no-ops, and headers expose the upstream Content-Type so the zip-entry
+        extension logic can resolve.
+        """
+        mock_response = MagicMock()
+        mock_response.iter_content = lambda chunk_size=None: iter([payload])
+        mock_response.raise_for_status = MagicMock()
+        mock_response.close = MagicMock()
+        mock_response.headers = {"Content-Type": content_type}
+        return mock_response
+
     @patch("cms.djangoapps.contentstore.video_storage_handlers.requests.get")
     def test_download_allowed_url(self, mock_get):
         """A URL that belongs to the course's videos is fetched and zipped."""
-        mock_get.return_value = MagicMock(
-            content=b"video-bytes",
-            headers={"Content-Type": "video/mp4"},
-        )
+        mock_get.return_value = self._stream_response_mock(b"video-bytes", "video/mp4")
         response = self.api_client.put(
             self.url,
             data={"files": [{"url": self.ALLOWED_URL, "name": "test.mp4"}]},
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)  # noqa: PT009
-        mock_get.assert_called_once_with(self.ALLOWED_URL, allow_redirects=True)
+        assert response.status_code == status.HTTP_200_OK
+        # The response body is a streamed zip; force the generator to run by
+        # consuming streaming_content so the mocked requests.get is invoked.
+        list(response.streaming_content)
+        mock_get.assert_called_once_with(
+            self.ALLOWED_URL, stream=True, allow_redirects=True,
+        )
 
     @patch("cms.djangoapps.contentstore.video_storage_handlers.requests.get")
     def test_rejects_url_not_belonging_to_course(self, mock_get):
@@ -243,3 +266,68 @@ class VideoDownloadViewTest(CourseTestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)  # noqa: PT009
         mock_get.assert_not_called()
+
+    @patch("cms.djangoapps.contentstore.video_storage_handlers.requests.get")
+    def test_zip_entry_uses_supplied_name_when_extension_present(self, mock_get):
+        """
+        When the caller-supplied name already has an extension matching the
+        upstream Content-Type, the zip entry's name is left exactly as given.
+        """
+        mock_get.return_value = self._stream_response_mock(b"video-bytes", "video/mp4")
+        response = self.api_client.put(
+            self.url,
+            data={"files": [{"url": self.ALLOWED_URL, "name": "test.mp4"}]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        zip_bytes = b"".join(response.streaming_content)
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            assert zf.namelist() == ["test.mp4"]
+
+    @patch("cms.djangoapps.contentstore.video_storage_handlers.requests.get")
+    def test_zip_entry_appends_extension_from_content_type(self, mock_get):
+        """
+        When the caller-supplied name lacks an extension, the upstream
+        Content-Type's extension (resolved via mimetypes) is appended.
+        """
+        mock_get.return_value = self._stream_response_mock(b"video-bytes", "video/mp4")
+        response = self.api_client.put(
+            self.url,
+            data={"files": [{"url": self.ALLOWED_URL, "name": "intro"}]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        zip_bytes = b"".join(response.streaming_content)
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            assert zf.namelist() == ["intro.mp4"]
+
+    def test_view_is_rate_limited(self):
+        """
+        ``VideoDownloadView`` is wired up with a per-user rate-limiting
+        throttle, sourced from the ``VIDEO_DOWNLOAD_RATE_LIMIT`` setting.
+        The throttle behaviour itself is DRF's responsibility; we just
+        confirm the throttle is attached and the rate is non-null.
+        """
+        from cms.djangoapps.contentstore.rest_api.v1.views.videos import (
+            VideoDownloadThrottle,
+            VideoDownloadView,
+        )
+        assert VideoDownloadThrottle in VideoDownloadView.throttle_classes
+        assert VideoDownloadThrottle.rate is not None
+
+    @patch("cms.djangoapps.contentstore.video_storage_handlers.requests.get")
+    def test_zip_entry_left_alone_when_content_type_unknown(self, mock_get):
+        """
+        An unknown / non-standard Content-Type from the upstream fetch leaves
+        the supplied name untouched -- we don't invent an extension.
+        """
+        mock_get.return_value = self._stream_response_mock(b"bytes", "application/x-not-a-real-type")
+        response = self.api_client.put(
+            self.url,
+            data={"files": [{"url": self.ALLOWED_URL, "name": "intro"}]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        zip_bytes = b"".join(response.streaming_content)
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            assert zf.namelist() == ["intro"]

--- a/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views/videos.py
@@ -3,9 +3,11 @@ Public rest API endpoints for contentstore API video assets (outside authoring A
 """
 import edx_api_doc_tools as apidocs
 import logging
+from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
 
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes, verify_course_exists
@@ -184,11 +186,24 @@ class VideoUsageView(DeveloperErrorViewMixin, APIView):
         return Response(serializer.data)
 
 
+class VideoDownloadThrottle(UserRateThrottle):
+    """
+    Per-user rate limit on the Studio video-download endpoint.
+
+    The download endpoint streams a multi-video zip into the response, which
+    keeps a uWSGI worker busy for the duration. Rate-limiting per user keeps
+    a single course author from initiating many overlapping streams.
+    """
+    rate = settings.VIDEO_DOWNLOAD_RATE_LIMIT
+
+
 @view_auth_classes(is_authenticated=True)
 class VideoDownloadView(DeveloperErrorViewMixin, APIView):
     """
     View for course video downloads.
     """
+    throttle_classes = (VideoDownloadThrottle,)
+
     @apidocs.schema(
         body=VideoDownloadSerializer,
         parameters=[
@@ -199,6 +214,7 @@ class VideoDownloadView(DeveloperErrorViewMixin, APIView):
             401: "The requester is not authenticated",
             403: "The requester cannot access the specified course",
             404: "The requested course does not exist",
+            429: "The requester has exceeded the per-user rate limit",
         },
     )
     @verify_course_exists()

--- a/cms/djangoapps/contentstore/video_storage_handlers.py
+++ b/cms/djangoapps/contentstore/video_storage_handlers.py
@@ -8,10 +8,8 @@ import csv
 import io
 import json
 import logging
-import os
+import mimetypes
 import requests
-import shutil
-import pathlib
 import zipfile
 
 from contextlib import closing
@@ -41,16 +39,12 @@ from edxval.api import (
     update_video_image,
     update_video_status
 )
-from fs.osfs import OSFS
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from path import Path as path
 from pytz import UTC
 from rest_framework import status as rest_status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
-from tempfile import NamedTemporaryFile, mkdtemp
-from wsgiref.util import FileWrapper
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.util.json_request import JsonResponse
@@ -232,17 +226,6 @@ def handle_videos(request, course_key_string, edx_video_id=None):
         return JsonResponse(data, status=status)
 
 
-def send_zip(zip_file, size=None):
-    """
-    Generates a streaming http response for the zip file
-    """
-    wrapper = FileWrapper(zip_file, settings.COURSE_EXPORT_DOWNLOAD_CHUNK_SIZE)
-    response = StreamingHttpResponse(wrapper, content_type='application/zip')
-    response['Content-Dispositon'] = 'attachment; filename=%s' % os.path.basename(zip_file.name)
-    response['Content-Length'] = size
-    return response
-
-
 def get_course_video_download_urls(course_key_string):
     """
     Return the set of encoded-video URLs that legitimately belong to the given
@@ -266,18 +249,86 @@ def get_course_video_download_urls(course_key_string):
     }
 
 
+class _ZipStreamBuffer(io.RawIOBase):
+    """
+    File-like sink for ``zipfile.ZipFile`` output that lets the writer drain
+    bytes incrementally. Used so we can emit a zip archive directly into a
+    streaming HTTP response without staging anything to disk or holding the
+    whole archive in memory.
+    """
+
+    def __init__(self):
+        self._buf = bytearray()
+
+    def writable(self):
+        return True
+
+    def write(self, data):
+        self._buf.extend(data)
+        return len(data)
+
+    def drain(self):
+        chunk = bytes(self._buf)
+        self._buf.clear()
+        return chunk
+
+
+def _stream_video_zip(files):
+    """
+    Yield bytes of a zip archive containing the requested videos.
+
+    Each video is fetched with ``stream=True`` and piped into its zip entry
+    chunk-by-chunk, so peak memory is roughly the chunk size rather than the
+    file size, and no temp files are written to disk. ``ZIP_STORED`` (no
+    compression) is used because the underlying video files are already
+    compressed; running them through DEFLATE just burns CPU.
+    """
+    buf = _ZipStreamBuffer()
+    with zipfile.ZipFile(buf, mode='w', compression=zipfile.ZIP_STORED) as zf:
+        for file in files:
+            response = requests.get(file['url'], stream=True, allow_redirects=True)
+            response.raise_for_status()
+            try:
+                # If the caller's name lacks an extension, derive one from
+                # the upstream Content-Type so the entry in the zip has a
+                # sensible filename. mimetypes handles the unknown-type
+                # case (returns None) cleanly.
+                file_name = file['name']
+                content_type = response.headers.get('Content-Type', '').split(';', 1)[0].strip()
+                extension = mimetypes.guess_extension(content_type) if content_type else None
+                if extension and not file_name.endswith(extension):
+                    file_name += extension
+                # force_zip64=True so a single >4 GiB video doesn't trip
+                # ZIP32 size limits.
+                with zf.open(zipfile.ZipInfo(file_name), mode='w', force_zip64=True) as entry:
+                    for chunk in response.iter_content(chunk_size=64 * 1024):
+                        entry.write(chunk)
+                        drained = buf.drain()
+                        if drained:
+                            yield drained
+            finally:
+                response.close()
+            drained = buf.drain()
+            if drained:
+                yield drained
+    # ZipFile.__exit__ writes the central directory; emit the trailing bytes.
+    final = buf.drain()
+    if final:
+        yield final
+
+
 def create_video_zip(course_key_string, files):
     """
-    Generates the video zip, or returns None if there was an error.
+    Return a streaming HTTP response that delivers the requested course
+    videos as a single zip archive.
 
-    Updates the context with any error information if applicable.
+    Validates that each file URL belongs to the course (SSRF protection via
+    ``get_course_video_download_urls``). The zip is then streamed directly
+    to the response without buffering anything to disk. Per-request
+    wall-clock is bounded by the WSGI server's request timeout and per-user
+    frequency by the ``VideoDownloadThrottle`` on the view; no explicit
+    batch-size limit is enforced here.
     """
-    name = course_key_string + '_videos'
-    video_folder_zip = NamedTemporaryFile(prefix=name + '_',
-                                          suffix=".zip")  # lint-amnesty, pylint: disable=consider-using-with
-    root_dir = path(mkdtemp())
-    video_dir = root_dir + '/' + name
-    zip_folder = None
     # Only allow fetching URLs that belong to this course's videos. Anything
     # else (internal services, cloud metadata endpoints, arbitrary hosts) is a
     # potential SSRF target and is rejected before any request is made.
@@ -285,28 +336,15 @@ def create_video_zip(course_key_string, files):
     for file in files:
         if file['url'] not in allowed_urls:
             raise ValidationError(f"Invalid video download url: {file['url']}")
-    try:
-        for file in files:
-            url = file['url']
-            file_name = file['name']
-            response = requests.get(url, allow_redirects=True)
-            file_type = '.' + response.headers['Content-Type'][6:]
-            if file_type not in file_name:
-                file_name = file['name'] + file_type
-            if not os.path.isdir(video_dir):
-                os.makedirs(video_dir)
-            with OSFS(video_dir).open(file_name, mode="wb") as f:
-                f.write(response.content)
-        directory = pathlib.Path(video_dir)
-        with zipfile.ZipFile(video_folder_zip, mode="w") as archive:
-            for file_path in directory.iterdir():
-                archive.write(file_path, arcname=file_path.name)
-        zip_folder = open(video_folder_zip.name, '+rb')
 
-        return send_zip(zip_folder, video_folder_zip.tell())
-    finally:
-        if os.path.exists(root_dir / name):
-            shutil.rmtree(root_dir / name)
+    response = StreamingHttpResponse(
+        _stream_video_zip(files),
+        content_type='application/zip',
+    )
+    response['Content-Disposition'] = (
+        f'attachment; filename={course_key_string}_videos.zip'
+    )
+    return response
 
 
 def get_video_usage_path(course_key, edx_video_id):

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1604,6 +1604,16 @@ YOUTUBE = {
 
 YOUTUBE_API_KEY = 'PUT_YOUR_API_KEY_HERE'
 
+# .. setting_name: VIDEO_DOWNLOAD_RATE_LIMIT
+# .. setting_default: '12/hour'
+# .. setting_description: Per-user rate limit applied to the Studio
+#    video-download endpoint
+#    (``PUT /api/contentstore/v1/videos/{course_id}/download``). Bounds how
+#    often a single course author can initiate a multi-video zip download.
+# Rate format: DRF ``UserRateThrottle`` rate string. See
+# https://www.django-rest-framework.org/api-guide/throttling/#setting-the-throttling-policy
+VIDEO_DOWNLOAD_RATE_LIMIT = '12/hour'
+
 ############################# SETTINGS FOR VIDEO UPLOAD PIPELINE #############################
 
 VIDEO_UPLOAD_PIPELINE = {


### PR DESCRIPTION
Per upstream:

The PUT /api/contentstore/v1/videos/{course_id}/download endpoint returns a zip of selected course videos -- the operation is a download. (The original implementation used PUT, which is the wrong verb for a read; that's tracked as a separate cleanup.) The handler synchronously fetched each requested video, materialised each response in RAM and wrote it to a temp file before zipping. A course author requesting download of many large videos in one request could tie up a uWSGI worker for many minutes; concurrent requests exhausted the worker pool.

Stream the zip directly into the response instead -- each video is fetched with stream=True and piped chunk-by-chunk into a streaming zip entry, so peak memory is roughly the chunk size and no temp files are written to disk. Rate-limit the endpoint per user via the new VIDEO_DOWNLOAD_RATE_LIMIT setting (default 12/hour, via a UserRateThrottle subclass on the view). Per-request wall-clock is bounded by the WSGI server's request timeout.

Closes GHSA-g266-6v7f-j465.

Internal ticket: https://tasks.opencraft.com/browse/BB-11055